### PR TITLE
Added config rule list validation

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -7,7 +7,7 @@
     "requireLeftStickedOperators": [","],
     "disallowImplicitTypeConversion": ["string"],
     "disallowKeywords": ["with"],
-    "disallowMulipleLineBreaks": true,
+    "disallowMultipleLineBreaks": true,
     "disallowKeywordsOnNewLine": ["else"],
     "requireLineFeedAtFileEnd": true,
     "validateJSDoc": {

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -75,14 +75,19 @@ Checker.prototype = {
      */
     configure: function(config) {
         this.throwNonCamelCaseErrorIfNeeded(config);
+        var configRules = Object.keys(config);
         var activeRules = this._activeRules;
         this._rules.forEach(function(rule) {
             var ruleOptionName = rule.getOptionName();
             if (config.hasOwnProperty(ruleOptionName)) {
                 rule.configure(config[ruleOptionName]);
                 activeRules.push(rule);
+                configRules.splice(configRules.indexOf(ruleOptionName), 1);
             }
         });
+        if (configRules.length > 0) {
+            throw new Error('Unsupported rules: ' + configRules.join(', '));
+        }
         this._excludes = (config.excludeFiles || []).map(function(pattern) {
             return new minimatch.Minimatch(pattern);
         });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,4 +84,3 @@ if (fs.existsSync(configPath)) {
      */
     process.exit(1);
 }
-

--- a/test/test.camel-case-options.js
+++ b/test/test.camel-case-options.js
@@ -10,7 +10,7 @@ describe('rules/camel-case-options', function() {
     it('should report illegal option names', function() {
         var error;
         try {
-            checker.configure({ my_option_name: { hello_world: true } });
+            checker.configure({ disallow_spaces_in_function_expression: { before_opening_round_brace: true } });
         } catch (e) {
             error = e;
         }
@@ -21,8 +21,8 @@ describe('rules/camel-case-options', function() {
             'On the bright side, we tried to convert your jscs config to camel case.\n' +
             '----------------------------------------\n' +
             '{\n' +
-            '    "myOptionName": {\n' +
-            '        "helloWorld": true\n' +
+            '    "disallowSpacesInFunctionExpression": {\n' +
+            '        "beforeOpeningRoundBrace": true\n' +
             '    }\n' +
             '}\n' +
             '----------------------------------------\n'
@@ -31,7 +31,7 @@ describe('rules/camel-case-options', function() {
     it('should not report legal option names', function() {
         var error;
         try {
-            checker.configure({ myOptionName: { helloWorld: true } });
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
         } catch (e) {
             error = e;
         }

--- a/test/test.non-registered-rules.js
+++ b/test/test.non-registered-rules.js
@@ -1,0 +1,31 @@
+var Checker = require('../lib/checker');
+var assert = require('assert');
+
+describe('rules/camel-case-options', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+    it('should report rules in config which don\'t match any registered rules', function() {
+        var error;
+        try {
+            checker.configure({ disallowMulipleLineBreaks: true, disallowMultipleVarDelc: true });
+        } catch (e) {
+            error = e;
+        }
+        assert.equal(
+            error.message,
+            'Unsupported rules: disallowMulipleLineBreaks, disallowMultipleVarDelc'
+        );
+    });
+    it('should not report rules in config which match registered rules', function() {
+        var error;
+        try {
+            checker.configure({ disallowMultipleLineBreaks: true, disallowMultipleVarDecl: true });
+        } catch (e) {
+            error = e;
+        }
+        assert(error === undefined);
+    });
+});


### PR DESCRIPTION
- checker.js now throws an error if it detects one or more rules in the config
  file which don't match any registered rules.
- Fixing typo in .jscs.json ^.^
