### PR TITLE
Remove line breaks validation from crockford preset

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -50,7 +50,6 @@
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "disallowKeywords": [ "with" ],
     "disallowMultipleLineBreaks": true,
-    "validateLineBreaks": "LF",
     "validateQuoteMarks": "'",
     "validateIndentation": 4,
     "disallowMixedSpacesAndTabs": true,


### PR DESCRIPTION
I do not see how this could be a generic check, especially when tools like Git automatically convert from CRLF to LF on commit.
