### PR TITLE
Fixing disallowMultipleLineBreaks when file starts with #!

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -218,7 +218,7 @@ StringChecker.prototype = {
     checkString: function(str, filename) {
         filename = filename || 'input';
         var tree;
-        str = str.replace(/^#!?[^\n]+$/gm, '\n');
+        str = str.replace(/^#!?[^\n]+\n/gm, '\n');
         try {
             tree = esprima.parse(str, {loc: true, range: true, comment: true, tokens: true});
         } catch (e) {

--- a/test/rules/disallow-multiple-line-breaks.js
+++ b/test/rules/disallow-multiple-line-breaks.js
@@ -15,6 +15,10 @@ describe('rules/disallow-multiple-line-breaks', function() {
         checker.configure({ disallowMultipleLineBreaks: true });
         assert(checker.checkString('x = 1;\n\ny = 2').isEmpty());
     });
+    it('should not report single line break when first line starts with #!', function() {
+        checker.configure({ disallowMultipleLineBreaks: true });
+        assert(checker.checkString('#!/usr/bin/env node\nx = 1;').isEmpty());
+    });
     it('should report only once per each sequence of line breaks', function() {
         checker.configure({ disallowMultipleLineBreaks: true });
         assert(checker.checkString('x = 1;\n\n\n\n\ny = 2').getErrorCount() === 1);


### PR DESCRIPTION
Version 1.5.3 introduced a change that breaks disallowMultipleLineBreaks in files that have a line like:

```
#! /usr/bin/env node
```

There are already tests for string-checker.js for this here: https://github.com/mdevils/node-jscs/blob/master/test/string-checker.js#L12

... but those tests apparently don't cover the issue I'm seeing.  I'm a bit worried my regex change will break something else, but all the tests still pass.

I've also verified that this change works in my real code projects.
