### PR TITLE
Fix for jQuery preset test timing out

### DIFF
--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -32,7 +32,7 @@ describe('cli', function() {
     it('should set jquery preset', function(done) {
         hooker.hook(console, 'log', {
             pre: function(message) {
-                if (message === '\n1 code style errors found.') {
+                if (message.indexOf('code style errors found.') > -1) {
                     hooker.unhook(console);
                     done();
                 }
@@ -40,11 +40,11 @@ describe('cli', function() {
                 return hooker.preempt(message);
             }
         });
-
+    
         var result = cli({
             args: ['test/data/cli.js'],
             preset: 'jquery',
-            config: ''
+            config: 'empty'
         });
 
         assert(result.getProcessedConfig().requireCurlyBraces);


### PR DESCRIPTION
`''` is falsey, so when the CLI did

``` javascript
var configPath = path.resolve(process.cwd(), program.config ||
'.jscs.json');
```

it was using the main `.jscs.json` file from the root, then adding the
jquery rules to that. That seems like it would create strange
side-effects and wasn't intended, so I switched it to a value that would
actually cause the `doesConfigExist` value to be what was expected.

Incidentally, JSCS now finds 2 errors in `test/data/cli.js` so I changed
the comparison to be a little more broad so it'll be less fragile in the
future.
