### PR TITLE
Fix disallowMultipleLineBreaks with shebang line

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -226,7 +226,7 @@ StringChecker.prototype = {
      */
     checkString: function(str, filename) {
         filename = filename || 'input';
-        str = str.replace(/^#!?[^\n]+\n/gm, '\n');
+        str = str.replace(/^#!?[^\n]+\n/gm, '');
 
         var tree;
         var parseError;

--- a/test/rules/disallow-multiple-line-breaks.js
+++ b/test/rules/disallow-multiple-line-breaks.js
@@ -18,6 +18,7 @@ describe('rules/disallow-multiple-line-breaks', function() {
     it('should not report single line break when first line starts with #!', function() {
         checker.configure({ disallowMultipleLineBreaks: true });
         assert(checker.checkString('#!/usr/bin/env node\nx = 1;').isEmpty());
+        assert(checker.checkString('#!/usr/bin/env node\n\nx = 1;').isEmpty());
     });
     it('should report only once per each sequence of line breaks', function() {
         checker.configure({ disallowMultipleLineBreaks: true });


### PR DESCRIPTION
Previously failing when there was a blank line between the shebang and
the following code.

Fixes #634
