### PR TITLE
disallowDanglingUnderscores: deprecate exceptions and use an array inste...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,33 +1711,39 @@ var x = {'a': 1};
 
 ### disallowDanglingUnderscores
 
-Disallows identifiers that start or end in `_`, except for some popular exceptions:
+Disallows identifiers that start or end in `_`. Some popular identifiers that are automatically excepted:
 
+ - `__proto__` (javascript)
  - `_` (underscore.js)
  - `__filename` (node.js global)
  - `__dirname` (node.js global)
  - `super_` (node.js, used by [`util.inherits`](http://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor))
 
-Type: `Boolean`
+Type: `Boolean` or `Object`
 
-Values: `true`
+Values:
+ - `true`
+ - `Object`:
+    - `allExcept`: array of quoted identifiers
 
 JSHint: [`nomen`](http://www.jshint.com/docs/options/#nomen)
 
 #### Example
 
 ```js
-"disallowDanglingUnderscores": true
+"disallowDanglingUnderscores": { allExcept: ["_exception"] }
 ```
 
 ##### Valid
 
 ```js
 var x = 1;
+var o = obj.__proto__;
 var y = _.extend;
 var z = __dirname;
 var w = __filename;
 var x_y = 1;
+var v = _exception;
 ```
 
 ##### Invalid

--- a/lib/rules/disallow-dangling-underscores.js
+++ b/lib/rules/disallow-dangling-underscores.js
@@ -4,22 +4,41 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(disallowDanglingUnderscores) {
+    configure: function(identifiers) {
         assert(
-            typeof disallowDanglingUnderscores === 'boolean',
-            'disallowDanglingUnderscores option requires boolean value'
-        );
-        assert(
-            disallowDanglingUnderscores === true,
-            'disallowDanglingUnderscores option requires true value or should be removed'
+            identifiers === true ||
+            typeof identifiers === 'object',
+            this.getOptionName() + ' option requires the value `true` ' +
+            'or an object with String[] `allExcept` property'
         );
 
-        this._allowedIdentifiers = {
-            _: true,
-            __dirname: true,
-            __filename: true,
-            super_: true
-        };
+         // verify first item in `allExcept` property in object (if it's an object)
+        assert(
+            typeof identifiers !== 'object' ||
+            Array.isArray(identifiers.allExcept) &&
+            typeof identifiers.allExcept[0] === 'string',
+            'Property `allExcept` in requireSpaceAfterLineComment should be an array of strings'
+        );
+
+        var isTrue = identifiers === true;
+        var defaultIdentifiers = [
+            '__proto__',
+            '_',
+            '__dirname',
+            '__filename',
+            'super_'
+        ];
+
+        if (isTrue) {
+            identifiers = defaultIdentifiers;
+        } else {
+            identifiers = (identifiers.allExcept).concat(defaultIdentifiers);
+        }
+
+        this._identifierIndex = {};
+        for (var i = 0, l = identifiers.length; i < l; i++) {
+            this._identifierIndex[identifiers[i]] = true;
+        }
     },
 
     getOptionName: function() {
@@ -27,7 +46,7 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var allowedIdentifiers = this._allowedIdentifiers;
+        var allowedIdentifiers = this._identifierIndex;
 
         file.iterateTokensByType('Identifier', function(token) {
             var value = token.value;

--- a/test/rules/disallow-dangling-underscores.js
+++ b/test/rules/disallow-dangling-underscores.js
@@ -7,43 +7,88 @@ describe('rules/disallow-dangling-underscores', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ disallowDanglingUnderscores: true });
     });
 
-    it('should report leading underscores', function() {
-        assert(checker.checkString('var _x = "x";').getErrorCount() === 1);
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({ disallowDanglingUnderscores: true });
+        });
+
+        it('should report leading underscores', function() {
+            assert(checker.checkString('var _x = "x";').getErrorCount() === 1);
+        });
+
+        it('should report trailing underscores', function() {
+            assert(checker.checkString('var x_ = "x";').getErrorCount() === 1);
+        });
+
+        it('should report trailing underscores in member expressions', function() {
+            assert(checker.checkString('var x = this._privateField;').getErrorCount() === 1);
+            assert(checker.checkString('var x = instance._protectedField;').getErrorCount() === 1);
+        });
+
+        it('should report trailing underscores', function() {
+            assert(checker.checkString('var x_ = "x";').getErrorCount() === 1);
+        });
+
+        it('should not report inner underscores', function() {
+            assert(checker.checkString('var x_y = "x";').isEmpty());
+        });
+
+        it('should not report no underscores', function() {
+            assert(checker.checkString('var xy = "x";').isEmpty());
+        });
     });
 
-    it('should report trailing underscores', function() {
-        assert(checker.checkString('var x_ = "x";').getErrorCount() === 1);
+    describe('option value true: default exceptions', function() {
+        beforeEach(function() {
+            checker.configure({ disallowDanglingUnderscores: true });
+        });
+
+        it('should not report the prototype property', function() {
+            assert(checker.checkString('var proto = obj.__proto__;').isEmpty());
+        });
+
+        it('should not report underscore.js', function() {
+            assert(checker.checkString('var extend = _.extend;').isEmpty());
+        });
+
+        it('should not report node globals', function() {
+            assert(checker.checkString('var a = __dirname + __filename;').isEmpty());
+        });
+
+        it('should not report the super constructor reference created by node\'s util.inherits', function() {
+            assert(checker.checkString('Inheritor.super_.call(this);').isEmpty());
+        });
     });
 
-    it('should report trailing underscores in member expressions', function() {
-        assert(checker.checkString('var x = this._privateField;').getErrorCount() === 1);
-        assert(checker.checkString('var x = instance._protectedField;').getErrorCount() === 1);
-    });
+    describe('exceptions', function() {
+        beforeEach(function() {
+            checker.configure({ disallowDanglingUnderscores: { allExcept: ['_test', 'test_', '_test_', '__test'] } });
+        });
 
-    it('should report trailing underscores', function() {
-        assert(checker.checkString('var x_ = "x";').getErrorCount() === 1);
-    });
+        it('should not report default exceptions: underscore.js', function() {
+            assert(checker.checkString('var extend = _.extend;').isEmpty());
+        });
 
-    it('should not report underscore.js', function() {
-        assert(checker.checkString('var extend = _.extend;').isEmpty());
-    });
+        it('should not report _test', function() {
+            assert(checker.checkString('var a = _test;').isEmpty());
+        });
 
-    it('should not report node globals', function() {
-        assert(checker.checkString('var a = __dirname + __filename;').isEmpty());
-    });
+        it('should not report test_', function() {
+            assert(checker.checkString('var a = test_;').isEmpty());
+        });
 
-    it('should not report the super constructor reference created by node\'s util.inherits', function() {
-        assert(checker.checkString('Inheritor.super_.call(this);').isEmpty());
-    });
+        it('should not report _test_', function() {
+            assert(checker.checkString('var a = _test_;').isEmpty());
+        });
 
-    it('should not report inner underscores', function() {
-        assert(checker.checkString('var x_y = "x";').isEmpty());
-    });
+        it('should not report test__', function() {
+            assert(checker.checkString('var a = __test;').isEmpty());
+        });
 
-    it('should not report no underscores', function() {
-        assert(checker.checkString('var xy = "x";').isEmpty());
+        it('should report dangling underscore identifier that is not included in the array', function() {
+            assert(checker.checkString('var a = _notIncluded;').getErrorCount() === 1);
+        });
     });
 });


### PR DESCRIPTION
...ad

I just left in the exceptions to be backwards compatible.
So if you have an array, it includes the exceptions from before.
It makes sense to remove them too though.
#723
