### PR TITLE
Update .jshintrc, disallow trailling whitespace

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -9,6 +9,7 @@
     "disallowKeywords": ["with"],
     "disallowMultipleLineBreaks": true,
     "disallowKeywordsOnNewLine": ["else"],
+    "disallowTrailingWhitespace": true,
     "requireLineFeedAtFileEnd": true,
     "excludeFiles": ["test/data/*.js"],
     "validateJSDoc": {


### PR DESCRIPTION
As requested by @markelog in #144
