### PR TITLE
ValidateQuoteMarks: add "escape" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,9 +1297,15 @@ x++;
 
 Requires all quote marks to be either the supplied value, or consistent if `true`
 
-Type: `String`
+Type: `String` or `Object`
 
-Values: `"\""`, `"'"`, `true`
+Values:
+ - `"\""`: all strings require double quotes
+ - `"'"`: all strings require single quotes
+ - `true`: all strings require the quote mark first encountered in the source code
+ - `Object`:
+    - `escape`: allow the "other" quote mark to be used, but only to avoid having to escape
+    - `mark`: the same effect as the non-object values
 
 JSHint: [`quotmark`](http://jshint.com/docs/options/#quotmark)
 
@@ -1307,6 +1313,22 @@ JSHint: [`quotmark`](http://jshint.com/docs/options/#quotmark)
 
 ```js
 "validateQuoteMarks": "\""
+```
+```js
+"validateQuoteMarks": { mark: "\"", escape: true }
+```
+
+##### Valid example for mode `{ mark: "\"", escape: true }`
+
+```js
+var x = "x";
+var y = '"x"';
+```
+##### Invalid example for mode `{ mark: "\"", escape: true }`
+
+```js
+var x = "x";
+var y = 'x';
 ```
 
 ##### Valid example for mode `"\""` or mode `true`

--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -4,13 +4,24 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(allowedQuoteMark) {
+    configure: function(quoteMark) {
+        this._allowEscape = false;
+
+        if (typeof quoteMark === 'object') {
+            assert(
+                typeof quoteMark.escape === 'boolean' && quoteMark.mark !== undefined,
+                'validateQuoteMarks option requires the "escape" and "mark" property to be defined'
+            );
+            this._allowEscape = quoteMark.escape;
+            quoteMark = quoteMark.mark;
+        }
+
         assert(
-            allowedQuoteMark === '"' || allowedQuoteMark === '\'' || allowedQuoteMark === true,
+            quoteMark === '"' || quoteMark === '\'' || quoteMark === true,
             'validateQuoteMarks option requires \'"\', "\'", or boolean true'
         );
 
-        this._allowedQuoteMark = allowedQuoteMark;
+        this._quoteMark = quoteMark;
     },
 
     getOptionName: function () {
@@ -18,14 +29,27 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var allowedQuoteMark = this._allowedQuoteMark;
+        var quoteMark = this._quoteMark;
+        var allowEscape = this._allowEscape;
+        var opposite = {
+            '"': '\'',
+            '\'': '"'
+        };
 
         file.iterateTokensByType('String', function(token) {
-            if (allowedQuoteMark === true) {
-                allowedQuoteMark = token.value[0];
+            var str = token.value;
+            var mark = str[0];
+            var stripped = str.substring(1, str.length -1);
+
+            if (quoteMark === true) {
+                quoteMark = mark;
             }
 
-            if (token.value[0] !== allowedQuoteMark) {
+            if (mark !== quoteMark) {
+                if (allowEscape && stripped.indexOf(opposite[mark]) > -1) {
+                    return;
+                }
+
                 errors.add(
                     'Invalid quote mark found',
                     token.loc.start.line,

--- a/test/test.validate-quote-marks.js
+++ b/test/test.validate-quote-marks.js
@@ -31,6 +31,37 @@ describe('rules/validate-quote-marks', function() {
         });
     });
 
+    describe('option value \' and escape ', function() {
+        beforeEach(function() {
+            checker.configure({
+                validateQuoteMarks: {
+                    mark: '\'',
+                    escape: true
+                }
+            });
+        });
+
+        it('should report double quotes in strings', function() {
+            assert(checker.checkString('var x = "x";').getErrorCount() === 1);
+        });
+
+        it('should not report double quotes to avoid escaping', function() {
+            assert(checker.checkString('var x = "\'x\'";').isEmpty());
+        });
+
+        it('should not report single quotes in strings', function() {
+            assert(checker.checkString('var x = \'x\';').isEmpty());
+        });
+
+        it('should not report double quotes values in single quotes strings', function() {
+            assert(checker.checkString('var x = \'"x"\';').isEmpty());
+        });
+
+        it('should not report double quotes in comments', function() {
+            assert(checker.checkString('var x = \'x\'; /*"y"*/').isEmpty());
+        });
+    });
+
     describe('option value " ', function() {
         beforeEach(function() {
             checker.configure({ validateQuoteMarks: '"' });
@@ -53,6 +84,37 @@ describe('rules/validate-quote-marks', function() {
         });
     });
 
+    describe('option value " and escape ', function() {
+        beforeEach(function() {
+            checker.configure({
+                validateQuoteMarks: {
+                    mark: '"',
+                    escape: true
+                }
+            });
+        });
+
+        it('should report single quotes in strings', function() {
+            assert(checker.checkString('var x = \'x\';').getErrorCount() === 1);
+        });
+
+        it('should not report single quotes to avoid escaping', function() {
+            assert(checker.checkString('var x = \'"x"\';').isEmpty());
+        });
+
+        it('should not report double quotes in strings', function() {
+            assert(checker.checkString('var x = "x";').isEmpty());
+        });
+
+        it('should not report single quotes values in double quotes strings', function() {
+            assert(checker.checkString('var x = "\'x\'";').isEmpty());
+        });
+
+        it('should not report single quotes in comments', function() {
+            assert(checker.checkString('var x = "x"; /*\'y\'*/').isEmpty());
+        });
+    });
+
     describe('option value true ', function() {
         beforeEach(function() {
             checker.configure({ validateQuoteMarks: true });
@@ -60,6 +122,37 @@ describe('rules/validate-quote-marks', function() {
 
         it('should report inconsistent quotes in strings', function() {
             assert(checker.checkString('var x = \'x\', y = "y";').getErrorCount() === 1);
+        });
+
+        it('should not report consistent single quotes in strings', function() {
+            assert(checker.checkString('var x = \'x\', y = \'y\';').isEmpty());
+        });
+
+        it('should not report consistent double quotes in strings', function() {
+            assert(checker.checkString('var x = "x", y = "y";').isEmpty());
+        });
+
+        it('should not report inconsistent quotes in comments', function() {
+            assert(checker.checkString('var x = "x", y = "y"; /*\'y\'*/').isEmpty());
+        });
+    });
+
+    describe('option value true and escape', function() {
+        beforeEach(function() {
+            checker.configure({
+                validateQuoteMarks: {
+                    mark: true,
+                    escape: true
+                }
+            });
+        });
+
+        it('should report inconsistent quotes in strings', function() {
+            assert(checker.checkString('var x = \'x\', y = "y";').getErrorCount() === 1);
+        });
+
+        it('should not report inconsistent quotes to avoid escaping', function() {
+            assert(checker.checkString('var x = \'x\', y = "\'y\'";').isEmpty());
         });
 
         it('should not report consistent single quotes in strings', function() {


### PR DESCRIPTION
Allows the other quote mark to avoid having to escape characters. Closes #229
