### PR TITLE
Fix issue #173

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -26,7 +26,7 @@ Errors.prototype = {
         this._errorList.push({
             message: message,
             line: line,
-            column: column
+            column: column || 0
         });
     },
 


### PR DESCRIPTION
Some rules don't provide column on error adding. This cause to exception on Errors#explainError invocation.
Fixes #173
