### PR TITLE
Use the singular "error" if only one error is found.

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -21,7 +21,7 @@ module.exports = function (errorsCollection) {
         /**
          * Printing summary.
          */
-        console.log('\n' + errorCount + ' code style errors found.');
+        console.log('\n' + errorCount + ' code style ' + (errorCount === 1 ? 'error' : 'errors') + ' found.');
         process.exit(1);
     } else {
         console.log('No code style errors found.');

--- a/lib/reporters/text.js
+++ b/lib/reporters/text.js
@@ -21,7 +21,7 @@ module.exports = function (errorsCollection) {
         /**
          * Printing summary.
          */
-        console.log('\n' + errorCount + ' code style errors found.');
+        console.log('\n' + errorCount + ' code style ' + (errorCount === 1 ? 'error' : 'errors') + ' found.');
         process.exit(1);
     } else {
         console.log('No code style errors found.');

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -32,7 +32,7 @@ describe('cli', function() {
     it('should set jquery preset', function(done) {
         hooker.hook(console, 'log', {
             pre: function(message) {
-                if (message === '\n1 code style errors found.') {
+                if (message === '\n1 code style error found.') {
                     hooker.unhook(console);
                     done();
                 }


### PR DESCRIPTION
Update the console & text reporters to use the singular if only one error is found, the plural otherwise.
Update the jquery preset test in the CLI test suite to look for the new text string.

All tests pass.
