### PR TITLE
safeContextKeyword option to check "var that = this" expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,20 @@ Example configuration:
     "requireLineFeedAtFileEnd": true,
 
     /*
+        Option: safeContextKeyword
+        Option to check "var that = this" expressions
+
+        Valid example:
+
+        var that = this;
+
+        Invalid example:
+
+        var _this = this;
+    */
+    "safeContextKeyword": "that"
+
+    /*
         Option: validateJSDoc
         Enables jsdoc validation.
 

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -66,6 +66,8 @@ Checker.prototype = {
 
         this.registerRule(new (require('./rules/require-spaces-in-function-expression'))());
         this.registerRule(new (require('./rules/disallow-spaces-in-function-expression'))());
+
+        this.registerRule(new (require('./rules/safe-context-keyword'))());
     },
 
     /**

--- a/lib/rules/safe-context-keyword.js
+++ b/lib/rules/safe-context-keyword.js
@@ -1,0 +1,47 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(keyword) {
+        assert(typeof keyword === 'string', 'safeContext option requires string value');
+
+        this._keyword = keyword;
+    },
+
+    getOptionName: function () {
+        return 'safeContextKeyword';
+    },
+
+    check: function(file, errors) {
+        var keyword = this._keyword;
+
+        // var that = this
+        file.iterateNodesByType('VariableDeclaration', function (node) {
+
+            for (var i = 0; i < node.declarations.length; i++) {
+                var decl = node.declarations[i];
+
+                if (decl.init.type === 'ThisExpression' && decl.id.name !== keyword) {
+                    errors.add(
+                        'You should use "' + keyword + '" to safe "this"',
+                        node.loc.start
+                    );
+                }
+            }
+        });
+
+        // that = this
+        file.iterateNodesByType('AssignmentExpression', function (node) {
+
+            if (node.right.type === 'ThisExpression' && node.left.name !== keyword) {
+                errors.add(
+                    'You should use "' + keyword + '" to safe "this"',
+                    node.loc.start
+                );
+            }
+        });
+    }
+
+};

--- a/test/test.safeContextKeyword.js
+++ b/test/test.safeContextKeyword.js
@@ -1,0 +1,43 @@
+var Checker = require('../lib/checker');
+var assert = require('assert');
+
+describe('rules/safe-context-keyword', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ safeContextKeyword: 'that' });
+    });
+
+    describe('var', function() {
+        it('should not report "var that = this"', function() {
+            assert(checker.checkString('var that = this;').isEmpty());
+        });
+
+        it('should report "var notthat = this"', function() {
+            assert(checker.checkString('var notthat = this;').getErrorCount() === 1);
+        });
+    });
+
+    describe('withot var', function() {
+        it('should not report "var that = this"', function() {
+            assert(checker.checkString('that = this;').isEmpty());
+        });
+
+        it('should report "var notthat = this"', function() {
+            assert(checker.checkString('notthat = this;').getErrorCount() === 1);
+        });
+    });
+
+    describe('multiple var decl', function() {
+        it('should not report "var that = this"', function() {
+            assert(checker.checkString('var a = 1, that = this;').isEmpty());
+        });
+
+        it('should report "var notthat = this"', function() {
+            assert(checker.checkString('var a = 1, notthat = this;').getErrorCount() === 1);
+        });
+    });
+
+});


### PR DESCRIPTION
Some developers use `that`, some `_this` or `self` keyword to safe `this`.
This option check such assignments

Not sure about option name, change it if you want )
