### PR TITLE
js-file.js: setting default tree to empty object

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -8,7 +8,7 @@ var treeIterator = require('./tree-iterator');
 var JsFile = function(filename, source, tree) {
     this._filename = filename;
     this._source = source;
-    this._tree = tree;
+    this._tree = tree || {};
     this._lines = source.split(/\r\n|\r|\n/);
     this._tokenIndex = null;
     var index = this._index = {};


### PR DESCRIPTION
This allows an empty tree to be passed into the JsFile constructor from string-checker.js.  Otherwise, if there's a parse error and tree is undefined, this throws an error in js-file.js:

```
   return this._tree.comments;
```

This fixes the travis-ci build failure.
