### PR TITLE
Utils: try/catch braces are not optional

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,8 +96,6 @@ exports.curlyBracedKeywords = [
     'for',
     'while',
     'do',
-    'try',
-    'catch',
     'case',
     'default'
 ];


### PR DESCRIPTION
Great point made in https://github.com/jscs-dev/node-jscs/issues/639#issuecomment-57081248 about try/catch incorrectly being on the list of optionally-braced keywords
