### PR TITLE
requireTrailingComma: Allow single property objects and single value arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -2080,9 +2080,13 @@ var bar = {a: "a", b: "b", }
 
 Requires an extra comma following the final element of an array or object literal.
 
-Type: `Boolean`
+Type: `Boolean` or `Object`
 
-Values: `true`
+Values:
+
+* `true`
+* Object:
+ * ignoreSingleValue: allow single property objects or single value arrays to not require a trailing comma
 
 #### Example
 
@@ -2095,6 +2099,12 @@ Values: `true`
 ```js
 var foo = [1, 2, 3,];
 var bar = {a: "a", b: "b",}
+```
+
+##### Valid with ignoreSingleValue
+```js
+var car = [1];
+var dar = {a: "a"};
 ```
 
 ##### Invalid

--- a/lib/rules/require-trailing-comma.js
+++ b/lib/rules/require-trailing-comma.js
@@ -5,14 +5,19 @@ module.exports = function() {};
 
 module.exports.prototype = {
     configure: function(requireTrailingComma) {
-        assert(
-            typeof requireTrailingComma === 'boolean',
-            'requireTrailingComma option requires boolean value'
-        );
-        assert(
-            requireTrailingComma === true,
-            'requireTrailingComma option requires true value or should be removed'
-        );
+        if (typeof requireTrailingComma === 'object') {
+            assert(
+                requireTrailingComma.ignoreSingleValue === true,
+                'requireTrailingComma option skipSingleValue requires true value or should be removed'
+            );
+
+            this._ignoreSingleValue = true;
+        } else {
+            assert(
+                requireTrailingComma === true,
+                'requireTrailingComma option requires true value or should be removed'
+            );
+        }
     },
 
     getOptionName: function() {
@@ -20,6 +25,8 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var _this = this;
+
         file.iterateNodesByType(['ObjectExpression', 'ArrayExpression'], function(node) {
             var isObject = node.type === 'ObjectExpression';
             var message = 'Missing comma before closing ' + (isObject ? ' curly brace' : ' bracket');
@@ -28,6 +35,10 @@ module.exports.prototype = {
             var hasTrailingComma;
 
             if (entities.length) {
+                if (_this._ignoreSingleValue && entities.length === 1) {
+                    return;
+                }
+
                 last = entities[entities.length - 1];
                 hasTrailingComma = tokenHelper.getTokenByRangeStartIfPunctuator(file, last.range[1], ',');
 

--- a/test/rules/require-trailing-comma.js
+++ b/test/rules/require-trailing-comma.js
@@ -7,38 +7,73 @@ describe('rules/require-trailing-comma', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requireTrailingComma: true });
     });
 
-    it('should allow object or array initialization without comma', function() {
-        assert(checker.checkString('var x = {}').getErrorCount() === 0);
-        assert(checker.checkString('var x = { }').getErrorCount() === 0);
-        assert(checker.checkString('var x = []').getErrorCount() === 0);
-        assert(checker.checkString('var x = [ ]').getErrorCount() === 0);
+    describe('option value true', function () {
+        beforeEach(function () {
+            checker.configure({ requireTrailingComma: true });
+        });
+
+        it('should allow object or array initialization without comma', function() {
+            assert(checker.checkString('var x = {}').getErrorCount() === 0);
+            assert(checker.checkString('var x = { }').getErrorCount() === 0);
+            assert(checker.checkString('var x = []').getErrorCount() === 0);
+            assert(checker.checkString('var x = [ ]').getErrorCount() === 0);
+        });
+
+        it('should report trailing comma required in object literal', function() {
+            assert(checker.checkString('var x = {a: "a", b: "b",}').getErrorCount() === 0);
+            assert(checker.checkString('var x = {a: "a", b: "b",\n}').getErrorCount() === 0);
+            assert(checker.checkString('var x = {a: "a", b: "b"}').getErrorCount() === 1);
+            assert(checker.checkString('var x = {a: "a", b: "b"\n}').getErrorCount() === 1);
+            assert(checker.checkString('function foo() {\nreturn {a: "a"};\n}').getErrorCount() === 1);
+        });
+
+        it('should report trailing comma required in array', function() {
+            assert(checker.checkString('var x = [1, 2,]').getErrorCount() === 0);
+            assert(checker.checkString('var x = [1, 2,\n]').getErrorCount() === 0);
+            assert(checker.checkString('var x = [1, 2]').getErrorCount() === 1);
+            assert(checker.checkString('var x = [1, 2\n]').getErrorCount() === 1);
+            assert(checker.checkString('function foo() {\nreturn [1, 2];\n}').getErrorCount() === 1);
+        });
+
+        it('should not report block scopes (#368)', function() {
+            assert(checker.checkString('if(true) {\nconsole.log(\'Hello World\');\n}').getErrorCount() === 0);
+            assert(checker.checkString('function add(a, b) {\nreturn a + b;\n}').getErrorCount() === 0);
+        });
+
+        it('should not report array access (#368)', function () {
+            assert(checker.checkString('var foo = [\'Hello World\',\n];\nvar bar = foo[0];').getErrorCount() === 0);
+        });
     });
 
-    it('should report trailing comma required in object literal', function() {
-        assert(checker.checkString('var x = {a: "a", b: "b",}').getErrorCount() === 0);
-        assert(checker.checkString('var x = {a: "a", b: "b",\n}').getErrorCount() === 0);
-        assert(checker.checkString('var x = {a: "a", b: "b"}').getErrorCount() === 1);
-        assert(checker.checkString('var x = {a: "a", b: "b"\n}').getErrorCount() === 1);
-        assert(checker.checkString('function foo() {\nreturn {a: "a"};\n}').getErrorCount() === 1);
-    });
+    describe('ignoreSingleValue', function () {
+        beforeEach(function () {
+            checker.configure({
+                requireTrailingComma: {
+                    ignoreSingleValue: true
+                }
+            });
+        });
 
-    it('should report trailing comma required in array', function() {
-        assert(checker.checkString('var x = [1, 2,]').getErrorCount() === 0);
-        assert(checker.checkString('var x = [1, 2,\n]').getErrorCount() === 0);
-        assert(checker.checkString('var x = [1, 2]').getErrorCount() === 1);
-        assert(checker.checkString('var x = [1, 2\n]').getErrorCount() === 1);
-        assert(checker.checkString('function foo() {\nreturn [1, 2];\n}').getErrorCount() === 1);
-    });
+        it('should allow object or array with single property', function () {
+            assert(checker.checkString('var x = [1]').getErrorCount() === 0);
+            assert(checker.checkString('var x = {a: "a"}').getErrorCount() === 0);
+        });
 
-    it('should not report block scopes (#368)', function() {
-        assert(checker.checkString('if(true) {\nconsole.log(\'Hello World\');\n}').getErrorCount() === 0);
-        assert(checker.checkString('function add(a, b) {\nreturn a + b;\n}').getErrorCount() === 0);
-    });
+        it('should report trailing comma required for two or more elements in an array', function () {
+            assert(checker.checkString('var x = [1, 2]').getErrorCount() === 1);
+            assert(checker.checkString('var x = [1, 2, 3]').getErrorCount() === 1);
+        });
 
-    it('should not report array access (#368)', function () {
-        assert(checker.checkString('var foo = [\'Hello World\',\n];\nvar bar = foo[0];').getErrorCount() === 0);
+        it('should report trailing comma required for two or more properties in an object', function () {
+            assert(checker.checkString('var x = {a: "a", b: "b"}').getErrorCount() === 1);
+            assert(checker.checkString('var x = {a: "a", b: "b", c: "c"}').getErrorCount() === 1);
+        });
+
+        it('should not report empty array or object', function () {
+            assert(checker.checkString('var x = []').getErrorCount() === 0);
+            assert(checker.checkString('var x = {}').getErrorCount() === 0);
+        });
     });
 });


### PR DESCRIPTION
Allow single property objects and single value arrays to not require trailing comma if `ignoreSingleValue` property is set. Fixes #369
