### PR TITLE
wikimedia: Add 'case' and 'typeof' to requireSpaceAfterKeywords

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -15,10 +15,12 @@
         "while",
         "do",
         "switch",
+        "case",
         "return",
         "try",
         "catch",
-        "function"
+        "function",
+        "typeof"
     ],
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,


### PR DESCRIPTION
While it looks weird, code like the following is valid:

``` js
x = typeof'foo';
x = typeof/foo/;
x = typeof[x];
switch ( x ) {
    case'string':
        break;
}
```

More common with parentheses:

``` js
x = typeof(y);
switch ( duration ) {
    case( 3600 * 24 ):
        break;
}
```
