### PR TITLE
Added/removed commas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example configuration:
         function() {}
         function (){}
 
-    */,
+    */
     "requireSpacesInFunctionExpression": { "beforeOpeningRoundBrace": true, "beforeOpeningCurlyBrace": true },
 
     /*
@@ -107,7 +107,7 @@ Example configuration:
         function () {}
         function a (){}
 
-    */,
+    */
     "disallowSpacesInFunctionExpression": { "beforeOpeningRoundBrace": true, "beforeOpeningCurlyBrace": true },
 
     /*
@@ -581,7 +581,7 @@ Example configuration:
 
         var _this = this;
     */
-    "safeContextKeyword": "that"
+    "safeContextKeyword": "that",
 
     /*
         Option: validateJSDoc


### PR DESCRIPTION
Discovered a few inconsistencies in the readme while trying to use the config example as .jscs.json. It's still not valid JSON (due to the comments), but at least this makes it marginally easier to use :)
- Added missing comma in readme config example after "safeContextKeyword"
- Removed commas after comments
