### PR TITLE
disallowQuotedKeysInObjects: Exclusion array

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,18 @@ Example configuration:
 
     /*
         Option: disallowQuotedKeysInObjects
+        Possible values:
+            `true`: for strict mode,
+            "allButReserved" allows ES3+ reserved words to remain quoted. This is helpfull when using this option with JSHint's `es3` option.
         Disallows quoted keys in object if possible.
 
-        Valid example:
+        Valid example for mode true:
 
-        var x = {a: 1};
+        var x = { a: { default: 1 } };
+
+        Valid example for mode "allButReserved":
+
+        var x = {a: 1, 'default': 2};
 
         Invalid example:
 

--- a/lib/rules/disallow-quoted-keys-in-objects.js
+++ b/lib/rules/disallow-quoted-keys-in-objects.js
@@ -8,13 +8,57 @@ module.exports.prototype = {
 
     configure: function(disallowQuotedKeysInObjects) {
         assert(
-            typeof disallowQuotedKeysInObjects === 'boolean',
-            OPTION_NAME + ' options requires boolean value'
+            disallowQuotedKeysInObjects === true || disallowQuotedKeysInObjects === 'allButReserved',
+            OPTION_NAME + ' options should be "true" or an array of exceptions'
         );
-        assert(
-            disallowQuotedKeysInObjects === true,
-            'disallowQuotedKeysInObjects option requires true value or should be removed'
-        );
+
+        this._mode = disallowQuotedKeysInObjects;
+
+        this._keywords = {
+            'arguments': true,
+            'break': true,
+            'case': true,
+            'catch': true,
+            'class': true,
+            'continue': true,
+            'debugger': true,
+            'default': true,
+            'delete': true,
+            'do': true,
+            'else': true,
+            'enum': true,
+            'eval': true,
+            'export': true,
+            'extends': true,
+            'finally': true,
+            'for': true,
+            'function': true,
+            'if': true,
+            'implements': true,
+            'import': true,
+            'in': true,
+            'instanceof': true,
+            'interface': true,
+            'let': true,
+            'new': true,
+            'package': true,
+            'private': true,
+            'protected': true,
+            'public': true,
+            'return': true,
+            'static': true,
+            'super': true,
+            'switch': true,
+            'this': true,
+            'throw': true,
+            'try': true,
+            'typeof': true,
+            'var': true,
+            'void': true,
+            'while': true,
+            'with': true,
+            'yield': true
+        };
     },
 
     getOptionName: function() {
@@ -23,9 +67,15 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var KEY_NAME_RE = /^(0|[1-9][0-9]*|[a-zA-Z_$]+[\w$]*)$/; // number or identifier
+        var keywords = this._keywords;
+        var mode = this._mode;
+
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(prop) {
                 var key = prop.key;
+                if (mode === 'allButReserved' && keywords[key.value]) {
+                    return;
+                }
                 if (key.type === 'Literal' &&
                     typeof key.value === 'string' &&
                     KEY_NAME_RE.test(key.value)

--- a/test/test.disallow-quoted-keys-in-objects.js
+++ b/test/test.disallow-quoted-keys-in-objects.js
@@ -50,4 +50,12 @@ describe('rules/disallow-quoted-keys-in-objects', function() {
     it('should check all keys in object', function() {
         assert(checker.checkString('var x = { "a": 1, b: 2, "3": 3 }').getErrorCount() === 2);
     });
+
+    it('should not report if reserved words when "allButReserved" mode is used', function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowQuotedKeysInObjects: 'allButReserved' });
+
+        assert(checker.checkString('var x = { "default": 1, "class": "foo" }').isEmpty());
+    });
 });


### PR DESCRIPTION
Fixes gh-47

Doesn't follow the nested property format as described in the linked issue, but I'm happy to change that if it is the preferred approach.
