### PR TITLE
fix bugs in safeContextKeyword

### DIFF
--- a/lib/rules/safe-context-keyword.js
+++ b/lib/rules/safe-context-keyword.js
@@ -5,7 +5,7 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(keyword) {
-        assert(typeof keyword === 'string', 'safeContext option requires string value');
+        assert(typeof keyword === 'string', 'safeContextKeyword option requires string value');
 
         this._keyword = keyword;
     },
@@ -23,7 +23,11 @@ module.exports.prototype = {
             for (var i = 0; i < node.declarations.length; i++) {
                 var decl = node.declarations[i];
 
-                if (decl.init.type === 'ThisExpression' && decl.id.name !== keyword) {
+                if (
+                    // decl.init === null in case of "var foo;"
+                    decl.init &&
+                    (decl.init.type === 'ThisExpression' && decl.id.name !== keyword)
+                ) {
                     errors.add(
                         'You should use "' + keyword + '" to safe "this"',
                         node.loc.start
@@ -35,7 +39,11 @@ module.exports.prototype = {
         // that = this
         file.iterateNodesByType('AssignmentExpression', function (node) {
 
-            if (node.right.type === 'ThisExpression' && node.left.name !== keyword) {
+            if (
+                // filter property assignments "foo.bar = this"
+                node.left.type === 'Identifier' &&
+                (node.right.type === 'ThisExpression' && node.left.name !== keyword)
+            ) {
                 errors.add(
                     'You should use "' + keyword + '" to safe "this"',
                     node.loc.start

--- a/test/test.safeContextKeyword.js
+++ b/test/test.safeContextKeyword.js
@@ -18,6 +18,10 @@ describe('rules/safe-context-keyword', function() {
         it('should report "var notthat = this"', function() {
             assert(checker.checkString('var notthat = this;').getErrorCount() === 1);
         });
+
+        it('should not report "var foo;"', function() {
+            assert(checker.checkString('var foo;').getErrorCount() === 0);
+        });
     });
 
     describe('withot var', function() {
@@ -27,6 +31,10 @@ describe('rules/safe-context-keyword', function() {
 
         it('should report "var notthat = this"', function() {
             assert(checker.checkString('notthat = this;').getErrorCount() === 1);
+        });
+
+        it('should not report propery assignment "foo.bar = this"', function() {
+            assert(checker.checkString('foo.bar = this').getErrorCount() === 0);
         });
     });
 


### PR DESCRIPTION
Fix two bugs
- `var foo;` throws exception
- `boo.bar = this` should be passed as valid code
