### PR TITLE
Checker: checks stdin. Fixes #577

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -11,6 +11,8 @@
     "disallowSpacesInsideObjectBrackets": null,
     "disallowImplicitTypeConversion": ["string"],
 
+    "safeContextKeyword": "_this",
+
     "excludeFiles": [
       "test/data/**",
       // this file tests that snake cased configs are detected

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -128,6 +128,31 @@ Checker.prototype.checkPath = function(path) {
 };
 
 /**
+ * Checks stdin for input
+ *
+ * @returns {Promise}
+ */
+Checker.prototype.checkStdin = function() {
+    var stdInput = [];
+    var deferred = Vow.defer();
+    var _this = this;
+
+    process.stdin.setEncoding('utf8');
+
+    process.stdin.on('data', function(chunk) {
+        stdInput.push(chunk);
+    });
+
+    process.stdin.on('end', function() {
+        var errors = _this.checkString(stdInput.join(''));
+
+        deferred.resolve(errors);
+    });
+
+    return deferred.promise();
+};
+
+/**
  * Returns true if specified path is in excluded list.
  *
  * @returns {Boolean}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,7 +26,6 @@ module.exports = function(program) {
         reporter: program.reporter,
         promise: promise
     };
-    var stdInput = [];
 
     promise.always(function(status) {
         process.exit(status.valueOf());
@@ -112,14 +111,7 @@ module.exports = function(program) {
         // So the dash doesn't register as a file
         if (usedDash) { args.length--; }
 
-        process.stdin.setEncoding('utf8');
-
-        process.stdin.on('data', function(chunk) {
-            stdInput.push(chunk);
-        });
-
-        process.stdin.on('end', function() {
-            var errors = checker.checkString(stdInput.join(''));
+        checker.checkStdin().then(function(errors) {
             reporter([errors]);
 
             if (!errors.isEmpty()) {

--- a/test/checker.js
+++ b/test/checker.js
@@ -57,4 +57,30 @@ describe('modules/checker', function() {
             });
         });
     });
+
+    describe('checkStdin', function() {
+        it('should check stdin for input', function() {
+            var spy = sinon.spy(process.stdin, 'on');
+
+            checker.checkStdin();
+
+            assert(spy.called);
+        });
+
+        it('returns a promise', function() {
+            var spy = sinon.spy(process.stdin, 'on');
+
+            assert(typeof checker.checkStdin().then === 'function');
+        });
+
+        it('resolves with the errors from processing stdin', function(done) {
+            checker.checkStdin().then(function(errors) {
+                assert(typeof errors !== 'undefined');
+                done();
+            });
+
+            process.stdin.emit('data', 'foo');
+            process.stdin.emit('end');
+        });
+    });
 });


### PR DESCRIPTION
Allows us to clean up cli.js and the stdin checking functionality fits nicely in checker.
