### PR TITLE
Added new inline reporter

### DIFF
--- a/lib/reporters/inlinesingle.js
+++ b/lib/reporters/inlinesingle.js
@@ -1,0 +1,24 @@
+/**
+ * inlinesingle solves an issue that Windows (7+) users have been
+ * experiencing using SublimeLinter-jscs. It appears this is due to
+ * SublimeText not managing multi-line output properly on these machines.
+ * This reporter differs from inline.js by producing one comment line
+ * separated by linebreaks rather than a series of separate lines.
+ */
+
+var util = require('util');
+
+/**
+ * @param {Errors[]} errorsCollection
+ */
+module.exports = function(errorsCollection) {
+    errorsCollection.forEach(function(errors) {
+        if (!errors.isEmpty()) {
+            var file = errors.getFilename();
+            var out = errors.getErrorList().map(function(error) {
+                return util.format('%s: line %d, col %d, %s', file, error.line, error.column, error.message);
+            });
+            console.log(out.join('\n'));
+        }
+    });
+};


### PR DESCRIPTION
[Several of us](https://github.com/SublimeLinter/SublimeLinter-jscs/issues/6) have been having problems with node-jscs working properly with SublimeLinter-jscs on Windows7+ machines. It appears this is due to SublimeText not managing multi-line output properly on these machines.

To fix this [I've created a new inline reporter called inlinesingle](https://github.com/SublimeLinter/SublimeLinter-jscs/issues/6#issuecomment-41304687) (inline-single failed the Travis test due to the hyphen) which SublimeLinter-jscs can use. I will be submitting a separate SublimeLinter-jscs pull request depending on whether this is approved.

[Other users have tested this approach](https://github.com/SublimeLinter/SublimeLinter-jscs/issues/6#issuecomment-41371635).
