### PR TITLE
disallowQuotedKeysInObjects option value `false` is ignored without assertion errors in the output

### DIFF
--- a/lib/rules/disallow-quoted-keys-in-objects.js
+++ b/lib/rules/disallow-quoted-keys-in-objects.js
@@ -6,10 +6,14 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(disallow) {
+    configure: function(disallowQuotedKeysInObjects) {
         assert(
-            typeof disallow === 'boolean',
+            typeof disallowQuotedKeysInObjects === 'boolean',
             OPTION_NAME + ' options requires boolean value'
+        );
+        assert(
+            disallowQuotedKeysInObjects === true,
+            'disallowQuotedKeysInObjects option requires true value or should be removed'
         );
     },
 


### PR DESCRIPTION
As i understand, boolean options for turn on rules must present and be equal to `true` or must be removed from configuration file.

Rule `disallowQuotedKeysInObjects` hasn't value assertion in the configuration method. This leads to enabled rule without reference to the option value (`true` of `false`).
