### PR TITLE
disallowMultipleVarDecl: Strict mode to disallow for statement exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,9 +866,9 @@ function a (){}
 
 Disallows multiple `var` declaration (except for-loop).
 
-Type: `Boolean`
+Type: `Boolean` or `String`
 
-Values: `true`
+Values: `true` or 'strict' (to disallow multiple variable declarations within a for loop)
 
 #### Example
 

--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -6,13 +6,11 @@ module.exports.prototype = {
 
     configure: function(disallowMultipleVarDecl) {
         assert(
-            typeof disallowMultipleVarDecl === 'boolean',
-            'disallowMultipleVarDecl option requires boolean value'
+            disallowMultipleVarDecl === true || disallowMultipleVarDecl === 'strict',
+            'disallowMultipleVarDecl option requires true or "strict" value'
         );
-        assert(
-            disallowMultipleVarDecl === true,
-            'disallowMultipleVarDecl option requires true value or should be removed'
-        );
+
+        this.strictMode = disallowMultipleVarDecl === 'strict';
     },
 
     getOptionName: function() {
@@ -20,10 +18,12 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var inStrictMode = this.strictMode;
+
         file.iterateNodesByType('VariableDeclaration', function(node) {
-            // allow multiple var declarations in for statement
+            // allow multiple var declarations in for statement unless we're in strict mode
             // for (var i = 0, j = myArray.length; i < j; i++) {}
-            if (node.declarations.length > 1 && node.parentNode.type !== 'ForStatement') {
+            if (node.declarations.length > 1 && (inStrictMode || node.parentNode.type !== 'ForStatement')) {
                 errors.add('Multiple var declaration', node.loc.start);
             }
         });

--- a/test/rules/disallow-multiple-var-decl.js
+++ b/test/rules/disallow-multiple-var-decl.js
@@ -3,24 +3,34 @@ var assert = require('assert');
 
 describe('rules/disallow-multiple-var-decl', function() {
     var checker;
+
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
     });
+
     it('should report multiple var decl', function() {
         checker.configure({ disallowMultipleVarDecl: true });
         assert(checker.checkString('var x, y;').getErrorCount() === 1);
     });
+
     it('should not report single var decl', function() {
         checker.configure({ disallowMultipleVarDecl: true });
         assert(checker.checkString('var x;').isEmpty());
     });
+
     it('should not report separated var decl', function() {
         checker.configure({ disallowMultipleVarDecl: true });
         assert(checker.checkString('var x; var y;').isEmpty());
     });
+
     it('should not report multiple var decl in for statement', function() {
         checker.configure({ disallowMultipleVarDecl: true });
         assert(checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+    });
+
+    it('should report multiple var decl in a for statement if given the "strict" value (#46)', function() {
+        checker.configure({ disallowMultipleVarDecl: 'strict' });
+        assert(!checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
     });
 });


### PR DESCRIPTION
Introduces a new value `"strict"` to fail multiple variable declarations within a `for` statement.
