### PR TITLE
Fixed the checker not checking excluded patterns when calling checkPath on file

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -61,9 +61,13 @@ Checker.prototype.checkFile = function(path) {
 Checker.prototype._checkFile = function(path) {
     var _this = this;
 
-    return vowFs.read(path, 'utf8').then(function(data) {
-        return _this.checkString(data, path);
-    });
+    if (!_this._isExcluded(path)) {
+        return vowFs.read(path, 'utf8').then(function(data) {
+            return _this.checkString(data, path);
+        });
+    }
+
+    return null;
 };
 
 /**


### PR DESCRIPTION
This resolves an issue we are having with grunt-jscs-checker and specifying ignore patterns

/cc @nschonni @pjackson28
