### PR TITLE
New Rules: (require|disallow)PaddingNewLinesInObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,74 @@ if (true) {
 }
 ```
 
+### requirePaddingNewLinesInObjects
+
+Requires newline inside curly braces of all objects.
+
+Type: `Boolean`
+
+Values: `true`
+
+#### Example
+
+```js
+"requirePaddingNewLinesInObjects": true
+```
+
+##### Valid
+
+```js
+var x = {
+    a: 1
+};
+foo({
+    a: {
+        b: 1
+    }
+});
+```
+
+##### Invalid
+
+```js
+var x = { a: 1 };
+foo({a:{b:1}});
+```
+
+### disallowPaddingNewLinesInObjects
+
+Disallows newline inside curly braces of all objects.
+
+Type: `Boolean`
+
+Values: `true`
+
+#### Example
+
+```js
+"disallowPaddingNewLinesInObjects": true
+```
+
+##### Valid
+
+```js
+var x = { a: 1 };
+foo({a: {b: 1}});
+```
+
+##### Invalid
+
+```js
+var x = {
+    a: 1
+};
+foo({
+    a: {
+        b: 1
+    }
+});
+```
+
 ### disallowEmptyBlocks
 
 Disallows empty blocks (except for catch blocks).

--- a/lib/rules/disallow-padding-newlines-in-objects.js
+++ b/lib/rules/disallow-padding-newlines-in-objects.js
@@ -1,0 +1,48 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(value) {
+        assert(
+            typeof value === 'boolean',
+            'disallowPaddingNewLinesInObjects option requires boolean value'
+        );
+        assert(
+            value === true,
+            'disallowPaddingNewLinesInObjects option requires true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowPaddingNewLinesInObjects';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            var tokens = file.getTokens();
+            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
+
+            var openingBracket = tokens[openingBracketPos];
+            var nextToken = tokens[openingBracketPos + 1];
+
+            if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
+                return;
+            }
+
+            if (openingBracket.loc.end.line !== nextToken.loc.start.line) {
+                errors.add('Illegal newline after opening curly brace', nextToken.loc.start);
+            }
+
+            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
+            var closingBracket = tokens[closingBracketPos];
+            var prevToken = tokens[closingBracketPos - 1];
+
+            if (closingBracket.loc.start.line !== prevToken.loc.end.line) {
+                errors.add('Illegal newline before closing curly brace', closingBracket.loc.start);
+            }
+        });
+    }
+
+};

--- a/lib/rules/require-padding-newlines-in-objects.js
+++ b/lib/rules/require-padding-newlines-in-objects.js
@@ -1,0 +1,48 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(value) {
+        assert(
+            typeof value === 'boolean',
+            'requirePaddingNewLinesInObjects option requires boolean value'
+        );
+        assert(
+            value === true,
+            'requirePaddingNewLinesInObjects option requires true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requirePaddingNewLinesInObjects';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            var tokens = file.getTokens();
+            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
+
+            var openingBracket = tokens[openingBracketPos];
+            var nextToken = tokens[openingBracketPos + 1];
+
+            if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
+                return;
+            }
+
+            if (openingBracket.loc.end.line === nextToken.loc.start.line) {
+                errors.add('Missing newline after opening curly brace', nextToken.loc.start);
+            }
+
+            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
+            var closingBracket = tokens[closingBracketPos];
+            var prevToken = tokens[closingBracketPos - 1];
+
+            if (closingBracket.loc.start.line === prevToken.loc.end.line) {
+                errors.add('Missing newline before closing curly brace', closingBracket.loc.start);
+            }
+        });
+    }
+
+};

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -80,6 +80,8 @@ StringChecker.prototype = {
 
         this.registerRule(new (require('./rules/disallow-padding-newlines-in-blocks'))());
         this.registerRule(new (require('./rules/require-padding-newlines-in-blocks'))());
+        this.registerRule(new (require('./rules/require-padding-newlines-in-objects'))());
+        this.registerRule(new (require('./rules/disallow-padding-newlines-in-objects'))());
         this.registerRule(new (require('./rules/require-newline-before-block-statements'))());
         this.registerRule(new (require('./rules/disallow-newline-before-block-statements'))());
 

--- a/test/rules/disallow-padding-newlines-in-objects.js
+++ b/test/rules/disallow-padding-newlines-in-objects.js
@@ -1,0 +1,31 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-padding-newlines-in-objects', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowPaddingNewLinesInObjects: true });
+    });
+
+    it('should report existing newline after opening brace', function() {
+        assert(checker.checkString('var x = {\na: 1};').getErrorCount() === 1);
+    });
+    it('should report existing newline before closing brace', function() {
+        assert(checker.checkString('var x = {a: 1\n};').getErrorCount() === 1);
+    });
+    it('should report existing newline in both cases', function() {
+        assert(checker.checkString('var x = {\na: 1\n};').getErrorCount() === 2);
+    });
+    it('should not report with no newlines', function() {
+        assert(checker.checkString('var x = {a: 1};').isEmpty());
+        assert(checker.checkString('var x = { a: 1 };').isEmpty());
+    });
+    it('should not report for empty object', function() {
+        assert(checker.checkString('var x = {};').isEmpty());
+    });
+    it('should report for nested object', function() {
+        assert(checker.checkString('var x = { a: {\nb: 1\n} };').getErrorCount() === 2);
+    });
+});

--- a/test/rules/require-padding-newlines-in-objects.js
+++ b/test/rules/require-padding-newlines-in-objects.js
@@ -1,0 +1,33 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-padding-newlines-in-objects', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requirePaddingNewLinesInObjects: true });
+    });
+
+    it('should report missing newline after opening brace', function() {
+        assert(checker.checkString('var x = {a: 1\n};').getErrorCount() === 1);
+        assert(checker.checkString('var x = { a: 1\n};').getErrorCount() === 1);
+    });
+    it('should report missing newline before closing brace', function() {
+        assert(checker.checkString('var x = {\na: 1};').getErrorCount() === 1);
+        assert(checker.checkString('var x = {\na: 1 };').getErrorCount() === 1);
+    });
+    it('should report missing newline in both cases', function() {
+        assert(checker.checkString('var x = {a: 1};').getErrorCount() === 2);
+        assert(checker.checkString('var x = { a: 1 };').getErrorCount() === 2);
+    });
+    it('should not report with newlines', function() {
+        assert(checker.checkString('var x = {\na: 1\n};').isEmpty());
+    });
+    it('should not report for empty object', function() {
+        assert(checker.checkString('var x = {};').isEmpty());
+    });
+    it('should report for nested object', function() {
+        assert(checker.checkString('var x = {\na: { b: 1 }\n};').getErrorCount() === 2);
+    });
+});


### PR DESCRIPTION
Adds two new rules:
- requireNewlineInsideObjectBrackets
- disallowNewlineInsideObjectBrackets
