### PR TITLE
Add --no-colors option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,6 +13,7 @@ program
     .version(require('../package.json').version)
     .usage('[options] <file ...>')
     .option('-c, --config [path]', 'configuration file path')
+    .option('-n, --no-colors', 'clean output without colors')
     .parse(process.argv);
 
 var Checker = require('./checker');
@@ -51,7 +52,7 @@ if (fs.existsSync(configPath)) {
                     errors.getErrorList().forEach(function(error) {
                         errorCount++;
                         console.log(
-                            errors.explainError(error, true) + '\n'
+                            errors.explainError(error, program.colors) + '\n'
                         );
                     });
                 }


### PR DESCRIPTION
When i write code in Sublime Text 2 editor i'm using jscs in my custom build system. In sublime's output console it looks quite uglish, so i have to use 

``` bash
jscs $1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"
```

to beutify output. This option should be very usefull: 

``` bash
jscs -n $1
```
