### PR TITLE
Handle properties as function expressions in dissallowSpacesInFunctionExpression

### DIFF
--- a/lib/rules/disallow-spaces-in-function-expression.js
+++ b/lib/rules/disallow-spaces-in-function-expression.js
@@ -50,6 +50,9 @@ module.exports.prototype = {
                 // named function
                 if (node.id) {
                     nodeBeforeRoundBrace = node.id;
+                } else if (node.parentNode.type === 'Property' && node.parentNode.kind !== 'init') {
+                    // function expression is a part of property expression
+                    nodeBeforeRoundBrace = node.parentNode.key;
                 }
 
                 var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);

--- a/test/rules/disallow-spaces-in-function-expression.js
+++ b/test/rules/disallow-spaces-in-function-expression.js
@@ -20,6 +20,16 @@ describe('rules/disallow-spaces-in-function-expression', function() {
             assert(checker.checkString('var x = function a(){}').isEmpty());
         });
 
+        it('should not report missing space before round brace in getters', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = {get property() { }}').isEmpty());
+        });
+
+        it('should report space before opening round brace in getters', function() {
+            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            assert(checker.checkString('var x = {get property () {}}').getErrorCount() === 1);
+        });
+
         it('should report space before round brace in FunctionExpression', function() {
             checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
             assert(checker.checkString('var x = function (){}').getErrorCount() === 1);


### PR DESCRIPTION
`get something() {}` and `set something()` is valid construct in ES5.
 Such expressions causes jscs to "miss" correct function token
and incorrectly report space after "{" as space before "()".
