### PR TITLE
Cast StringChecker maxErrors property to Number the first time

### DIFF
--- a/lib/options/max-errors.js
+++ b/lib/options/max-errors.js
@@ -5,7 +5,7 @@
  * @param {StringСhecker} instance
  */
 module.exports = function(config, instance) {
-    instance._maxErrors = config.maxErrors;
+    instance._maxErrors = Number(config.maxErrors);
 
     Object.defineProperty(config, 'maxErrors', {
         value: Number(config.maxErrors),

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -287,7 +287,7 @@ StringChecker.prototype = {
                 return (a.line - b.line) || (a.column - b.column);
             });
 
-            if (this._maxErrors !== undefined) {
+            if (!isNaN(this._maxErrors)) {
                 if (!this._maxErrorsExceeded) {
                     this._maxErrorsExceeded = this._errorsFound + errors.getErrorCount() > this._maxErrors;
                 }


### PR DESCRIPTION
In max-errors.js, Object.defineProperties cast the config maxErrors property to Number
but not the StringChecker maxErrors property.

This leads to a bug if multiple jscs checks are executed using the same config object
(config.maxerrors will equal 'undefined' the first time, and 'NaN' the second time)
