### PR TITLE
Use jsonminify on config files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,6 +8,7 @@
 var fs = require('fs');
 var Vow = require('vow');
 var path = require('path');
+var minify = require('jsonminify');
 
 var Checker = require('./checker');
 
@@ -22,7 +23,17 @@ module.exports = function(program) {
      * Custom config path can be specified using '-c' option.
      */
     if (doesConfigExist || program.preset) {
-        var config = doesConfigExist ? require(configPath) : {};
+        var config = {};
+        
+        if (doesConfigExist) {
+            var src = fs.readFileSync(configPath, 'utf8');
+            
+            /**
+             * Minify JSON config first, so comments are usable
+             */
+            src = minify(src);
+            config = JSON.parse(src);
+        }
 
         if (program.preset) {
             config.preset = program.preset;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "minimatch": "0.2.12",
     "glob": "3.2.7",
     "xmlbuilder": "1.1.2",
-    "hooker": "0.2.3"
+    "hooker": "0.2.3",
+    "jsonminify": "~0.2.2"
   },
   "devDependencies": {
     "jshint": "2.1.3",

--- a/test/data/comments-config.json
+++ b/test/data/comments-config.json
@@ -1,0 +1,6 @@
+// Testing comment
+{
+    /**
+     * Other type of testing comment
+     */
+}

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -40,7 +40,7 @@ describe('cli', function() {
                 return hooker.preempt(message);
             }
         });
-
+    
         var result = cli({
             args: ['test/data/cli.js'],
             preset: 'jquery',
@@ -48,5 +48,14 @@ describe('cli', function() {
         });
 
         assert(result.getProcessedConfig().requireCurlyBraces);
+    });
+    
+    it('should allow comments in config files', function() {
+        var result = cli({
+            args: ['test/data/cli.js'],
+            config: './test/data/comments-config.json'
+        });
+
+        assert(result.getProcessedConfig());
     });
 });


### PR DESCRIPTION
Adds support for having comments in your JSON config file, which means
the example in README.md can now be copied almost verbatim into an
actual config.

It can't be copied actually verbatim due to overlapping rules, but it's
way easier to start from it now.

Fixes #143
