### PR TITLE
fix error position for disallow_spaces_inside_object_brackets and disall...

### DIFF
--- a/lib/rules/disallow-spaces-inside-array-brackets.js
+++ b/lib/rules/disallow-spaces-inside-array-brackets.js
@@ -30,7 +30,7 @@ module.exports.prototype = {
             if (openingBracket.loc.start.line === nextToken.loc.start.line &&
                 openingBracket.range[1] !== nextToken.range[0]
             ) {
-                errors.add('Illegal space after opening square brace', nextToken.loc.start);
+                errors.add('Illegal space after opening square brace', openingBracket.loc.end);
             }
 
             var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
@@ -40,7 +40,7 @@ module.exports.prototype = {
             if (closingBracket.loc.start.line === prevToken.loc.start.line &&
                 closingBracket.range[0] !== prevToken.range[1]
             ) {
-                errors.add('Illegal space before closing square brace', prevToken.loc.start);
+                errors.add('Illegal space before closing square brace', prevToken.loc.end);
             }
         });
     }

--- a/lib/rules/disallow-spaces-inside-object-brackets.js
+++ b/lib/rules/disallow-spaces-inside-object-brackets.js
@@ -30,7 +30,7 @@ module.exports.prototype = {
             if (openingBracket.loc.start.line === nextToken.loc.start.line &&
                 openingBracket.range[1] !== nextToken.range[0]
             ) {
-                errors.add('Illegal space after opening curly brace', nextToken.loc.start);
+                errors.add('Illegal space after opening curly brace', openingBracket.loc.end);
             }
 
             var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
@@ -40,7 +40,7 @@ module.exports.prototype = {
             if (closingBracket.loc.start.line === prevToken.loc.start.line &&
                 closingBracket.range[0] !== prevToken.range[1]
             ) {
-                errors.add('Illegal space before closing curly brace', prevToken.loc.start);
+                errors.add('Illegal space before closing curly brace', prevToken.loc.end);
             }
         });
     }


### PR DESCRIPTION
...ow_spaces_inside_array_brackets

Source:

``` javascript
var a = [ 'a', 'b' ]
var b = { a: 1, b: 2 }
```

Before:

```
Illegal space after opening curly brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
     1 |var b = { a: 1, b: 2 }
------------------^
     2 |

Illegal space before closing curly brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
     1 |var b = { a: 1, b: 2 }
---------------------------^
     2 |

Illegal space after opening square brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
------------------^
     1 |var b = { a: 1, b: 2 }
     2 |

Illegal space before closing square brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
-----------------------^
     1 |var b = { a: 1, b: 2 }

```

After:

```
Illegal space after opening curly brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
     1 |var b = { a: 1, b: 2 }
-----------------^
     2 |

Illegal space before closing curly brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
     1 |var b = { a: 1, b: 2 }
----------------------------^
     2 |

Illegal space after opening square brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
-----------------^
     1 |var b = { a: 1, b: 2 }
     2 |

Illegal space before closing square brace at ./test.js :
     0 |var a = [ 'a', 'b' ]
--------------------------^
     1 |var b = { a: 1, b: 2 }
     2 |

```
