### PR TITLE
Add missing constraints to Google preset

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -49,6 +49,11 @@
     "requireSpacesInFunctionExpression": {
         "beforeOpeningCurlyBrace": true
     },
+    "disallowSpacesInsideObjectBrackets": "all",
+    "disallowSpacesInsideArrayBrackets": "all",
+    "disallowSpacesInsideParentheses": true,
+
+
     "validateJSDoc": {
         "checkParamNames": true,
         "requireParamTypes": true

--- a/publish/helpers/readme.js
+++ b/publish/helpers/readme.js
@@ -18,7 +18,7 @@ module.exports = {
             console.error('There is no string to remove from README.md');
             process.exit(1);
         }
-        readme.publish = readme.original.replace( replaceString, '' );
+        readme.publish = readme.original.replace(replaceString, '');
 
         fs.writeFileSync(tmpPath, readme.original);
         fs.writeFileSync(readmePath, readme.publish);

--- a/test/data/options/preset/google.js
+++ b/test/data/options/preset/google.js
@@ -38,3 +38,10 @@ function rootCheck() {
     } catch (err) {}
   }
 }
+
+// disallowSpacesInsideArrayBrackets
+var arr = [1, 2, 3];
+// disallowSpacesInsideObjectBrackets
+var obj = {a: 1, b: 2, c: 3};
+// disallowSpacesInsideParentheses
+console.log('string');


### PR DESCRIPTION
[Google's style guide section on Code Formatting](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml?showone=Code_formatting#Code_formatting) specifies:

```
var arr = [1, 2, 3];  // No space after [ or before ].
var obj = {a: 1, b: 2, c: 3};  // No space after { or before }.
```

The section on function arguments doesn't say so explicitly, but none of the code shown allows spaces before ')' or after '(' (except multiline, which disallowSpacesInsideParentheses also allows). Moreover it would be consistent with the {} and [] explicit spacing rules.
