### PR TITLE
Don't report about extra quotes for key if its starts with zero

### DIFF
--- a/lib/rules/disallow-quoted-keys-in-objects.js
+++ b/lib/rules/disallow-quoted-keys-in-objects.js
@@ -22,7 +22,7 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var KEY_NAME_RE = /^([1-9][0-9]+|[a-zA-Z_$]+[\w$]*)$/; // number or identifier
+        var KEY_NAME_RE = /^(0|[1-9][0-9]*|[a-zA-Z_$]+[\w$]*)$/; // number or identifier
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(prop) {
                 var key = prop.key;

--- a/test/test.disallow-quoted-keys-in-objects.js
+++ b/test/test.disallow-quoted-keys-in-objects.js
@@ -30,6 +30,7 @@ describe('rules/disallow-quoted-keys-in-objects', function() {
         assert(checker.checkString('var x = { a_a: 1 }').isEmpty());
         assert(checker.checkString('var x = { 12: 1 }').isEmpty());
         assert(checker.checkString('var x = { $: 1 }').isEmpty());
+        assert(checker.checkString('var x = { 0: 1 }').isEmpty());
     });
 
     it('should not report if key is invalid without quotes', function() {


### PR DESCRIPTION
Here is problem.

```
// I have object with quoted and unquoted keys. 
var labels = {
    200204 : 'brown',
    EE1D19 : 'red',
    '0000CC' : 'blue',
    040001 : 'black, but undefuned :)'
};
// And I have array of keys which is always a Strings.
var stringKeys = [ '200204', 'EE1D19', '0000CC', '040001' ];

stringKeys.forEach(function(key) {
    // With key 040001 and similar I'll have undefuned. 
    console.log(labels[key]);
});
```

So I want to have quotes on keys like these.
