### PR TITLE
Google Preset: No newlines before block statements

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -23,6 +23,7 @@
     "disallowTrailingWhitespace": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowMultipleVarDecl": true,
+    "disallowNewlineBeforeBlockStatements": true,
 
     "requireSpaceAfterKeywords": [
       "if",


### PR DESCRIPTION
Consequently tightens up our own jscsrc.

I noticed violations of this in an upcoming PR.
