### PR TITLE
Ignore maxErrors when NaN

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -287,7 +287,7 @@ StringChecker.prototype = {
                 return (a.line - b.line) || (a.column - b.column);
             });
 
-            if (this._maxErrors !== undefined) {
+            if (!isNaN(this._maxErrors)) {
                 if (!this._maxErrorsExceeded) {
                     this._maxErrorsExceeded = this._errorsFound + errors.getErrorCount() > this._maxErrors;
                 }

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -124,6 +124,17 @@ describe('modules/string-checker', function() {
             assert(errors.length === 1);
             assert(errors2.length === 0);
         });
+
+        it('should not be used when not a number', function() {
+            var errors;
+            checker.configure({
+                requireSpaceBeforeBinaryOperators: ['='],
+                maxErrors: NaN
+            });
+
+            errors = checker.checkString('var foo=1;\n var bar=2;').getErrorList();
+            assert(errors.length > 0);
+        });
     });
 
     describe('esprima version', function() {


### PR DESCRIPTION
For some reason, in some of the grunt-jscs tests, `maxErrors` option was passed as `NaN`.
This resulted in failure of the tests (because the error list was being cut to 0) and the delay
in releasing a new version depending in jscs@1.7.0.

I don't know if I should have invested more time in trying to fix this problem in grunt-jscs, but
right now is 3h12 AM here in Brazil, and I'm tired as hell :(
All I wanted to do is fix these errors so a new release of grunt-jscs could be made :D
