### PR TITLE
fixes appending of absolute config path to absolute directory path if config path is inside of quotes

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -45,6 +45,8 @@ exports.getContent = function(config, directory) {
         return;
     }
 
+    config = config.replace(/^("|')/, '').replace(/("|')$/, '');
+
     var configPath = path.resolve(directory, config);
     var content;
 


### PR DESCRIPTION
In some cases the config path has quotations (see https://github.com/AtomLinter/linter-jscs/issues/15 here), `path.resolve` returns a path something like this:
/path/to/my/cwd/"/path/to/my/.jscsrc  
