### PR TITLE
Ignoring ios instruments style imports.

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -214,7 +214,7 @@ StringChecker.prototype = {
     checkString: function(str, filename) {
         filename = filename || 'input';
         var tree;
-        str = str.replace(/^#![^\n]+\n/, '\n');
+        str = str.replace(/^#!?[^\n]+$/gm, '\n');
         try {
             tree = esprima.parse(str, {loc: true, range: true, comment: true, tokens: true});
         } catch (e) {

--- a/test/line-starting-with-hash.js
+++ b/test/line-starting-with-hash.js
@@ -1,0 +1,37 @@
+var Checker = require('../lib/checker');
+var assert = require('assert');
+
+describe.only('line srating with hash', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+    it('should ignore lines starting with #!', function() {
+        var errors = checker.checkString(
+            '#! random stuff\n' +
+            '#! 1234\n' +
+            'var a = 5;\n'
+        ).getErrorList();
+        assert(errors.length === 0);
+    });
+
+    it('should ignore ios instruments style import', function() {
+        var errors = checker.checkString(
+            '#import "abc.js"\n' +
+            '#import abc.js\n' +
+            'var a = 5;\n'
+        ).getErrorList();
+        assert(errors.length === 0);
+    });
+
+    it('should not replace when not beginning of line', function() {
+        var errors = checker.checkString(
+            '#import "abc.js"\n' +
+            'var b="#import abc.js";\n' +
+            'var a = 5;\n'
+        ).getErrorList();
+        assert(errors.length === 0);
+    });
+
+});


### PR DESCRIPTION
This lets jscs work with ios instruments style js.

See example file [here](https://github.com/appium/appium-uiauto/blob/master/uiauto/bootstrap.js), import are unstandard.
