### PR TITLE
Updated google preset

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -63,5 +63,6 @@
         "requireParamTypes": true
     },
 
-    "disallowMultipleLineBreaks": true
+    "disallowMultipleLineBreaks": true,
+    "disallowNewlineBeforeBlockStatements": true
 }


### PR DESCRIPTION
According to [Google's JavaScript Style Guide](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml?showone=Code_formatting#Code_formatting):

> Because of implicit semicolon insertion, always start your curly braces on the same line as whatever they're opening. For example:
> 
> ```
> if (something) {
>   // ...
> } else {
>   // ...
> }
> ```
