### PR TITLE
Temporary fix for esprima tokenizer

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -22,6 +22,19 @@ var JsFile = function(filename, source, tree) {
             }
         }
     });
+
+    // Temporary fix (i hope) for esprima tokenizer
+    // (https://code.google.com/p/esprima/issues/detail?id=481)
+    // Fixes #83, #180
+    this._tree.tokens.forEach(function(token, index) {
+        if (index && token.type === 'Keyword') {
+
+            var previous = this[index - 1].value;
+            if (previous === ',' || previous === '{' || previous === '.') {
+                token.type = 'Identifier';
+            }
+        }
+    }, this._tree.tokens);
 };
 
 JsFile.prototype = {

--- a/test/test.js-file.js
+++ b/test/test.js-file.js
@@ -1,0 +1,32 @@
+var assert = require('assert');
+var esprima = require('esprima');
+var JsFile = require('../lib/js-file');
+
+describe('lib/js-file', function() {
+    it('should fix token array for object keys', function() {
+        var str = '({ for: 42 })';
+        var file = new JsFile(null, str, esprima.parse(str, {tokens: true}));
+
+        file.getTokens().forEach(function(token) {
+            assert(token.type !== 'Keyword');
+        });
+    });
+
+    it('should fix token array for object keys with multiple keys', function() {
+        var str = '({ test: 1, for: 42 })';
+        var file = new JsFile(null, str, esprima.parse(str, {tokens: true}));
+
+        file.getTokens().forEach(function(token) {
+            assert(token.type !== 'Keyword');
+        });
+    });
+
+    it('should fix token array for method calls', function() {
+        var str = 'promise.catch()';
+        var file = new JsFile(null, str, esprima.parse(str, {tokens: true}));
+
+        file.getTokens().forEach(function(token) {
+            assert(token.type !== 'Keyword');
+        });
+    });
+});

--- a/test/test.require-curly-braces.js
+++ b/test/test.require-curly-braces.js
@@ -83,4 +83,8 @@ describe('rules/require-curly-braces', function() {
         checker.configure({ requireCurlyBraces: ['default'] });
         assert(checker.checkString('switch(x){default:{a=b;}}').isEmpty());
     });
+    it('should ignore method name if it\'s a reserved word (#180)', function() {
+        checker.configure({ requireCurlyBraces: ['catch'] });
+        assert(checker.checkString('promise.catch()').isEmpty());
+    });
 });

--- a/test/test.require-space-after-keywords.js
+++ b/test/test.require-space-after-keywords.js
@@ -19,4 +19,12 @@ describe('rules/require-space-after-keywords', function() {
         checker.configure({ requireSpaceAfterKeywords: ['return'] });
         assert(checker.checkString('var x = function () { return; }').isEmpty());
     });
+    it('should ignore reserved word if it\'s an object key (#83)', function() {
+        checker.configure({ requireSpaceAfterKeywords: ['for'] });
+        assert(checker.checkString('({for: "bar"})').isEmpty());
+    });
+    it('should ignore method name if it\'s a reserved word (#180)', function() {
+        checker.configure({ requireSpaceAfterKeywords: ['catch'] });
+        assert(checker.checkString('promise.catch()').isEmpty());
+    });
 });


### PR DESCRIPTION
Replaces type of reserved keywords if the are object keys.
See https://code.google.com/p/esprima/issues/detail?id=481 for more info

Fixes #83, #180
