### PR TITLE
Use npm command to browserify instead of makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: browser
-browser:
-	node_modules/.bin/browserify --standalone JscsStringChecker lib/string-checker.js -o jscs-browser.js

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "jscs" : "./bin/jscs"
     },
     "scripts": {
-        "test" : "jshint . && node bin/jscs lib test && mocha -u bdd -R spec"
+        "test" : "jshint . && node bin/jscs lib test && mocha -u bdd -R spec",
+        "browserify": "browserify --standalone JscsStringChecker lib/string-checker.js -o jscs-browser.js"
     }
 }


### PR DESCRIPTION
It's easier to build browser version of `jscs` with `npm run browserify` command instead of `make` one. 
Since you have to install XCode on Mac and something crazy on Windows in order for it to work
