### PR TITLE
Remove spaces in array declaration check from crockford preset

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -34,7 +34,6 @@
     "requireMultipleVarDecl": "onevar",
     "requireBlocksOnNewline": 1,
     "disallowEmptyBlocks": true,
-    "disallowSpacesInsideArrayBrackets": true,
     "disallowSpacesInsideParentheses": true,
     "disallowQuotedKeysInObjects": true,
     "disallowDanglingUnderscores": true,


### PR DESCRIPTION
jslint.com does not care about spaces you add, or don't add, in an array declaration.
