### PR TITLE
Updated package description so as not to troll pedants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Marat Dulin <mdevils@yandex.ru>",
-  "description": "JavaScript Style Checker",
+  "description": "JavaScript Code Style",
   "name": "jscs",
   "version": "1.3.0",
   "main": "lib/checker",


### PR DESCRIPTION
npm reads the description field from package.json and renders it along with the package name.

> node-_jscs_
> JavaScript _Style Checker_

The mismatch between the acronym and the description made me want to claw my own eyes out, so I swapped it for the package name from the readme.
