### PR TITLE
Implement wikimedia preset

### DIFF
--- a/lib/options/preset.js
+++ b/lib/options/preset.js
@@ -1,6 +1,10 @@
 var presets = {
+    // https://contribute.jquery.org/style-guide/js/
     jquery: require('../../presets/jquery.json'),
-    google: require('../../presets/google.json')
+    // https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
+    google: require('../../presets/google.json'),
+    // https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
+    wikimedia: require('../../presets/wikimedia.json')
 };
 
 module.exports = function(config) {

--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -1,0 +1,80 @@
+{
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "return",
+        "try",
+        "catch",
+        "function"
+    ],
+    "requireSpaceBeforeBlockStatements": true,
+    "requireParenthesesAroundIIFE": true,
+    "requireSpacesInConditionalExpression": true,
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireMultipleVarDecl": "onevar",
+    "requireBlocksOnNewline": 1,
+    "disallowEmptyBlocks": true,
+    "requireSpacesInsideObjectBrackets": "all",
+    "requireSpacesInsideArrayBrackets": "all",
+    "disallowQuotedKeysInObjects": true,
+    "disallowDanglingUnderscores": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "requireCommaBeforeLineBreak": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
+    "disallowSpaceBeforeBinaryOperators": [
+        ","
+    ],
+    "requireSpaceBeforeBinaryOperators": [
+        "=",
+        "+=",
+        "-=",
+        "+",
+        "-",
+        "*",
+        "/",
+        "&&",
+        "||",
+        "===",
+        "==",
+        ">=",
+        "<=",
+        ">",
+        "<",
+        "!=",
+        "!=="
+    ],
+    "requireSpaceAfterBinaryOperators": true,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "disallowKeywords": [ "with" ],
+    "disallowMultipleLineBreaks": true,
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": "'",
+    "validateIndentation": "\t",
+    "disallowMixedSpacesAndTabs": true,
+    "disallowTrailingWhitespace": true,
+    "disallowTrailingComma": true,
+    "disallowKeywordsOnNewLine": [ "else" ],
+    "requireLineFeedAtFileEnd": true,
+    "requireCapitalizedConstructors": true,
+    "requireDotNotation": true,
+    "disallowYodaConditions": true
+}

--- a/test/options/preset.js
+++ b/test/options/preset.js
@@ -31,4 +31,19 @@ describe('options/preset', function() {
         assert(config.requireCurlyBraces === preset.requireCurlyBraces);
         assert(config.config !== preset);
     });
+
+    it('should set rules from the wikimedia preset', function() {
+        var checker = new Checker();
+        var preset = require('../../presets/wikimedia');
+
+        checker.registerDefaultRules();
+        checker.configure({
+            preset: 'wikimedia'
+        });
+
+        var config = checker.getProcessedConfig();
+
+        assert(config.requireSpaceAfterKeywords === preset.requireSpaceAfterKeywords);
+        assert(config.config !== preset);
+    });
 });


### PR DESCRIPTION
Per @markelog's request. This would be used by dozens of repositories very quickly. Both official repositories hosted on git.wikimedia.org that use Grunt, and by various repositories hosted on GitHub related to MediaWiki software that have adopted the same coding style.

A few examples:
- https://github.com/wikimedia/oojs/blob/master/.jscsrc
- https://github.com/wikimedia/oojs-ui/blob/master/.jscsrc
- https://github.com/wikimedia/VisualEditor/blob/master/.jscsrc
- https://github.com/wikimedia/mediawiki-core/blob/master/.jscsrc
- https://github.com/wikimedia/mediawiki-extensions-VisualEditor/blob/master/.jscsrc
- https://github.com/wikimedia/mediawiki-extensions-TemplateData/blob/master/.jscsrc
- https://github.com/wikimedia/mediawiki-services-cxserver/blob/master/.jscsrc

And interested in using them once landed as preset in jscs:
- https://github.com/wikimedia/jquery.i18n
- https://github.com/Krinkle/intuition
- https://github.com/Krinkle/mw-gadget-rtrc
