### PR TITLE
disallowAnonymousFunctions: Function Expressions should be named.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2585,6 +2585,44 @@ $('#foo').click(function(){
 };)
 ```
 
+### requireAnonymousFunctions
+
+Requires that a function expression be anonymous.
+
+Type: `Boolean`
+
+Values: `true`
+
+#### Example
+
+```js
+"requireAnonymousFunctions": true
+```
+
+##### Valid
+
+```js
+var a = function(){
+
+};
+
+$('#foo').click(function(){
+
+};)
+```
+
+##### Invalid
+
+```js
+var a = function foo(){
+
+};
+
+$('#foo').click(function bar(){
+
+};)
+```
+
 ## Removed Rules
 
 ### ~~disallowLeftStickedOperators~~

--- a/lib/rules/disallow-anonymous-functions.js
+++ b/lib/rules/disallow-anonymous-functions.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 
 module.exports = function() {};
 
@@ -16,7 +15,7 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateNodesByType(['FunctionExpression'], function(node) {
+        file.iterateNodesByType(['FunctionExpression', 'FunctionDeclaration'], function(node) {
             if (node.id === null) {
                 errors.add('Anonymous functions needs to be named', node.loc.start);
             }

--- a/lib/rules/require-anonymous-functions.js
+++ b/lib/rules/require-anonymous-functions.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(requireAnonymousFunctions) {
+        assert(
+            requireAnonymousFunctions === true,
+            'requireAnonymousFunctions option requires true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireAnonymousFunctions';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType(['FunctionExpression', 'FunctionDeclaration'], function(node) {
+            if (node.id !== null) {
+                errors.add('Functions must not be named', node.loc.start);
+            }
+        });
+    }
+};

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -123,6 +123,7 @@ StringChecker.prototype = {
         this.registerRule(new (require('./rules/require-space-after-line-comment'))());
         this.registerRule(new (require('./rules/disallow-space-after-line-comment'))());
 
+        this.registerRule(new (require('./rules/require-anonymous-functions'))());
         this.registerRule(new (require('./rules/disallow-anonymous-functions'))());
     },
 

--- a/test/rules/disallow-anonymous-funtions.js
+++ b/test/rules/disallow-anonymous-funtions.js
@@ -1,7 +1,7 @@
 var Checker = require('../../lib/checker');
 var assert = require('assert');
 
-describe.only('rules/disallow-anonymous-function', function() {
+describe('rules/disallow-anonymous-function', function() {
     var checker;
 
     beforeEach(function() {
@@ -23,11 +23,11 @@ describe.only('rules/disallow-anonymous-function', function() {
     });
 
     it('should not report on named function declarations', function () {
-        assert(checker.checkString('$("hi").click(function named(){});').isEmpty());
         assert(checker.checkString('function named(){};').isEmpty());
     });
 
     it('should not report on named function expressions', function () {
+        assert(checker.checkString('$("hi").click(function named(){});').isEmpty());
         assert(checker.checkString('var x = function named(){};').isEmpty());
     });
 });

--- a/test/rules/require-anonymous-functions.js
+++ b/test/rules/require-anonymous-functions.js
@@ -1,0 +1,33 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-anonymous-function', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+
+        checker.configure({
+            requireAnonymousFunctions: true
+        });
+    });
+
+    it('should not report on anonymous function declarations', function () {
+        assert(checker.checkString('$("hi").click(function(){});').isEmpty());
+    });
+
+    it('should not report on anonymous function expressions', function () {
+        assert(checker.checkString('var x = function(){};').isEmpty());
+        assert(checker.checkString('var foo = {bar: function() {}};').isEmpty());
+    });
+
+    it('should report on named function declarations', function () {
+        assert(checker.checkString('function named(){}').getErrorCount() === 1);
+    });
+
+    it('should report on named function expressions', function () {
+        assert(checker.checkString('$("hi").click(function named(){});').getErrorCount() === 1);
+        assert(checker.checkString('var x = function named(){};').getErrorCount() === 1);
+    });
+});


### PR DESCRIPTION
Fixes #508
