### PR TITLE
Sort errors list to show errors as they appear in source

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -213,6 +213,12 @@ StringChecker.prototype = {
         this._activeRules.forEach(function(rule) {
             rule.check(file, errors);
         });
+
+        // sort errors list to show errors as they appear in source
+        errors.getErrorList().sort(function(a, b){
+            return (a.line - b.line) || (a.column - b.column);
+        });
+
         return errors;
     }
 };


### PR DESCRIPTION
Without this patch errors showing in order rule applied.
