### PR TITLE
Remove hooker from the main dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "commander": "1.2.0",
     "minimatch": "0.2.12",
     "glob": "3.2.7",
-    "xmlbuilder": "1.1.2",
-    "hooker": "0.2.3"
+    "xmlbuilder": "1.1.2"
   },
   "devDependencies": {
     "jshint": "2.1.3",


### PR DESCRIPTION
It's only used for tests & already exists in `devDependencies`.
