### PR TITLE
#533: Update requireAlignedObjectValues rule to work with whitespace aligned via spaces and/or tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,12 +1454,16 @@ var x = {
 
 Requires proper alignment in object literals.
 
-Type: `String`
+Type: `String` or `Object`
 
 Values:
- - `"all"` for strict mode,
- - `"ignoreFunction"` ignores objects if one of the property values is a function expression,
- - `"ignoreLineBreak"` ignores objects if there are line breaks between properties
+ - `String`:
+    - `"all"` for strict mode,
+    - `"ignoreFunction"` ignores objects if one of the property values is a function expression,
+    - `"ignoreLineBreak"` ignores objects if there are line breaks between properties
+ - `Object`:
+    - `mode`: (required) specify one of the string options above
+    - `tabSize`: (default: `1`) considered the tab character as number of specified spaces
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -2341,7 +2341,7 @@ Values:
  - `Integer`: lines should be at most the number of characters specified
  - `Object`:
     - `value`: (required) lines should be at most the number of characters specified
-    - `tabSize`: (default: `1`) considered the tab character as number of specified spaces
+    - `tabSize`: (default: `1`) considers the tab character as the number of specified spaces
     - `allowComments`: (default: `false`) allows comments to break the rule
     - `allowUrlComments`: (default: `false`) allows comments with long urls to break the rule
     - `allowRegex`: (default: `false`) allows regular expression literals to break the rule

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -1,3 +1,7 @@
+/* globals require, module */
+/* jshint -W097 */
+'use strict';
+
 var assert = require('assert');
 var tokenHelper = require('../token-helper');
 
@@ -39,7 +43,8 @@ module.exports.prototype = {
 
         assert(
             typeof mode === 'string' && modes[mode],
-            this.getOptionName() + (isProperty ? '.mode' : '') + ' requires one of the following values: ' + Object.keys(modes).join(', ')
+            this.getOptionName() + (isProperty ? '.mode' : '') +
+                ' requires one of the following values: ' + Object.keys(modes).join(', ')
         );
 
         this._mode = modes[mode];
@@ -54,7 +59,7 @@ module.exports.prototype = {
         var tabSize = this._tabSize;
         var keyPos = file.getTokenPosByRangeStart(property.key.range[0]);
         var colon = file.getTokens()[keyPos + 1];
-        var line = (file.getLines()[colon.loc.start.line-1]);
+        var line = (file.getLines()[colon.loc.start.line - 1]);
         var colonPosition = tokenHelper.getTabAdjustedStartPosition(colon, line, tabSize);
 
         return {

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -1,10 +1,34 @@
 var assert = require('assert');
+var tokenHelper = require('../token-helper');
 
 module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(mode) {
+    configure: function(config) {
+
+        this._tabSize = 1;
+
+        if (typeof config === 'object') {
+
+            this.configureMode(config.mode, true);
+            this.configureTabSize(config.tabSize);
+
+        } else {
+            this.configureMode(config);
+        }
+    },
+
+    configureTabSize: function(tabSize) {
+
+        if (tabSize) {
+            this._tabSize = tabSize;
+        }
+
+    },
+
+    configureMode: function(mode, isProperty) {
+
         var modes = {
             'all': 'all',
             'ignoreFunction': 'ignoreFunction',
@@ -12,10 +36,12 @@ module.exports.prototype = {
             'skipWithFunction': 'ignoreFunction',
             'skipWithLineBreak': 'ignoreLineBreak'
         };
+
         assert(
             typeof mode === 'string' && modes[mode],
-            this.getOptionName() + ' requires one of the following values: ' + Object.keys(modes).join(', ')
+            this.getOptionName() + (isProperty ? '.mode' : '') + ' requires one of the following values: ' + Object.keys(modes).join(', ')
         );
+
         this._mode = modes[mode];
     },
 
@@ -23,17 +49,33 @@ module.exports.prototype = {
         return 'requireAlignedObjectValues';
     },
 
+    _getColonPosition: function(file, property) {
+
+        var tabSize = this._tabSize;
+        var keyPos = file.getTokenPosByRangeStart(property.key.range[0]);
+        var colon = file.getTokens()[keyPos + 1];
+        var line = (file.getLines()[colon.loc.start.line-1]);
+        var colonPosition = tokenHelper.getTabAdjustedStartPosition(colon, line, tabSize);
+
+        return {
+            pos: colonPosition,
+            colon: colon
+        };
+    },
+
     check: function(file, errors) {
-        var tokens = file.getTokens();
+
         var mode = this._mode;
+        var getColonPosition = this._getColonPosition.bind(this);
+
         file.iterateNodesByType('ObjectExpression', function(node) {
             if (node.loc.start.line === node.loc.end.line || node.properties < 2) {
                 return;
             }
 
-            var maxKeyEndPos = 0;
+            var maxColonStartPosition = 0;
             var skip = node.properties.some(function(property, index) {
-                maxKeyEndPos = Math.max(maxKeyEndPos, property.key.loc.end.column);
+                maxColonStartPosition = Math.max(maxColonStartPosition, getColonPosition(file, property).pos);
 
                 if (mode === 'ignoreFunction' && property.value.type === 'FunctionExpression') {
                     return true;
@@ -50,10 +92,11 @@ module.exports.prototype = {
             }
 
             node.properties.forEach(function(property) {
-                var keyPos = file.getTokenPosByRangeStart(property.key.range[0]);
-                var colon = tokens[keyPos + 1];
-                if (colon.loc.start.column !== maxKeyEndPos + 1) {
-                    errors.add('Alignment required', colon.loc.start);
+
+                var colonInfo = getColonPosition(file, property);
+
+                if (colonInfo.pos !== maxColonStartPosition) {
+                    errors.add('Alignment required', colonInfo.colon.loc.start);
                 }
             });
         });

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -1,7 +1,3 @@
-/* globals require, module */
-/* jshint -W097 */
-'use strict';
-
 var assert = require('assert');
 var tokenHelper = require('../token-helper');
 

--- a/lib/token-helper.js
+++ b/lib/token-helper.js
@@ -115,3 +115,39 @@ exports.getTokenByRangeStartIfPunctuator = function(file, range, operator, backw
 exports.getPointerEntities = function(column, length) {
     return column - 1 + Math.ceil(length / 2);
 };
+
+
+/**
+ * Get the correct start position of a token after correctly calculating tab whitespace
+ *
+ * @param {String} line
+ * @param {Number} tabSize
+ *
+ * @return {Number}
+ */
+exports.getTabAdjustedStartPosition = function(token, line, tabSize) {
+
+    var tabCount = 0;
+    var tabPos = 0;
+    var totalTabWhitespace = 0;
+    var nextTabStopPosition;
+    var originalColonPosition = token.loc.start.column;
+    var colonPosition = originalColonPosition;
+
+    tabPos = line.indexOf('\t', tabPos);
+
+    while (-1 < tabPos && tabPos < originalColonPosition) {
+        tabPos = tabPos + totalTabWhitespace - tabCount;
+
+        tabCount++;
+
+        nextTabStopPosition = (Math.floor(tabPos/tabSize) * tabSize) + tabSize;
+        totalTabWhitespace += nextTabStopPosition - tabPos;
+
+        tabPos = line.indexOf('\t', tabPos+1);
+    }
+
+    colonPosition = originalColonPosition + totalTabWhitespace - tabCount;
+
+    return colonPosition;
+};

--- a/lib/token-helper.js
+++ b/lib/token-helper.js
@@ -1,3 +1,8 @@
+/* globals exports */
+
+/* jshint -W097 */
+'use strict';
+
 /**
  * Returns token by range start. Ignores ()
  *
@@ -116,10 +121,10 @@ exports.getPointerEntities = function(column, length) {
     return column - 1 + Math.ceil(length / 2);
 };
 
-
 /**
  * Get the correct start position of a token after correctly calculating tab whitespace
  *
+ * @param {String} token
  * @param {String} line
  * @param {Number} tabSize
  *
@@ -132,7 +137,7 @@ exports.getTabAdjustedStartPosition = function(token, line, tabSize) {
     var totalTabWhitespace = 0;
     var nextTabStopPosition;
     var originalColonPosition = token.loc.start.column;
-    var colonPosition = originalColonPosition;
+    var colonPosition;
 
     tabPos = line.indexOf('\t', tabPos);
 
@@ -141,10 +146,10 @@ exports.getTabAdjustedStartPosition = function(token, line, tabSize) {
 
         tabCount++;
 
-        nextTabStopPosition = (Math.floor(tabPos/tabSize) * tabSize) + tabSize;
+        nextTabStopPosition = (Math.floor(tabPos / tabSize) * tabSize) + tabSize;
         totalTabWhitespace += nextTabStopPosition - tabPos;
 
-        tabPos = line.indexOf('\t', tabPos+1);
+        tabPos = line.indexOf('\t', tabPos + 1);
     }
 
     colonPosition = originalColonPosition + totalTabWhitespace - tabCount;

--- a/lib/token-helper.js
+++ b/lib/token-helper.js
@@ -1,8 +1,3 @@
-/* globals exports */
-
-/* jshint -W097 */
-'use strict';
-
 /**
  * Returns token by range start. Ignores ()
  *
@@ -136,12 +131,12 @@ exports.getTabAdjustedStartPosition = function(token, line, tabSize) {
     var tabPos = 0;
     var totalTabWhitespace = 0;
     var nextTabStopPosition;
-    var originalColonPosition = token.loc.start.column;
+    var originalTokenPosition = token.loc.start.column;
     var colonPosition;
 
     tabPos = line.indexOf('\t', tabPos);
 
-    while (-1 < tabPos && tabPos < originalColonPosition) {
+    while (tabPos < originalTokenPosition && tabPos > -1) {
         tabPos = tabPos + totalTabWhitespace - tabCount;
 
         tabCount++;
@@ -152,7 +147,7 @@ exports.getTabAdjustedStartPosition = function(token, line, tabSize) {
         tabPos = line.indexOf('\t', tabPos + 1);
     }
 
-    colonPosition = originalColonPosition + totalTabWhitespace - tabCount;
+    colonPosition = originalTokenPosition + totalTabWhitespace - tabCount;
 
     return colonPosition;
 };

--- a/test/rules/require-aligned-object-values.js
+++ b/test/rules/require-aligned-object-values.js
@@ -1,3 +1,7 @@
+/* globals require, module, describe, it, beforeEach */
+/* jshint -W097 */
+'use strict';
+
 var Checker = require('../../lib/checker');
 var assert = require('assert');
 
@@ -7,6 +11,21 @@ describe('rules/require-aligned-object-values', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
+    });
+
+    describe('object{mode:all,tabSize:4} option', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireAlignedObjectValues: {
+                    mode: 'all',
+                    tabSize: 4
+                }
+            });
+        });
+
+        it('should not report any errors for tab alignment', function() {
+            assert(checker.checkString('var x = {\n').isEmpty());
+        });
     });
 
     describe('all option', function() {


### PR DESCRIPTION
This fixes #533. 

I verified that this fix works in the following scenarios:

- Only tabs used for alignment
- Only spaces used for alignment
- tabs used for some object keys and spaces used for others
- tabs and spaces used for some object keys, spaces used for some, and tabs used for others.

It should work in all scenarios and give you an accurate reading as to whether your objects are aligned or not as long as you update the requireAlignedObjectValues rule to be set to something like the following:
```
{
  "requireAlignedObjectValues" : {
    "mode" : "any string that was valid before",
    "tabSize" : "the amount of whitespace that your tabs count as"
  }
```