### PR TITLE
Remove check for Yoda conditions in crockford preset

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -59,6 +59,5 @@
     "disallowKeywordsOnNewLine": [ "else" ],
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
-    "requireDotNotation": true,
-    "disallowYodaConditions": true
+    "requireDotNotation": true
 }


### PR DESCRIPTION
I could not find any evidence of Crockford preferring one way or the other.
jslint.com does not throw any error, and I found no mention of this in neither
"JavaScript: The Good Parts", or http://javascript.crockford.com/code.html.
