### PR TITLE
simple jsdoc @returns validation. closes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -2208,6 +2208,10 @@ Values:
  - "checkParamNames" ensures param names in jsdoc and in function declaration are equal
  - "requireParamTypes" ensures params in jsdoc contains type
  - "checkRedundantParams" reports redundant params in jsdoc
+ - "checkReturnTypes" tries to compare function result type with declared type in jsdoc
+ - "requireReturnTypes" ensures returns in jsdoc contains type
+ - "checkRedundantReturns" reports redundant returns in jsdoc
+ - "checkTypes" reports invalid types in jsdoc
 
 #### Example
 
@@ -2215,7 +2219,11 @@ Values:
 "validateJSDoc": {
     "checkParamNames": true,
     "checkRedundantParams": true,
-    "requireParamTypes": true
+    "requireParamTypes": true,
+    "checkReturnTypes": true,
+    "checkRedundantReturns": true,
+    "requireReturnTypes": true,
+    "checkTypes": true
 }
 ```
 

--- a/lib/esprima-helpers.js
+++ b/lib/esprima-helpers.js
@@ -1,0 +1,21 @@
+module.exports = {
+	closestScopeNode : closestScopeNode,
+    treeIterator     : require('./tree-iterator')
+};
+
+var scopeNodeTypes = [
+    'Program',
+    'FunctionDeclaration',
+    'FunctionExpression'
+];
+
+/**
+ * Search for the closest scope node tree for Node
+ * @param {{type: String}} n
+ */
+function closestScopeNode (n) {
+    while (n && scopeNodeTypes.indexOf(n.type) === -1) {
+        n = n.parentNode;
+    }
+    return n;
+}

--- a/lib/jsdoc-helpers.js
+++ b/lib/jsdoc-helpers.js
@@ -1,0 +1,144 @@
+var doctrineParser = require('doctrine');
+
+module.exports = {
+    parseComments : jsDocParseComments,
+
+    parse : jsDocParseType,
+    match : jsDocMatchType
+};
+
+function jsDocParseComments (comments) {
+
+    /**
+     * metaobject for parsing jsdoc comments string
+     */
+    return {
+        node: getJsDocForNode,
+        line: getJsDocForLine
+    };
+
+    function getJsDocForNode (node) {
+        return getJsDocForLine(node.loc.start.line);
+    }
+
+    function getJsDocForLine (line) {
+        line--;
+        for (var i = 0, l = comments.length; i < l; i++) {
+            var comment = comments[i];
+            if (comment.loc.end.line === line && comment.type === 'Block' && comment.value.charAt(0) === '*') {
+                return comment;
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Parses jsDoc string
+ * @param {String} typeString
+ * @return {?Array.<SimplifiedType>} - parsed jsdoctype string as array
+ */
+function jsDocParseType (typeString) {
+    var node;
+
+    try {
+        node = jsDocSimplifyNode(doctrineParser.parseType(typeString));
+    } catch (e) {
+        node = [];
+        node.invalid = true;
+    }
+
+    return node;
+}
+
+/**
+ * Converts AST jsDoc node to simple object
+ * @param {Object} node
+ * @returns {!(SimplifiedType[])}
+ */
+function jsDocSimplifyNode (node) {
+    var result;
+
+    switch (node.type) {
+
+    case 'NullableType':
+    case 'NonNullableType':
+        result = jsDocSimplifyNode (node.expression);
+        result.nullable = (node.type === 'NullableType');
+        return result;
+
+    case 'UnionType':
+        result = [];
+        for (var i = 0, l = node.elements.length; i < l; i += 1) {
+            result.push(jsDocSimplifyNode(node.elements[i]));
+        }
+        break;
+
+    case 'TypeApplication':
+        result = {type: node.expression.name, native: true};
+        break;
+
+    case 'NameExpression':
+        result = {type: node.name};
+        break;
+
+    case 'RecordType':
+        result = {type: 'Object', native: true};
+        break;
+
+    case 'FunctionType':
+        result = {type: 'Function', native: true};
+        break;
+
+    // unused
+    case 'FieldType':
+        break;
+
+    default:
+        result = {type: 'Object', unknown: true};
+        break;
+
+    }
+
+    if (!Array.isArray(result)) {
+        result = [result];
+    }
+
+    return result;
+}
+
+/**
+ * Compare parsed jsDocTypes with esprima node
+ * @param {SimplifiedType[]} variants - result of jsDocParseType
+ * @param {Object} argument - esprima source code node
+ */
+function jsDocMatchType (variants, argument) {
+    var i, l, variant, type;
+
+    for (i = 0, l = variants.length; i < l; i += 1) {
+        variant = variants[i];
+        type = variant.type.toLowerCase();
+
+        if (argument.type === 'Literal') {
+            if (typeof argument.value !== 'object') {
+                return type === typeof argument.value;
+            }
+            if (!argument.value.type) {
+                return type === (argument.value instanceof RegExp ? 'regexp' : 'object');
+            }
+            return type === argument.value.type;
+
+        } else if (argument.type === 'ObjectExpression') {
+            return (type === 'object');
+
+        } else if (argument.type === 'ArrayExpression') {
+            return (type === 'array');
+
+        } else if (argument.type === 'NewExpression') {
+            return (type === 'object') || (type === argument.callee.name.toLowerCase());
+        }
+    }
+
+    // variables, expressions, another behavior
+    return true;
+}

--- a/lib/rules/validate-jsdoc.js
+++ b/lib/rules/validate-jsdoc.js
@@ -1,4 +1,7 @@
-var assert = require('assert');
+var assert = require('assert'),
+
+    jsDocHelpers = require('../jsdoc-helpers'),
+    esprimaHelpers = require('../esprima-helpers');
 
 module.exports = function() {};
 
@@ -15,77 +18,164 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var options = this._options;
-        var comments = file.getComments();
+        var lineValidators = [];
+
+        // create validators list
+        if (options.checkParamNames || options.checkRedundantParams || options.requireParamTypes) {
+            lineValidators.push(validateParamLine);
+        }
+        if (options.checkReturnTypes || options.checkRedundantReturns || options.checkTypes ||
+            options.requireReturnTypes) {
+            lineValidators.push(validateReturnsLine);
+        }
+
+        // skip if there is nothing to check
+        if (!lineValidators.length) {
+            return;
+        }
+
+        var jsDocs = jsDocHelpers.parseComments(file.getComments());
+
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
-            var jsDoc = getJsDocForLine(node.loc.start.line);
-            if (jsDoc) {
-                var jsDocData = jsDoc.value;
-                var jsDocLines = jsDocData.split('\n');
-                var paramIndex = 0;
-                if (options.checkParamNames || options.checkRedundantParams || options.requireParamTypes) {
-                    for (var i = 0, l = jsDocLines.length; i < l; i++) {
-                        var line = jsDocLines[i].trim();
-                        if (line.charAt(0) === '*') {
-                            line = line.substr(1).trim();
-                            if (line.indexOf('@param') === 0) {
-                                var match = line.match(/^@param\s+(?:{(.+?)})?\s*(?:\[)?([a-zA-Z0-9_\.\$]+)/);
-                                if (match) {
-                                    var jsDocParamType = match[1];
-                                    var jsDocParamName = match[2];
-                                    if (options.requireParamTypes && !jsDocParamType) {
-                                        errors.add(
-                                            'Missing JSDoc @param type',
-                                            jsDoc.loc.start.line + i,
-                                            jsDocLines[i].indexOf('@param')
-                                        );
-                                    }
-                                    if (jsDocParamName.indexOf('.') === -1) {
-                                        var param = node.params[paramIndex];
-                                        if (param) {
-                                            if (jsDocParamName !== param.name) {
-                                                if (options.checkParamNames) {
-                                                    errors.add(
-                                                        'Invalid JSDoc @param argument name',
-                                                        jsDoc.loc.start.line + i,
-                                                        jsDocLines[i].indexOf('@param')
-                                                    );
-                                                }
-                                            }
-                                        } else {
-                                            if (options.checkRedundantParams) {
-                                                errors.add(
-                                                    'Redundant JSDoc @param',
-                                                    jsDoc.loc.start.line + i,
-                                                    jsDocLines[i].indexOf('@param')
-                                                );
-                                            }
-                                        }
-                                        paramIndex++;
-                                    }
-                                } else {
-                                    errors.add(
-                                        'Invalid JSDoc @param',
-                                        jsDoc.loc.start.line + i,
-                                        jsDocLines[i].indexOf('@param')
-                                    );
-                                }
-                            }
-                        }
-                    }
+            var jsDoc = jsDocs.node(node);
+            if (!jsDoc) {
+                return;
+            }
+
+            node.jsDoc = jsDoc.value.split('\n');
+            node.jsDoc = node.jsDoc || {};
+            node.jsDoc.paramIndex = 0;
+
+            function addError (text, locStart) {
+                locStart = locStart || {};
+                errors.add(
+                    text,
+                    locStart.line || (jsDoc.loc.start.line + i),
+                    locStart.column || (node.jsDoc[i].indexOf('@'))
+                );
+            }
+
+            for (var i = 0, l = node.jsDoc.length; i < l; i++) {
+                var line = node.jsDoc[i].trim();
+                if (line.charAt(0) !== '*') {
+                    continue;
+                }
+
+                line = line.substr(1).trim();
+
+                for (var j = 0, k = lineValidators.length; j < k; j++) {
+                    lineValidators[j](node, line, addError);
                 }
             }
         });
 
-        function getJsDocForLine(line) {
-            line--;
-            for (var i = 0, l = comments.length; i < l; i++) {
-                var comment = comments[i];
-                if (comment.loc.end.line === line && comment.type === 'Block' && comment.value.charAt(0) === '*') {
-                    return comment;
-                }
+        /**
+         * validator for @param
+         * @param {{type: 'FunctionDeclaration'}|{type: 'FunctionExpression'}} node
+         * @param {Number} line
+         * @param {Function} err
+         */
+        function validateParamLine(node, line, err) {
+            if (line.indexOf('@param') !== 0) {
+                return;
             }
-            return null;
+
+            // checking validity
+            var match = line.match(/^@param\s+(?:{(.+?)})?\s*(\[)?([a-zA-Z0-9_\.\$]+)/);
+            if (!match) {
+                return err('Invalid JsDoc @param');
+            }
+
+            var jsDocType = match[1];
+            var jsDocName = match[3];
+            var jsDocOptional = match[2] === '[';
+
+            // checking existance
+            if (options.requireParamTypes && !jsDocType) {
+                return err('Missing JsDoc @param type');
+            }
+
+            var jsDocParsedType = jsDocHelpers.parse(jsDocType);
+            if (options.checkTypes && jsDocParsedType.invalid) {
+                return err('Invalid JsDoc type definition');
+            }
+
+            // skip if there is dot in param name (object's inner param)
+            if (jsDocName.indexOf('.') !== -1) {
+                return;
+            }
+
+            // checking redudant
+            var param = node.params[node.jsDoc.paramIndex];
+            if (options.checkRedundantParams && !jsDocOptional && !param) {
+                return err('Redundant JsDoc @param');
+            }
+
+            // checking name
+            if (options.checkParamNames && jsDocName !== param.name) {
+                return err('Invalid JsDoc @param argument name');
+            }
+
+            node.jsDoc.paramIndex++;
         }
+
+        /**
+         * validator for @return/@returns
+         * @param {(FunctionDeclaration|FunctionExpression)} node
+         * @param {Number} line
+         * @param {Function} err
+         */
+        function validateReturnsLine(node, line, err) {
+            if (line.indexOf('@return') !== 0) {
+                return;
+            }
+
+            // checking validity
+            var match = line.match(/^@returns?\s+(?:{(.+?)})?/);
+            if (!match) {
+                return err('Invalid JsDoc @returns');
+            }
+
+            var jsDocType = match[1];
+
+            // checking existance
+            if (options.requireReturnTypes && !jsDocType) {
+                err('Missing JsDoc @returns type');
+            }
+
+            var jsDocParsedType = jsDocHelpers.parse(jsDocType);
+            if (options.checkTypes && jsDocParsedType.invalid) {
+                return err('Invalid JsDoc type definition');
+            }
+
+            if (!options.checkRedundantReturns && !options.checkReturnTypes) {
+                return;
+            }
+
+            var returnsArgumentStatements = [];
+            esprimaHelpers.treeIterator.iterate(node, function(n/*, parentNode, parentCollection*/) {
+                if (n && n.type === 'ReturnStatement' && n.argument) {
+                    if (node === esprimaHelpers.closestScopeNode(n)) {
+                        returnsArgumentStatements.push(n.argument);
+                    }
+                }
+            });
+
+            // checking redundant
+            if (options.checkRedundantReturns && !returnsArgumentStatements.length) {
+                err('Redundant JsDoc @returns');
+            }
+
+            // try to check returns types
+            if (options.checkReturnTypes && jsDocParsedType) {
+                returnsArgumentStatements.forEach(function (argument) {
+                    if (!jsDocHelpers.match(jsDocParsedType, argument)) {
+                        err('Wrong returns value', argument.loc.start);
+                    }
+                });
+            }
+        }
+
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "vow": "~0.3.12",
     "vow-fs": "~0.2.3",
     "xmlbuilder": "~2.1.0",
-    "findup-sync": "~0.1.2"
+    "findup-sync": "~0.1.2",
+    "doctrine": "0.5.0"
   },
   "devDependencies": {
     "browserify": "~3.30.2",
@@ -43,13 +44,14 @@
     "mocha": "~1.17.1",
     "sinon": "~1.8.2",
     "xml2js": "~0.4.1"
+
   },
   "bin": {
     "jscs": "./bin/jscs"
   },
   "scripts": {
-    "lint": "jshint . && node bin/jscs lib test bin",
-    "test": "npm run lint && mocha -u bdd -R spec",
+    "lint": "./node_modules/.bin/jshint . && node bin/jscs lib test bin",
+    "test": "npm run lint && ./node_modules/.bin/mocha -u bdd -R spec",
     "browserify": "browserify --standalone JscsStringChecker lib/string-checker.js -o jscs-browser.js"
   },
   "files": [

--- a/test/test.validate-jsdoc-returns.js
+++ b/test/test.validate-jsdoc-returns.js
@@ -1,0 +1,219 @@
+var Checker = require('../lib/checker');
+var assert = require('assert');
+
+describe('rules/validate-jsdoc', function() {
+
+    describe('returns', function () {
+
+        var checker;
+        beforeEach(function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+        });
+
+        it('should report invalid @returns jsdoc', function() {
+            checker.configure({ validateJSDoc: { requireReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    'var x = 1;\n' +
+                    '/**\n' +
+                    ' * @return' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        '\n' +
+                    '}'
+                ).getErrorCount() === 1
+            );
+        });
+
+        it('should report redundant @returns for function', function() {
+            checker.configure({ validateJSDoc: { checkRedundantReturns: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {string}' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        '\n' +
+                    '}\n' +
+
+                    '/**\n' +
+                    ' * @returns {String}' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'var x = function () { return 1; }\n' +
+                    '}\n' +
+
+                    '/**\n' +
+                    ' * @returns {String}' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return;\n' +
+                    '}'
+                ).getErrorCount() === 3
+            );
+        });
+
+        it('should not report redundant @returns for function', function() {
+            checker.configure({ validateJSDoc: { checkRedundantReturns: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @returns {String}' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'var x = function () { return 1; }\n' +
+                        'if (true) { return x; }\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should report invalid @returns type in function', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @returns {Object}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return "";\n' +
+                    '}'
+                ).getErrorCount() === 1
+            );
+        });
+
+        it('should not report valid jsdoc with object type in method', function() {
+            checker.configure({ validateJSDoc: { requireReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    'Cls.prototype = {\n' +
+                        '    /**\n' +
+                        '     * @return {{bar: number}}\n' +
+                        '     */\n' +
+                        '    run: function(xxx) {\n' +
+                        '        return {};\n' +
+                        '    }\n' +
+                        '};'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report valid resulting type with object type in method', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    'Cls.prototype = {\n' +
+                    '    /**\n' +
+                    '     * @return {{bar: number}}\n' +
+                    '     */\n' +
+                    '    run: function(xxx) {\n' +
+                    '        return {};\n' +
+                    '    }\n' +
+                    '};\n'
+                ).isEmpty()
+            );
+        });
+        it('should not report valid resulting type with object type in function', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {Object}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return new Object();\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report comparition jsdoc type to any expression in function', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {Object}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return Object.create();\n' +
+                    '}\n' +
+                    '/**\n' +
+                    ' * @return {string}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return makeMyDay("zxc");\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report valid resulting array type for function', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {Array}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return [1, 2];\n' +
+                    '}\n' +
+                    '/**\n' +
+                    ' * @return {Array}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return new Array("zxc");\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report valid resulting regexp type for function', function() {
+            checker.configure({ validateJSDoc: { checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {RegExp}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return /[a-z]+/i;\n' +
+                    '}\n' +
+                    '/**\n' +
+                    ' * @return {RegExp}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return new RegExp("[a-z]+", "i");\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report valid resulting array.<String> and Object[] for function', function () {
+            checker.configure({ validateJSDoc: { requireReturnTypes: true, checkReturnTypes: true } });
+            assert(
+                checker.checkString(
+                    '/**\n' +
+                    ' * @return {String[]}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return ["a", "b", "c"];\n' +
+                    '}\n' +
+                    '/**\n' +
+                    ' * @return {Object[]}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return [{}, {}];\n' +
+                    '}\n' +
+                    '/**\n' +
+                    ' * @return {Array.<Number>}\n' +
+                    ' */\n' +
+                    'function funcName() {\n' +
+                        'return [1, 2, 3];\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+    });
+
+});

--- a/test/test.validate-jsdoc.js
+++ b/test/test.validate-jsdoc.js
@@ -109,6 +109,20 @@ describe('rules/validate-jsdoc', function() {
             ).getErrorCount() === 1
         );
     });
+    it('should not report redundant jsdoc-param for function', function() {
+        checker.configure({ validateJSDoc: { checkRedundantParams: true } });
+        assert(
+            checker.checkString(
+                '/**\n' +
+                ' * @param {Object} [elem] Nested element\n' +
+                ' * @param {String} [modName1, ..., modNameN] Modifier names\n' +
+                ' */\n' +
+                'function funcName(elem) {\n' +
+                    '\n' +
+                '}'
+            ).getErrorCount() === 0
+        );
+    });
     it('should not report valid jsdoc for method', function() {
         checker.configure({ validateJSDoc: { checkRedundantParams: true } });
         assert(


### PR DESCRIPTION
  rebuild of jsdoc validator
  basic functionality for returns
  tests for returns
  readme updated
  fixed jsdoc optional param redudancy validation if it wasn't declared in function/method arity
