### PR TITLE
disallowMultipleSpaces: add option to prevent multiple spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2472,6 +2472,55 @@ Values: `true`
 // A comment
 ```
 
+
+### disallowMultipleSpaces
+
+Disallows multiple spaces
+
+Type: `Boolean`
+
+Values: `true`
+
+#### Example
+
+```js
+"disallowMultipleSpaces": true
+```
+
+##### Valid
+
+```js
+var x = 'something';
+
+if (cond) {
+  foo();
+}
+
+for (var e in elements) {
+  bar(e);
+}
+
+while (cond) {
+  foo();
+}
+```
+
+##### Invalid
+
+```js
+if (cond)  {
+  foo();
+}
+
+for  (var e in elements){
+  bar(e);
+}
+
+while  (cond){
+  foo();
+}
+```
+
 ## Removed Rules
 
 ### ~~disallowLeftStickedOperators~~

--- a/lib/rules/disallow-multiple-spaces.js
+++ b/lib/rules/disallow-multiple-spaces.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(disallowMultipleSpaces) {
+        assert(
+            typeof disallowMultipleSpaces === 'boolean',
+            'disallowMultipleSpaces option requires boolean value'
+        );
+        assert(
+            disallowMultipleSpaces === true,
+            'disallowMultipleSpaces option requires true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowMultipleSpaces';
+    },
+
+    check: function(file, errors) {
+        var lines = file.getLines();
+
+        for (var i = 0, l = lines.length; i < l; i++) {
+            var trimedLine = lines[i].trim();
+            if (trimedLine.match(/\s{2,}(?=(?:(?:[^"]*"){2})*[^"]*$)(?=(?:(?:[^']*'){2})*[^']*$)/g)) {
+                errors.add('Multiple spaces', i + 1, lines[i].length);
+            }
+        }
+
+    }
+};

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -118,6 +118,8 @@ StringChecker.prototype = {
 
         this.registerRule(new (require('./rules/require-space-after-line-comment'))());
         this.registerRule(new (require('./rules/disallow-space-after-line-comment'))());
+
+        this.registerRule(new (require('./rules/disallow-multiple-spaces'))());
     },
 
     /**

--- a/test/rules/disallow-multiple-spaces.js
+++ b/test/rules/disallow-multiple-spaces.js
@@ -1,0 +1,47 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-multiple-spaces', function() {
+
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowMultipleSpaces: true });
+    });
+
+    it('should report illegal amount of spaces for vars', function() {
+        assert(checker.checkString('var  a = "something  i", b = "";').getErrorCount() === 1);
+    });
+
+    it('should report once for each line', function() {
+        assert(checker.checkString('var  x;\nvar  y;').getErrorCount() === 2);
+    });
+
+    it('should not report for strings with single quotes', function() {
+        var test = 'console.log(\'some  reporter double space\')';
+        assert(checker.checkString(test).isEmpty());
+    });
+
+    it('should not report for strings with double quotes', function() {
+        var test = 'console.log("some reporter double  spaces.");';
+        assert(checker.checkString(test).isEmpty());
+    });
+
+    it('should not report for strings with double quotes', function() {
+        var test = 'console.log("some reporter double  space\'s.");';
+        assert(checker.checkString(test).isEmpty());
+    });
+
+    it('should not report when there is no duplicate spaces', function() {
+        assert(checker.checkString('var x;').isEmpty());
+    });
+
+    it('should not report about spaces at the start of lines', function() {
+        var test = '  var someVarialbe = "something",\n' +
+                '    l = "another";\n' +
+                'function x () {return 1+1;};';
+
+        assert(checker.checkString(test).isEmpty());
+    });
+});


### PR DESCRIPTION
Prevent multiple spaces when not wrapped in quotes (single or double)
Example of errors:
- `var x  = 1;`
- `function  y(){}`

Closes: #435
