### PR TITLE
NPM Test fix for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
         "jscs" : "./bin/jscs"
     },
     "scripts": {
-        "test" : "jshint . && bin/jscs lib test && mocha -u bdd -R spec"
+        "test" : "jshint . && node bin/jscs lib test && mocha -u bdd -R spec"
     }
 }


### PR DESCRIPTION
Follow up to #80, as it looks like the `jscs` call still needs the `node` to run properly on Windows.
