### PR TITLE
JsFile: Allows for file-wide jscs configuration

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -12,6 +12,11 @@
 
     "excludeFiles": [
       "test/data/**",
+      // Excluded because it contains sample jscs file configurations
+      // that would get picked up during the processing of this file
+      // and used to then throw errors since the file doesn't conform
+      // to the sample file configuration
+      "test/string-checker.js",
       // this file tests that snake cased configs are detected
       // which violates the camelcase identifier rule
       // TODO: remove when inline error exclusions exist

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -46,6 +46,16 @@ var JsFile = function(filename, source, tree) {
             }
         }
     }
+
+    // Get file-wide configuration (#487)
+    this.getComments().forEach(function(comment) {
+        if (comment.value.trim().indexOf('jscs: ') === 0) {
+            comment.value = comment.value.replace(/jscs:\s/, '').trim();
+            if (comment.value && !this._config) {
+                this._config = JSON.parse(comment.value);
+            }
+        }
+    }, this);
 };
 
 JsFile.prototype = {
@@ -157,9 +167,11 @@ JsFile.prototype = {
     },
     /**
      * Returns comment token list, built using esprima.
+     *
+     * @returns {Object[]}
      */
     getComments: function() {
-        return this._tree.comments;
+        return this._tree.comments || [];
     },
     /**
      * Returns source filename for this object representation.
@@ -176,7 +188,14 @@ JsFile.prototype = {
      */
     getLines: function() {
         return this._lines;
-    }
+    },
+    /**
+     * Returns the configuration supplied at the top of the file
+     * @return {Object|null}
+     */
+    getConfiguration: function () {
+        return this._config || null;
+    },
 };
 
 module.exports = JsFile;

--- a/lib/rules/require-trailing-comma.js
+++ b/lib/rules/require-trailing-comma.js
@@ -10,14 +10,17 @@ module.exports.prototype = {
                 requireTrailingComma.ignoreSingleValue === true,
                 'requireTrailingComma option ignoreSingleValue requires true value or should be removed'
             );
-
-            this._ignoreSingleValue = true;
         } else {
             assert(
                 requireTrailingComma === true,
                 'requireTrailingComma option requires true value or should be removed'
             );
+
         }
+
+        // If it's an object, then requireTrailingComma.ignoreSingleValue must be true
+        // If it's a boolean, then it's not an object, setting _ignoreSingleValue to false
+        this._ignoreSingleValue = typeof requireTrailingComma === 'object';
     },
 
     getOptionName: function() {

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -146,6 +146,12 @@ StringChecker.prototype = {
 
         preset.extend(config);
 
+        // Reset the active ruleset before and after using a file configuration
+        // to avoid previous rules leaking into the processing of the current file
+        if (this._savedConfig) {
+            this._activeRules = [];
+        }
+
         var configRules = Object.keys(config);
         var activeRules = this._activeRules;
 
@@ -154,15 +160,19 @@ StringChecker.prototype = {
             var ruleOptionName = rule.getOptionName();
 
             if (config.hasOwnProperty(ruleOptionName)) {
-
                 // Do not configure the rule if it's equals to null (#203)
                 if (config[ruleOptionName] !== null) {
                     rule.configure(config[ruleOptionName]);
                 }
-                activeRules.push(rule);
+
+                // Prevent duplicate references with multiple calls to configure
+                if (activeRules.indexOf(rule) === -1) {
+                    activeRules.push(rule);
+                }
                 configRules.splice(configRules.indexOf(ruleOptionName), 1);
             }
         });
+
         if (configRules.length > 0) {
             throw new Error('Unsupported rules: ' + configRules.join(', '));
         }
@@ -225,6 +235,13 @@ StringChecker.prototype = {
             throw new Error('Syntax error at ' + filename + ': ' + e.message);
         }
         var file = new JsFile(filename, str, tree);
+        var fileConfig = file.getConfiguration();
+
+        if (fileConfig) {
+            this._savedConfig = this.getProcessedConfig();
+            this.configure(fileConfig);
+        }
+
         var errors = new Errors(file, this._verbose);
         this._activeRules.forEach(function(rule) {
 
@@ -240,6 +257,11 @@ StringChecker.prototype = {
         errors.getErrorList().sort(function(a, b) {
             return (a.line - b.line) || (a.column - b.column);
         });
+
+        if (this._savedConfig) {
+            this.configure(this._savedConfig);
+            this._savedConfig = null;
+        }
 
         return errors;
     }

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -2,7 +2,7 @@ var Checker = require('../lib/checker');
 var assert = require('assert');
 
 describe('modules/string-checker', function() {
-    describe('line srating with hash, temporary, until we will have inline rules', function() {
+    describe('line starting with hash, temporary, until we will have inline rules', function() {
         var checker;
         beforeEach(function() {
             checker = new Checker();
@@ -61,6 +61,112 @@ describe('modules/string-checker', function() {
         } catch (e) {
             assert(e.toString() === 'Error: Preset "not-exist" does not exist');
         }
+    });
+
+    describe('per-file configuration (#487)', function() {
+        var checker;
+        var defaultConfig = {
+            requireTrailingComma: true
+        };
+
+        function testSuccess() {
+            /* jscs: {"requireTrailingComma": { "ignoreSingleValue": true }} */
+            var y = [1];
+            function foo () {}
+        }
+
+        function testSuccess2() {
+            /* jscs: {"requireSpacesInAnonymousFunctionExpression": { "beforeOpeningRoundBrace": true }} */
+            var y = [1, 2];
+            y.forEach(function () {});
+        }
+
+        function testSuccess3() {
+            /* jscs: {"requireTrailingComma": { "ignoreSingleValue": true }} */
+            /* jscs: {"requireTrailingComma": true } */
+            var y = [1];
+            function foo () {}
+        }
+
+        function testFail() {
+            var x = [1];
+            function foo () {}
+        }
+
+        function testBlank() {
+            /* jscs: */
+            console.log('foo');
+        }
+
+        beforeEach(function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure(defaultConfig);
+        });
+
+        it('should use configuration at the top of the file, if supplied', function () {
+            assert(checker.checkString(testSuccess.toString()).isEmpty());
+        });
+
+        it('should only affect the file containing the configuration', function() {
+            var errorsSuccess = checker.checkString(testSuccess.toString());
+            var errorsFail = checker.checkString(testFail.toString());
+
+            assert(errorsSuccess.isEmpty());
+            assert(errorsFail.getErrorCount() === 1);
+        });
+
+        it('should not fail if the config has no set properties', function() {
+            assert(checker.checkString(testBlank.toString()).isEmpty());
+        });
+
+        it('should not use any other rules but the ones supplied in the config', function() {
+            var checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                requireTrailingComma: true,
+                disallowSpacesInFunctionExpression: {
+                    beforeOpeningRoundBrace: true,
+                    beforeOpeningCurlyBrace: true
+                }
+            });
+            // The config doesn't mention disallowSpacesInFunctionExpression, so it should pass
+            // though clearly violating that rule
+            assert(checker.checkString(testSuccess.toString()).isEmpty());
+
+            // The config is now reset, so fail should violate the spaces rule
+            assert(checker.checkString(testFail.toString()).getErrorCount() === 1);
+        });
+
+        it('should not fail for multiple files having a configuration', function() {
+            var errorsSuccess = checker.checkString(testSuccess.toString());
+            var errorsSuccess2 = checker.checkString(testSuccess2.toString());
+            var errorsSuccess3 = checker.checkString(testSuccess3.toString());
+            assert(errorsSuccess.isEmpty());
+            assert(errorsSuccess2.isEmpty());
+            assert(errorsSuccess3.isEmpty());
+        });
+
+        it('should restore the configuration after processing each file that has a config', function() {
+            function testConfigs() {
+                var config = checker.getProcessedConfig();
+                assert(Object.keys(config).length === Object.keys(defaultConfig).length);
+
+                Object.keys(config).forEach(function(param) {
+                  assert(config[param] === defaultConfig[param]);
+                });
+            }
+
+            var errorsSuccess = checker.checkString(testSuccess.toString());
+            testConfigs();
+            var errorsSuccess2 = checker.checkString(testSuccess2.toString());
+            testConfigs();
+        });
+
+        it('should only use the first configuration in a file', function() {
+            var errorsSuccess = checker.checkString(testSuccess.toString());
+            assert(errorsSuccess.isEmpty());
+        });
     });
 
     describe('rules registration', function() {


### PR DESCRIPTION
Fixes #487
- [ ] File config should only be the first line in the file. Currently it chooses the first seen, which will conflict with #486 
