### PR TITLE
Add check to disallow line breaks before blocks in crockford preset

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -60,5 +60,6 @@
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
-    "disallowYodaConditions": true
+    "disallowYodaConditions": true,
+    "disallowNewlineBeforeBlockStatements": true
 }


### PR DESCRIPTION
As verified on jslint.com this code does not pass validation:

var foo = 0;
if (foo > 0)
{
    foo = 0;
}

It fails with "Expected exactly one space between ')' and '{'.".
