### PR TITLE
Allow custom esprima version.

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima');
+var defaultEsprima = require('esprima');
 var Errors = require('./errors');
 var JsFile = require('./js-file');
 var preset = require('./options/preset');
@@ -9,11 +9,12 @@ var preset = require('./options/preset');
  * @name StringChecker
  * @param {Boolean} verbose
  */
-var StringChecker = function(verbose) {
+var StringChecker = function(verbose, esprima) {
     this._rules = [];
     this._activeRules = [];
     this._config = {};
     this._verbose = verbose || false;
+    this._esprima = esprima || defaultEsprima;
 };
 
 StringChecker.prototype = {
@@ -228,7 +229,7 @@ StringChecker.prototype = {
         var parseError;
 
         try {
-            tree = esprima.parse(str, {loc: true, range: true, comment: true, tokens: true});
+            tree = this._esprima.parse(str, {loc: true, range: true, comment: true, tokens: true});
         } catch (e) {
             parseError = e;
         }

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -104,4 +104,37 @@ describe('modules/string-checker', function() {
             assert(error === undefined);
         });
     });
+
+    describe('custom esprima version', function() {
+      var description = 'parsing error thrown by custom esprima';
+      var customEsprima = {
+        parse: function() {
+          var error = new Error();
+          error.description = description;
+
+          throw error;
+        }
+      };
+
+      it('uses the esprima provided to constructor for parsing', function() {
+        checker = new Checker(false, customEsprima);
+        checker.registerDefaultRules();
+
+        var errors = checker.checkString('import { foo } from "bar";');
+        var error = errors.getErrorList()[0];
+
+        assert(error.rule === 'parseError');
+        assert(error.message === description);
+      });
+
+      it('uses the _esprima property for parsing', function() {
+        checker._esprima = customEsprima;
+
+        var errors = checker.checkString('import { foo } from "bar";');
+        var error = errors.getErrorList()[0];
+
+        assert(error.rule === 'parseError');
+        assert(error.message === description);
+      });
+    });
 });


### PR DESCRIPTION
This allows usage of `harmony` branch of Esprima to provide ES6 support.

I realize that this likely shouldn't be a user-facing feature so I have not updated the bin script or CLI, but this allows usage of JSCS for projects that are already using ES6 module syntax.

For reference this simple script is what I have been testing with (in Ember source):

``` javascript
var esprima = require('esprima');
var configFile = require('jscs/lib/cli-config');
var Checker = require('jscs/lib/checker');
var reporter = require('jscs/lib/reporters/console');

var checker = new Checker(false, esprima);
var config = configFile.load();

checker.registerDefaultRules();
checker.configure(config);

checker.checkPath('packages/ember-metal')
  .then(function(results) {
    var errorsCollection = [].concat.apply([], results);

    reporter(errorsCollection);
  });
```

In this case the version of Esprima is used from the including repo (instead of the stable version that is included with node-jscs).
