### PR TITLE
Convert tabs to spaces at console output

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -134,6 +134,10 @@ function prependSpaces(s, len) {
  * @returns {String}
  */
 function renderLine(n, line, colorize) {
+    // Convert tabs to spaces, so errors in code lines with tabs as indention symbol
+    // could be correctly rendered, plus it will provide less verbose output
+    line = line.replace(/\t/g, ' ');
+
     // "n + 1" to print lines in human way (counted from 1)
     var lineNumber = prependSpaces((n + 1).toString(), 5) + ' |';
     return ' ' + (colorize ? colors.grey(lineNumber) : lineNumber) + line;

--- a/test/test.errors.js
+++ b/test/test.errors.js
@@ -1,0 +1,16 @@
+var Checker = require('../lib/checker');
+var assert = require('assert');
+
+describe('lib/errors', function() {
+    var checker = new Checker();
+
+    checker.registerDefaultRules();
+    checker.configure({ disallowQuotedKeysInObjects: true });
+
+    it('should provide correct indent for tabbed lines', function() {
+        var errors = checker.checkString('\tvar x = { "a": 1 }'),
+            error = errors.getErrorList()[0];
+
+        assert.ok(!/\t/.test(errors.explainError(error)));
+    });
+});


### PR DESCRIPTION
On projects that uses tabs as indentation symbol, warning messages will be rendered incorrectly: 

<pre>
Operator + should not stick to following expression at test.js :
     1 |    test = +"";
----------------^
     2 |
>> 1 code style errors found!
</pre>
