### PR TITLE
Remove repeated rule in yandex preset.

### DIFF
--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -14,7 +14,6 @@
         "do",
         "switch",
         "return",
-        "function",
         "catch"
     ],
     "disallowKeywords": [


### PR DESCRIPTION
These two rules:
- `requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true }` 
- `requireSpaceAfterKeywords: [ 'function' ]`

always triggers on same places and combined produce duplicate error reports.
Please, consider removing it from Yandex preset.
