### PR TITLE
"null" must be quoted keys in IE 6-8

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,7 @@ var ES3_KEYWORDS = {
     'in': true,
     'instanceof': true,
     'new': true,
+    'null': true,
     'return': true,
     'switch': true,
     'this': true,

--- a/test/rules/disallow-quoted-keys-in-objects.js
+++ b/test/rules/disallow-quoted-keys-in-objects.js
@@ -58,4 +58,12 @@ describe('rules/disallow-quoted-keys-in-objects', function() {
 
         assert(checker.checkString('var x = { "default": 1, "class": "foo" }').isEmpty());
     });
+
+    it('does not report for "null" when "allButReserved" mode is used', function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowQuotedKeysInObjects: 'allButReserved' });
+
+        assert(checker.checkString('var x = { "null": 1, undefined: "foo" }').isEmpty());
+    });
 });


### PR DESCRIPTION
Fixes #382.
