### PR TITLE
Do not use the caret, because that will break older nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "supports-color": "~1.1.0"
   },
   "devDependencies": {
-    "browserify": "^5.10.0",
+    "browserify": "~5.10.0",
     "hooker": "~0.2.3",
     "jshint": "~2.5.0",
     "mocha": "~1.21.4",


### PR DESCRIPTION
This is a change to https://github.com/mdevils/node-jscs/commit/80f036ada7dd0eb32ec08a220a5ff0a97e7df9be by @markelog. Using the caret (^) breaks older 0.10 nodes, and <= 0.8 nodes, which don't ship with a version of `npm` new enough to handle it.
