### PR TITLE
Reporters: Custom path to reporter (Fixes #211)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@
  * ./node_modules/.bin/jscs file1 dir1 file2 dir2
  */
 var Vow = require('vow');
-
+var path = require('path');
 var Checker = require('./checker');
 var configFile = require('./cli-config');
 
@@ -55,8 +55,24 @@ module.exports = function(program) {
      */
     Vow.all(args.map(checker.checkPath, checker)).then(function(results) {
         var errorsCollection = [].concat.apply([], results);
-        var reporterStr = program.reporter || (program.colors ? 'console' : 'text');
-        var reporter = require('./reporters/' + reporterStr);
+        var reporter;
+
+        try {
+            reporter = require(path.resolve(process.cwd(), program.reporter));
+        }
+        catch (err) {
+            try {
+                reporter = require('./reporters/' + program.reporter);
+            } catch (e) {
+                if (program.reporter) {
+                    console.error('Specified reporter doesn\'t exist.');
+                    return promise.reject(1);
+                }
+
+                var reporterStr = program.colors ? 'console' : 'text';
+                reporter = require('./reporters/' + reporterStr);
+            }
+        }
 
         reporter(errorsCollection);
 

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -98,6 +98,7 @@ describe('cli', function() {
             process.stdout.write.restore();
         });
 
+        // Testing pre-defined reporters with names
         glob.sync(path.resolve(process.cwd(), 'lib/reporters/*.js')).map(function(path) {
             var name = path.match(rname)[1];
 
@@ -129,6 +130,84 @@ describe('cli', function() {
                     reporter: name,
                     config: 'test/data/cli/cli.json'
                 }).promise.then(function(status) {
+                    assert(!status.valueOf());
+
+                    done();
+                });
+            });
+        });
+
+        // Testing reporters with absolute paths
+        glob.sync(path.resolve(process.cwd(), 'lib/reporters/*.js')).map(function (path) {
+            var name = path.match(rname).input;
+
+            it('should return fail exit code for "' + name + '" reporter', function (done) {
+
+                // Can't do it in beforeEach hook,
+                // because otherwise name of the test would not be printed
+                sinon.stub(process.stdout, 'write');
+
+                cli({
+                    args: ['test/data/cli/error.js'],
+                    reporter: name,
+                    config: 'test/data/cli/cli.json'
+                }).promise.fail(function (status) {
+                    assert(status.valueOf());
+
+                    done();
+                });
+            });
+
+            it('should return successful exit code for "' + name + '" reporter', function (done) {
+
+                // Can't do it in beforeEach hook,
+                // because otherwise name of the test would not be printed
+                sinon.stub(process.stdout, 'write');
+
+                cli({
+                    args: ['test/data/cli/success.js'],
+                    reporter: name,
+                    config: 'test/data/cli/cli.json'
+                }).promise.then(function (status) {
+                    assert(!status.valueOf());
+
+                    done();
+                });
+            });
+        });
+
+        // Testing reporters with relative paths
+        glob.sync(path.resolve(process.cwd(), 'lib/reporters/*.js')).map(function (filepath) {
+            var name = 'lib/reporters' + filepath.match(rname)[0];
+
+            it('should return fail exit code for "' + name + '" reporter', function (done) {
+
+                // Can't do it in beforeEach hook,
+                // because otherwise name of the test would not be printed
+                sinon.stub(process.stdout, 'write');
+
+                cli({
+                    args: ['test/data/cli/error.js'],
+                    reporter: name,
+                    config: 'test/data/cli/cli.json'
+                }).promise.fail(function (status) {
+                    assert(status.valueOf());
+
+                    done();
+                });
+            });
+
+            it('should return successful exit code for "' + name + '" reporter', function (done) {
+
+                // Can't do it in beforeEach hook,
+                // because otherwise name of the test would not be printed
+                sinon.stub(process.stdout, 'write');
+
+                cli({
+                    args: ['test/data/cli/success.js'],
+                    reporter: name,
+                    config: 'test/data/cli/cli.json'
+                }).promise.then(function (status) {
                     assert(!status.valueOf());
 
                     done();


### PR DESCRIPTION
- Supports relative to current path: `--reporter ../some/relative/path/custom-reporter.js`
- Supports absolute path: `--reporter /absolute/path/custom-reporter.js`
- Retains built-in reporters support: `--reporter checkstyle`
- Added tests.
- More details at #211.
