### PR TITLE
Make jquery test less brittle

### DIFF
--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -32,7 +32,7 @@ describe('cli', function() {
     it('should set jquery preset', function(done) {
         hooker.hook(console, 'log', {
             pre: function(message) {
-                if (message === '\n1 code style error found.') {
+                if (message.indexOf('code style errors found.') > -1) {
                     hooker.unhook(console);
                     done();
                 }
@@ -41,6 +41,7 @@ describe('cli', function() {
             }
         });
 
+        // The merging of the main project's config w/ the jquery preset is intentional
         var result = cli({
             args: ['test/data/cli.js'],
             preset: 'jquery',


### PR DESCRIPTION
Now checks that there were _some_ errors, instead of exactly 1 error.
- Added comment to point out that config merging is indeed intentional,
  since I got confused.

This is a re-issue of #144 after I got my head out of my (git) ass.
