### PR TITLE
Использовать абсолютный путь для конфигов, передаваемый через параметр

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,6 +8,7 @@
 var fs = require('fs');
 var program = require('commander');
 var Vow = require('vow');
+var path = require('path');
 
 program
     .version(require('../package.json').version)
@@ -19,7 +20,7 @@ program
 var Checker = require('./checker');
 var checker = new Checker();
 
-var configPath = program.config || (process.cwd() + '/.jscs.json');
+var configPath = path.resolve(process.cwd(), program.config || '.jscs.json');
 
 /**
  * Trying to load config.


### PR DESCRIPTION
Захотелось доопределить общий jscs-конфиг проекта для определенных файлов.

К примеру, в описании enb-конфига хочется разрешить использовать пробелы внутри массивов для большей читаемости списка технологий. Поэтому я создаю второй jscs-конфиг и доопределяю в нем общий:

``` javascript
var jscsConfig = require('../.jscs.json');

delete jscsConfig.disallowSpacesInsideArrayBrackets;

module.exports = jscsConfig;
```

Но при вызове проверки путь к этому конфигу отсчитывается, похоже, от `cli.js` внутри пакета. Этот пулреквест должен это исправить.
