### PR TITLE
Config: Look in user-profile folder first

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -94,13 +94,19 @@ exports.load = function(config, cwd) {
         return content;
     }
 
-    // Try to load standart configs from home dir
-    directory = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-    for (var i = 0, len = configs.length; i < len; i++) {
-        content = this.getContent(configs[i], directory);
+    // Try to load standard configs from home dir
+    var directoryArr = [process.env.USERPROFILE, process.env.HOMEPATH, process.env.HOME];
+    for (var i = 0, dirLen = directoryArr.length; i < dirLen; i++) {
+        if (!directoryArr[i]) {
+            continue;
+        }
 
-        if (content) {
-            return content;
+        for (var j = 0, len = configs.length; j < len; j++) {
+            content = this.getContent(configs[j], directoryArr[i]);
+
+            if (content) {
+                return content;
+            }
         }
     }
 };

--- a/test/cli-config.js
+++ b/test/cli-config.js
@@ -77,11 +77,42 @@ describe('modules/cli-config', function() {
         assert.strictEqual(config.from, '.jscsrc');
     });
 
-    it('should load config from home path', function() {
+    it('should load config from home path: HOME', function() {
         var oldHome = process.env.HOME;
+        var oldHOMEPATH = process.env.HOMEPATH;
+        var oldUSERPROFILE = process.env.USERPROFILE;
 
+        process.env.HOMEPATH = process.env.USERPROFILE = null;
         process.env.HOME = './test/data/configs/jscsrc';
         assert.equal(configFile.load(null, '/').from, 'jscsrc');
         process.env.HOME = oldHome;
+        process.env.HOMEPATH = oldHOMEPATH;
+        process.env.USERPROFILE = oldUSERPROFILE;
+    });
+
+    it('should load a config from the available home path: HOMEPATH', function () {
+        var oldHome = process.env.HOME;
+        var oldHOMEPATH = process.env.HOMEPATH;
+        var oldUSERPROFILE = process.env.USERPROFILE;
+
+        process.env.HOME = process.env.USERPROFILE = null;
+        process.env.HOMEPATH = './test/data/configs/jscsrc';
+        assert.equal(configFile.load(null, '/').from, 'jscsrc');
+        process.env.HOME = oldHome;
+        process.env.HOMEPATH = oldHOMEPATH;
+        process.env.USERPROFILE = oldUSERPROFILE;
+    });
+
+    it('should load a config from the available home path: USERPROFILE', function () {
+        var oldHome = process.env.HOME;
+        var oldHOMEPATH = process.env.HOMEPATH;
+        var oldUSERPROFILE = process.env.USERPROFILE;
+
+        process.env.HOME = process.env.HOMEPATH = null;
+        process.env.USERPROFILE = './test/data/configs/jscsrc';
+        assert.equal(configFile.load(null, '/').from, 'jscsrc');
+        process.env.HOME = oldHome;
+        process.env.HOMEPATH = oldHOMEPATH;
+        process.env.USERPROFILE = oldUSERPROFILE;
     });
 });


### PR DESCRIPTION
On new Windows versions, the user home is resolved with `process.env.USERPROFILE` and `process.env.HOME` is set to the (default) user's home, which may be different than that of the current user.

This commit changes the sequence, to locate the `.jscsrc` file.

_(related: madskristensen/WebEssentials2013#1310)_
