### PR TITLE
CLI: Add --esprima option. #708

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ jscs path[ path[...]] --reporter=./some-dir/my-reporter.js
 ### `--esnext`
 Attempts to parse your code as ES6 using the harmony version of the esprima parser. Please note that this is currently experimental, and will improve over time.
 
+### `--esprima <path>`
+Attempts to parse your code with a custom Esprima version. For example `jscs --esprima=esprima-fb`
+
 ### `--no-colors`
 Clean output without colors.
 

--- a/bin/jscs
+++ b/bin/jscs
@@ -15,6 +15,7 @@ program
     .usage('[options] <file ...>')
     .option('-c, --config [path]', 'configuration file path')
     .option('-e, --esnext', 'attempts to parse esnext code (currently es6)')
+    .option('-s, --esprima <path>', 'attempts to use a custom version of Esprima')
     .option('-n, --no-colors', 'clean output without colors')
     .option('-p, --preset <preset>', 'preset config')
     .option('-v, --verbose', 'adds rule names to the error output')

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -8,6 +8,7 @@ var additionalRules = require('./options/additional-rules');
 var excludeFiles = require('./options/exclude-files');
 var fileExtensions = require('./options/file-extensions');
 var esnext = require('./options/esnext');
+var esprima = require('./options/esprima');
 
 /**
  * Starts Code Style checking process.
@@ -32,6 +33,7 @@ Checker.prototype.configure = function(config) {
     excludeFiles(config, this, cwd);
     additionalRules(config, this, cwd);
     esnext(config);
+    esprima(config);
 
     StringChecker.prototype.configure.apply(this, arguments);
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -113,6 +113,12 @@ module.exports = function(program) {
         return returnArgs;
     }
 
+    if (typeof program.esprima === 'string') {
+        config.esprima = require(program.esprima);
+    } else if (typeof config.esprima === 'string') {
+        config.esprima = require(config.esprima);
+    }
+
     checker.registerDefaultRules();
     checker.configure(config);
 

--- a/lib/options/esprima.js
+++ b/lib/options/esprima.js
@@ -1,0 +1,6 @@
+module.exports = function(config) {
+    Object.defineProperty(config, 'esprima', {
+        value: config.esprima,
+        enumerable: false
+    });
+};

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -184,7 +184,9 @@ StringChecker.prototype = {
 
         preset.extend(config);
 
-        if (config.esnext) {
+        if (config.esprima) {
+            this._esprima = config.esprima;
+        } else if (config.esnext) {
             this._esprima = harmonyEsprima;
         }
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -559,4 +559,53 @@ describe('modules/cli', function() {
             });
         });
     });
+
+    describe('esprima option', function() {
+        beforeEach(function() {
+            sinon.spy(console, 'log');
+        });
+
+        afterEach(function() {
+            console.log.restore();
+        });
+
+        it('should use a custom esprima provided in the config file', function(done) {
+            var data = 'import { foo } from "bar";\n';
+
+            var result = cli({
+                args: [],
+                'no-colors': true,
+                config: 'test/data/cli/esprima.json'
+            });
+
+            process.stdin.emit('data', data);
+            process.stdin.emit('end');
+
+            return result.promise.always(function() {
+                assert(console.log.getCall(0).args[0] === 'No code style errors found.');
+                rAfter();
+                done();
+            });
+        });
+
+        it('should use a custom esprima provided at CLI', function(done) {
+            var data = 'import { foo } from "bar";\n';
+
+            var result = cli({
+                args: [],
+                esprima: 'esprima-harmony-jscs',
+                'no-colors': true,
+                config: 'test/data/cli/cli.json'
+            });
+
+            process.stdin.emit('data', data);
+            process.stdin.emit('end');
+
+            return result.promise.always(function() {
+                assert(console.log.getCall(0).args[0] === 'No code style errors found.');
+                rAfter();
+                done();
+            });
+        });
+    });
 });

--- a/test/data/cli/esprima.json
+++ b/test/data/cli/esprima.json
@@ -1,0 +1,4 @@
+{
+    "disallowKeywords": ["with"],
+    "esprima": "esprima-harmony-jscs"
+}


### PR DESCRIPTION
Currently you cannot use `csjs` with [JSX](https://github.com/facebook/jsx) (ReactJS) files:

``` js
var React = require('react');
module.exports = React.createClass({
  render() {
    return <div>Hello</div>;
  }
});
```

```
Unexpected token < at ./src/components/test.jsx :
      3 |  render() {
      4 |    return <div>Hello</div>;
--------------------^
```

If you could provide a custom [Esprima](http://esprima.org/) version via CLI or `.jscsrc` file, that would fix the problem:

at the CLI:

`jscs --esprima=esprima-fb`

in `.jscsrc`

``` json
{
  "esprima": "esprima-fb"
}
```
