### PR TITLE
requireSpacesInsideParentheses: "allButSolitaryPunctuators"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,9 @@ Requires space after opening round bracket and before closing.
 
 Type: `String`
 
-Values: `"all"` for strict mode, `"allButNested"` ignores nested brackets in a row.
+Values: `"all"` for strict mode, `"allButNested"` ignores nested brackets in a
+row, `"allButSolitaryPunctuators"` ignores a list of punctuators followed by a
+newline, or a list of puncutuators on their own line.
 
 #### Example
 
@@ -1266,6 +1268,28 @@ var x = Math.pow(( 1 + 2 ), ( 3 + 4 ));
 
 ```js
 var x = Math.pow(1 + 2, 3 + 4);
+```
+
+##### Valid for mode `"allButSolitaryPunctuators"`
+
+```js
+foo( function() {
+    return 'bar';
+});
+```
+
+##### Invalid
+
+```js
+foo( function() {
+    return 'bar';
+} )
+```
+
+```js
+foo(function() {
+    return 'bar';
+});
 ```
 
 

--- a/lib/rules/require-spaces-inside-parentheses.js
+++ b/lib/rules/require-spaces-inside-parentheses.js
@@ -7,7 +7,8 @@ module.exports.prototype = {
     configure: function(mode) {
         var modes = {
             'all': true,
-            'allButNested': true
+            'allButNested': true,
+            'allButSolitaryPunctuators': true
         };
         assert(
             typeof mode === 'string' &&
@@ -32,8 +33,13 @@ module.exports.prototype = {
 
         // Iterate punctuators since '(', ')' can exist in multiple contexts.
         file.iterateTokensByType('Punctuator', function(token, index, tokens) {
+            var foundNonPunctuator;
+            var currentToken;
+            var lastToken;
+            var i;
             if (token.value === '(') {
                 var nextToken = tokens[index + 1];
+                var nextTokens = tokens.slice(index + 1);
 
                 // Skip the cases where we allow no space even if spaces are required.
                 if (nextToken.type === 'Punctuator' && nextToken.value === ')') {
@@ -45,6 +51,28 @@ module.exports.prototype = {
                     return;
                 }
 
+                if (mode === 'allButSolitaryPunctuators') {
+                    // allows for no space between punctuators on their own
+                    // line e.g. function({
+                    lastToken = null;
+                    foundNonPunctuator = false;
+                    var len = nextTokens.length;
+                    for (i = 0; i < len; i++) {
+                        currentToken = nextTokens[i];
+                        if (nextTokens[i - 1]) { lastToken = nextTokens[i - 1]; }
+                        if (currentToken.loc.start.line !== token.loc.start.line ||
+                           (lastToken && currentToken.loc.start.line !== lastToken.loc.start.line)) {
+                            break;
+                        }
+                        if (currentToken.type !== 'Punctuator') {
+                            foundNonPunctuator = true;
+                        }
+                    }
+                    if (!foundNonPunctuator) {
+                        return;
+                    }
+                }
+
                 if ((token.range[1] === nextToken.range[0] &&
                         token.loc.end.line === nextToken.loc.start.line) ||
                         isComment(token.range[1])) {
@@ -54,6 +82,7 @@ module.exports.prototype = {
 
             if (token.value === ')') {
                 var prevToken = tokens[index - 1];
+                var prevTokens = tokens.slice(0, index);
 
                 // Skip the cases where we allow no space even if spaces are required.
                 if (prevToken.type === 'Punctuator' && prevToken.value === '(') {
@@ -63,6 +92,27 @@ module.exports.prototype = {
                 if (mode === 'allButNested' && prevToken.type === 'Punctuator' &&
                     prevToken.value === ')') {
                     return;
+                }
+
+                if (mode === 'allButSolitaryPunctuators') {
+                    // allows for no space between punctuators on their own
+                    // line e.g. })
+                    lastToken = null;
+                    foundNonPunctuator = false;
+                    for (i = prevTokens.length - 1; i >= 0; i--) {
+                        currentToken = prevTokens[i];
+                        if (prevTokens[i + 1]) { lastToken = prevTokens[i + 1]; }
+                        if (currentToken.loc.start.line !== token.loc.start.line ||
+                            (lastToken && currentToken.loc.start.line !== lastToken.loc.start.line)) {
+                            break;
+                        }
+                        if (currentToken.type !== 'Punctuator') {
+                            foundNonPunctuator = true;
+                        }
+                    }
+                    if (!foundNonPunctuator) {
+                        return;
+                    }
                 }
 
                 if ((token.range[0] === prevToken.range[1] &&

--- a/test/rules/require-spaces-inside-parentheses.js
+++ b/test/rules/require-spaces-inside-parentheses.js
@@ -79,4 +79,56 @@ describe('rules/require-spaces-inside-parentheses', function() {
         });
     });
 
+    describe('allButSolitaryPunctuators', function() {
+        beforeEach(function() {
+            checker.configure({ requireSpacesInsideParentheses: 'allButSolitaryPunctuators' });
+        });
+
+        it('should allow no space between solitary punctuators', function() {
+            assert(checker.checkString('foo( function() {\n  return;\n});').isEmpty());
+            assert(checker.checkString('foo({\n  foo: "bar"\n}, "bar" );').isEmpty());
+            assert(checker.checkString('foo({\n  foo: "bar",\n  bar: "baz"\n});').isEmpty());
+        });
+
+        it('should require spaces between nonpunctuators and parentheses', function() {
+            assert(checker.checkString('foo( function() {\n  return;\n}, "bar");').getErrorCount() === 1);
+            assert(checker.checkString('foo(function() {\n  return;\n}, "bar" );').getErrorCount() === 1);
+            assert(checker.checkString('foo(function() {\n  return;\n}, "bar");').getErrorCount() === 2);
+        });
+
+        it('should require between simple arguments', function() {
+            assert(checker.checkString('foo(a,b);').getErrorCount() === 2);
+            assert(checker.checkString('foo( a,b);').getErrorCount() === 1);
+            assert(checker.checkString('foo( a,b );').isEmpty());
+        });
+
+        it('should not require spaces for empty arguments list', function() {
+            assert(checker.checkString('foo();').isEmpty());
+        });
+
+        it('should require spaces for grouping parentheses', function() {
+            assert(checker.checkString('var test = (true ? true : false)').getErrorCount() === 2);
+            assert(checker.checkString('var test = ( true ? true : false)').getErrorCount() === 1);
+            assert(checker.checkString('var test = ( true ? true : false )').isEmpty());
+        });
+
+        it('should require spaces for "for" keyword', function() {
+            assert(checker.checkString('for (var i = 0; i < 100; i++) {}').getErrorCount() === 2);
+            assert(checker.checkString('for ( var i = 0; i < 100; i++) {}').getErrorCount() === 1);
+            assert(checker.checkString('for ( var i = 0; i < 100; i++ ) {}').isEmpty());
+        });
+
+        it('should require spaces for "while" keyword', function() {
+            assert(checker.checkString('while (!condition) {}').getErrorCount() === 2);
+            assert(checker.checkString('while ( !condition) {}').getErrorCount() === 1);
+            assert(checker.checkString('while ( !condition ) {}').isEmpty());
+        });
+
+        it('should require spaces for "try...catch" statement', function() {
+            assert(checker.checkString('try {} catch(e) {}').getErrorCount() === 2);
+            assert(checker.checkString('try {} catch( e) {}').getErrorCount() === 1);
+            assert(checker.checkString('try {} catch( e ) {}').isEmpty());
+        });
+    });
+
 });


### PR DESCRIPTION
Going to paste in what I wrote in #517:

I like almost all of jQuery's styleguide. I really like spaces inside all object brackets, array brackets, and parens. But I don't like either of these:

``` javascript
funcWithCallback( function( params ) {
    // do something with params
    return 'result';
} ); // <- space between delimiter is butt-ugly
```

``` javascript
//               ↓ hard to read without space between ( and function
funcWithCallback(function( params ) {
    // do something with params
    return 'result';
});
```

What I'd like to have (allButSolitaryPunctuators):

``` javascript
funcWithCallback( function( params ) {
    // do something with params
    return 'result';
});
```
