### PR TITLE
Tweak .gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
+/node_modules
 .idea
 *.sublime-*
 /npm-debug.log


### PR DESCRIPTION
This changes the `.gitignore` patterns to only match the `node_modules` folder for `node-jscs`, in a way that does not interfere with projects that check in their `node_modules` folder into git.
