### PR TITLE
README.md fixes for requireMultipleVarDecl and disallowMultipleVarDecl

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ var x = 1,
 ```js
 var x = 1;
 var y = 2;
-
 ```
 
 ### disallowEmptyBlocks


### PR DESCRIPTION
README.md had  requireMultipleVarDecl and disallowMultipleVarDecl examples backwards.
