### PR TITLE
Fixes repository URL in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description" : "JavaScript Style Checker",
     "name" : "jscs",
     "version" : "0.0.12",
-    "repository" : "https://github.com/mdevils/jscs",
+    "repository" : "https://github.com/mdevils/node-jscs",
     "contributors" : [
         {
             "name": "Marat Dulin",


### PR DESCRIPTION
I've just tried to access the repo thru the [NPM page](https://npmjs.org/package/jscs) and got an 404 from GitHub :)
This fixes it.
