### PR TITLE
Function expressions ignore getters and setters

### DIFF
--- a/lib/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -45,6 +45,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var parent = node.parentNode;
+
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
 
             // anonymous function expressions only
             if (!node.id) {

--- a/lib/rules/disallow-spaces-in-function-expression.js
+++ b/lib/rules/disallow-spaces-in-function-expression.js
@@ -44,6 +44,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
+            var parent = node.parentNode;
+
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
 
             if (beforeOpeningRoundBrace) {
                 var nodeBeforeRoundBrace = node;

--- a/lib/rules/require-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/require-spaces-in-anonymous-function-expression.js
@@ -45,6 +45,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var parent = node.parentNode;
+
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
 
             if (!node.id) {
 

--- a/lib/rules/require-spaces-in-function-expression.js
+++ b/lib/rules/require-spaces-in-function-expression.js
@@ -44,6 +44,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
+            var parent = node.parentNode;
+
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
 
             if (beforeOpeningRoundBrace) {
                 var nodeBeforeRoundBrace = node;

--- a/test/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/test/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -25,6 +25,25 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -37,6 +56,26 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
         it('should report space before curly brace in FunctionExpression', function() {
             checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function() {}').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in of setter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });

--- a/test/rules/disallow-spaces-in-function-expression.js
+++ b/test/rules/disallow-spaces-in-function-expression.js
@@ -45,6 +45,25 @@ describe('rules/disallow-spaces-in-function-expression', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -57,6 +76,26 @@ describe('rules/disallow-spaces-in-function-expression', function() {
         it('should report space before curly brace in FunctionExpression', function() {
             checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function() {}').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in of setter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });

--- a/test/rules/disallow-spaces-in-named-function-expression.js
+++ b/test/rules/disallow-spaces-in-named-function-expression.js
@@ -25,6 +25,25 @@ describe('rules/disallow-spaces-in-named-function-expression', function() {
             assert(checker.checkString('var x = function a (){}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -37,6 +56,26 @@ describe('rules/disallow-spaces-in-named-function-expression', function() {
         it('should report space before curly brace in named FunctionExpression', function() {
             checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function a() {}').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in setter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });

--- a/test/rules/require-spaces-in-anonymous-function-expression.js
+++ b/test/rules/require-spaces-in-anonymous-function-expression.js
@@ -25,6 +25,26 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
             assert(checker.checkString('var x = function() {}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
+
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -37,6 +57,26 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
         it('should not report space before curly brace in FunctionExpression', function() {
             checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function() {}').isEmpty());
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });

--- a/test/rules/require-spaces-in-function-expression.js
+++ b/test/rules/require-spaces-in-function-expression.js
@@ -45,6 +45,25 @@ describe('rules/require-spaces-in-function-expression', function() {
             assert(checker.checkString('var x = function() {}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -57,6 +76,26 @@ describe('rules/require-spaces-in-function-expression', function() {
         it('should not report space before curly brace in FunctionExpression', function() {
             checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function() {}').isEmpty());
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });

--- a/test/rules/require-spaces-in-named-function-expression.js
+++ b/test/rules/require-spaces-in-named-function-expression.js
@@ -25,6 +25,25 @@ describe('rules/require-spaces-in-named-function-expression', function() {
             assert(checker.checkString('var x = function a() {}').isEmpty());
         });
 
+        it('should not report space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in getter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { get y() {} }').isEmpty());
+        });
+
+        it('should not report missing space before round brace in setter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -37,6 +56,26 @@ describe('rules/require-spaces-in-named-function-expression', function() {
         it('should not report space before curly brace in named FunctionExpression', function() {
             checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
             assert(checker.checkString('var x = function a() {}').isEmpty());
+        });
+
+        it('should not report space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y () {} }').isEmpty());
+        });
+
+        it('should not report space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v) {} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in getter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { get y (){} }').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in setter expression', function() {
+            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            assert(checker.checkString('var x = { set y (v){} }').isEmpty());
         });
     });
 });


### PR DESCRIPTION
Added a check to the following rules:
- disallow-spaces-in-anonymous-function-expression
- disallow-spaces-in-function-expression
- require-spaces-in-anonymous-function-expression
- require-spaces-in-function-expression

These rules erroneously interpreted setter and getter expressions like
these as full function expressions:

```
{
  get x () {
  },
  set x (v) {
  }
}
```

This made it impossible to run jscs on JS code that used these constructs,
as it threw false errors whenever it encountered them.

The bug was caused by the fact that esprima actually registers these constructs as
functions assigned to a property with the special kinds 'set' and 'get'.
This patch checks the parent node of the function expression against these
special kinds in order to ignore the special getter and setter constructs.

Tests for this condition were also added for the following rules:
- disallow-spaces-in-anonymous-function-expression
- disallow-spaces-in-function-expression
- disallow-spaces-in-named-function-expression
- require-spaces-in-anonymous-function-expression
- require-spaces-in-function-expression
- require-spaces-in-named-function-expression

The named function expression rules did not need to be patched
because these constructs never generate named functions.

Fixes #69
