### PR TITLE
Count comments as valid tokens in `disallowPaddingNewlinesInBlocks`

### DIFF
--- a/lib/rules/disallow-padding-newlines-in-blocks.js
+++ b/lib/rules/disallow-padding-newlines-in-blocks.js
@@ -19,6 +19,7 @@ module.exports.prototype = {
         var _commentLineMap;
 
         function getCommentLines() {
+            // builds a cache of lines with comments
             if (!_commentLineMap) {
                 _commentLineMap = file.getComments().reduce(function(map, comment) {
                     for (var x = comment.loc.start.line; x <= comment.loc.end.line; x++) {
@@ -31,42 +32,38 @@ module.exports.prototype = {
             return _commentLineMap;
         }
 
-        function hasEmptyLine(startLine, endLine) {
+        file.iterateNodesByType('BlockStatement', function(node) {
+            var tokens = file.getTokens();
             var commentLines = getCommentLines();
 
-            for (var x = startLine; x < endLine; x++) {
-                if (!commentLines[x]) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        file.iterateNodesByType('BlockStatement', function(node) {
-            if (node.body.length === 0) {
-                return;
-            }
-
-            var tokens = file.getTokens();
             var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
 
             var openingBracket = tokens[openingBracketPos];
             var nextToken = tokens[openingBracketPos + 1];
+
             var startLine = openingBracket.loc.start.line + 1;
             var nextLine = nextToken.loc.start.line;
 
-            if (startLine < nextLine && hasEmptyLine(startLine, nextLine)) {
+            var openingComment = commentLines[startLine];
+            var openingCode = nextLine - startLine < 1;
+            var openingCommentOrCode = openingComment || openingCode;
+
+            if (!openingCommentOrCode) {
                 errors.add('Expected no padding newline after opening curly brace', openingBracket.loc.end);
             }
 
             var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
             var closingBracket = tokens[closingBracketPos];
             var prevToken = tokens[closingBracketPos - 1];
+
             var closingLine = closingBracket.loc.start.line;
             var prevLine = prevToken.loc.start.line + 1;
 
-            if (closingLine > prevLine && hasEmptyLine(prevLine, closingLine)) {
+            var closingComment = commentLines[closingLine - 1];
+            var closingCode = closingLine - prevLine < 1;
+            var closingCommentOrCode = closingComment || closingCode;
+
+            if (!closingCommentOrCode) {
                 errors.add('Expected no padding newline before closing curly brace', prevToken.loc.end);
             }
         });

--- a/test/rules/disallow-padding-newlines-in-blocks.js
+++ b/test/rules/disallow-padding-newlines-in-blocks.js
@@ -37,6 +37,21 @@ describe('rules/disallow-padding-newlines-in-blocks', function() {
         assert(checker.checkString('if (true) {\n/*\ncomment\n*/\nabc();\n}').isEmpty());
     });
     it('should not report empty function definitions', function() {
-        assert(checker.checkString('var a = function() {};').isEmpty());
+        assert(checker.checkString('var a = function() {\n};').isEmpty());
+    });
+    it('should report extra padding newline after opening brace', function() {
+        assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n}').getErrorCount() === 1);
+    });
+    it('should report extra padding newline before closing brace', function() {
+        assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n\n}').getErrorCount() === 1);
+    });
+    it('should report extra padding newlines in both cases', function() {
+        assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n\n}').getErrorCount() === 2);
+    });
+    it('should count comments as valid tokens', function() {
+        assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n}').isEmpty());
+    });
+    it('should not report errors with comments or code', function() {
+        assert(checker.checkString('if (true) {\n//comment\n\n\n/* comments */\n}').isEmpty());
     });
 });


### PR DESCRIPTION
- Fix #392
