### PR TITLE
New Rules: (require|disallow)CapitalizedComments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3015,6 +3015,84 @@ function a(b, c) {}
 function a(b , c) {}
 ```
 
+### requireCapitalizedComments
+
+Requires the first alphabetical character of a comment to be uppercase
+
+Type: `Boolean`
+
+Value: `true`
+
+#### Example
+
+`requireCapitalizedComments: true`
+
+Valid:
+
+```
+// Valid
+//Valid
+
+/*
+  Valid
+ */
+
+/**
+ * Valid
+ */
+
+// 123 or any non-alphabetical starting character
+```
+
+Invalid:
+```
+// invalid
+//invalid
+/** invalid */
+/**
+ * invalid
+ */
+```
+
+### disallowCapitalizedComments
+
+Requires the first alphabetical character of a comment to be lowercase.
+
+Type: `String`
+
+Value: `true`
+
+#### Example
+
+`disallowCapitalizedComments: true`
+
+Valid:
+
+```
+// valid
+//valid
+
+/*
+  valid
+ */
+
+/**
+ * valid
+ */
+
+// 123 or any non-alphabetical starting character
+```
+
+Invalid:
+```
+// Invalid
+//Invalid
+/** Invalid */
+/**
+ * Invalid
+ */
+```
+
 ### ~~validateJSDoc~~
 
 Please use the [JSCS-JSDoc](https://github.com/jscs-dev/jscs-jsdoc) plugin instead.

--- a/lib/rules/disallow-capitalized-comments.js
+++ b/lib/rules/disallow-capitalized-comments.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(disallowCapitalizedComments) {
+        assert(
+            disallowCapitalizedComments === true,
+            'disallowCapitalizedComments option requires a value of true or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowCapitalizedComments';
+    },
+
+    check: function(file, errors) {
+        var lowerCasePattern = /[a-z]/;
+        var alphabeticalPattern = /[a-z|A-Z]/;
+
+        file.getComments().forEach(function(comment) {
+            var stripped = comment.value.replace(/[\n\s\*]/g, '');
+            var firstChar = stripped[0];
+
+            if (alphabeticalPattern.test(firstChar) && !lowerCasePattern.test(firstChar)) {
+                errors.add(
+                    'Comments must start with a lowercase letter',
+                    comment.loc.start
+                );
+            }
+        });
+    }
+};

--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(requireCapitalizedComments) {
+        assert(
+            requireCapitalizedComments === true,
+            'requireCapitalizedComments option requires a value of true or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireCapitalizedComments';
+    },
+
+    check: function(file, errors) {
+        var upperCasePattern = /[A-Z]/;
+        var alphabeticalPattern = /[a-z|A-Z]/;
+
+        file.getComments().forEach(function(comment) {
+            var stripped = comment.value.replace(/[\n\s\*]/g, '');
+            var firstChar = stripped[0];
+
+            if (alphabeticalPattern.test(firstChar) && !upperCasePattern.test(firstChar)) {
+                errors.add(
+                    'Comments must start with an uppercase letter',
+                    comment.loc.start
+                );
+            }
+        });
+    }
+};

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -137,6 +137,9 @@ StringChecker.prototype = {
 
         this.registerRule(new (require('./rules/require-function-declarations'))());
         this.registerRule(new (require('./rules/disallow-function-declarations'))());
+
+        this.registerRule(new (require('./rules/require-capitalized-comments'))());
+        this.registerRule(new (require('./rules/disallow-capitalized-comments'))());
     },
 
     /**

--- a/test/rules/disallow-capitalized-comments.js
+++ b/test/rules/disallow-capitalized-comments.js
@@ -1,0 +1,35 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-capitalized-comments', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowCapitalizedComments: true });
+    });
+
+    it('should report on an uppercase start of a comment', function() {
+        assert(checker.checkString('//Invalid').getErrorCount() === 1);
+        assert(checker.checkString('// Invalid').getErrorCount() === 1);
+        assert(checker.checkString('/** Invalid */').getErrorCount() === 1);
+        assert(checker.checkString('/**\n * Invalid\n */').getErrorCount() === 1);
+        assert(checker.checkString('/* Invalid */').getErrorCount() === 1);
+        assert(checker.checkString('/*\n Invalid\n */').getErrorCount() === 1);
+    });
+
+    it('should not report on a lowercase start of a comment', function() {
+        assert(checker.checkString('//valid').isEmpty());
+        assert(checker.checkString('// valid').isEmpty());
+        assert(checker.checkString('/** valid */').isEmpty());
+    });
+
+    it('should not report on comments that start with a non-alphabetical character', function() {
+        assert(checker.checkString('//123').isEmpty());
+        assert(checker.checkString('// 123').isEmpty());
+        assert(checker.checkString('/**123*/').isEmpty());
+        assert(checker.checkString('/**\n @todo: foobar\n */').isEmpty());
+        assert(checker.checkString('/** 123*/').isEmpty());
+    });
+});

--- a/test/rules/require-capitalized-comments.js
+++ b/test/rules/require-capitalized-comments.js
@@ -1,0 +1,34 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-capitalized-comments', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requireCapitalizedComments: true });
+    });
+
+    it('should report on a lowercase start of a comment', function() {
+        assert(checker.checkString('//invalid').getErrorCount() === 1);
+        assert(checker.checkString('// invalid').getErrorCount() === 1);
+        assert(checker.checkString('/** invalid */').getErrorCount() === 1);
+        assert(checker.checkString('/* invalid */').getErrorCount() === 1);
+        assert(checker.checkString('/**\n * invalid\n*/').getErrorCount() === 1);
+    });
+
+    it('should not report an uppercase start of a comment', function() {
+        assert(checker.checkString('//Valid').isEmpty());
+        assert(checker.checkString('// Valid').isEmpty());
+        assert(checker.checkString('/** Valid */').isEmpty());
+    });
+
+    it('should not report on comments that start with a non-alphabetical character', function() {
+        assert(checker.checkString('//123').isEmpty());
+        assert(checker.checkString('// 123').isEmpty());
+        assert(checker.checkString('/**123*/').isEmpty());
+        assert(checker.checkString('/**\n @todo: foobar\n */').isEmpty());
+        assert(checker.checkString('/** 123*/').isEmpty());
+    });
+});


### PR DESCRIPTION
Remaining:
- [x] Change filenames to dashed
- [x] Test multi-line comments (newlines to start a block should be ignored)
