### PR TITLE
validateJSDoc: Deprecate rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2850,55 +2850,10 @@ function a(b, c) {}
 function a(b , c) {}
 ```
 
-### validateJSDoc
+### ~~validateJSDoc~~
 
-Enables JSDoc validation.
+Please use the [JSCS-JSDoc](https://github.com/jscs-dev/jscs-jsdoc) plugin instead.
 
-Type: `Object`
-
-Values:
-
- - "checkParamNames" ensures param names in jsdoc and in function declaration are equal
- - "requireParamTypes" ensures params in jsdoc contains type
- - "checkRedundantParams" reports redundant params in jsdoc
-
-#### Example
-
-```js
-"validateJSDoc": {
-    "checkParamNames": true,
-    "checkRedundantParams": true,
-    "requireParamTypes": true
-}
-```
-
-##### Valid
-
-```js
-/**
- * Adds style error to the list
- *
- * @param {String} message
- * @param {Number|Object} line
- * @param {Number} [column]
- */
-add: function(message, line, column) {
-}
-```
-
-##### Invalid
-
-```js
-/**
- * Adds style error to the list
- *
- * @param {String} message
- * @param {Number|Object} line
- * @param {Number} [column]
- */
-add: function() {
-}
-```
 ### safeContextKeyword
 
 Option to check `var that = this` expressions

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -43,6 +43,7 @@ StringChecker.prototype = {
         this.registerRule(new (require('./rules/disallow-left-sticked-operators'))());
         this.registerRule(new (require('./rules/require-right-sticked-operators'))());
         this.registerRule(new (require('./rules/disallow-right-sticked-operators'))());
+        this.registerRule(new (require('./rules/validate-jsdoc'))());
         /* deprecated rules (end) */
 
         this.registerRule(new (require('./rules/require-operator-before-line-break'))());
@@ -60,7 +61,6 @@ StringChecker.prototype = {
         this.registerRule(new (require('./rules/disallow-keywords-on-new-line'))());
         this.registerRule(new (require('./rules/require-line-feed-at-file-end'))());
         this.registerRule(new (require('./rules/maximum-line-length'))());
-        this.registerRule(new (require('./rules/validate-jsdoc'))());
         this.registerRule(new (require('./rules/require-yoda-conditions'))());
         this.registerRule(new (require('./rules/disallow-yoda-conditions'))());
         this.registerRule(new (require('./rules/require-spaces-inside-object-brackets'))());


### PR DESCRIPTION
This PR deprecates the validateJSDoc rule and opts for redirecting users to the JSCS-JSDoc plugin. 

@markelog It feels a bit wrong to just remove that rule from the presets that used them. The alternative is to use JSCS-JSDoc internally and add the appropriate configuration to the presets.
