### PR TITLE
Fix format of --esnext and --max-errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ But you also can specify your own reporter, since this flag accepts relative or 
 jscs path[ path[...]] --reporter=./some-dir/my-reporter.js
 ```
 
-### '--esnext'
+### `--esnext`
 Attempts to parse your code as ES6 using the harmony version of the esprima parser. Please note that this is currently experimental, and will improve over time.
 
 ### `--no-colors`
 Clean output without colors.
 
-### '--max-errors'
+### `--max-errors`
 Set the maximum number of errors to report
 
 ### `--help`


### PR DESCRIPTION
These options were surrounded by single quotes instead of
backticks, so they were not formatted as code like the
other options.
