### PR TITLE
Update maximum-line-length.js

### DIFF
--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -23,7 +23,7 @@ module.exports.prototype = {
         var lines = file.getLines();
         for (var i = 0, l = lines.length; i < l; i++) {
             if (lines[i].length > maximumLineLength) {
-                errors.add('Line must be at most ' + maximumLineLength + 'characters', i + 1, 0);
+                errors.add('Line must be at most ' + maximumLineLength + ' characters', i + 1, 0);
             }
         }
     }


### PR DESCRIPTION
Adding a space in the error message. Currently it returns strings such as:

> Line must be at most 100characters at routes/account.js :

But [I think] it reads a bit better if we say "at most 100 characters"
