### PR TITLE
allow disallowMultipleVarDecl to be false as to override preset

### DIFF
--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -9,6 +9,7 @@ module.exports.prototype = {
             typeof disallowMultipleVarDecl === 'boolean',
             'disallowMultipleVarDecl option requires boolean value'
         );
+        this._disallowMultipleVarDecl = disallowMultipleVarDecl;
     },
 
     getOptionName: function() {
@@ -16,6 +17,9 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        if (!this._disallowMultipleVarDecl) {
+            return;
+        }
         file.iterateNodesByType('VariableDeclaration', function(node) {
             // allow multiple var declarations in for statement
             // for (var i = 0, j = myArray.length; i < j; i++) {}


### PR DESCRIPTION
I inherit from the preset "google", but I want to allow multiple vars. Unless I'm missing something I think it would be best to remove that assertion otherwise you cannot override the extended preset.
