### PR TITLE
Errors.add should throw on invalid calls

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 var colors = require('colors');
 
 /**
@@ -20,13 +21,19 @@ Errors.prototype = {
      *
      * @param {String} message
      * @param {Number|Object} line
-     * @param {Number} [column]
+     * @param {Number} [column] optional if line is an object
      */
     add: function(message, line, column) {
         if (typeof line === 'object') {
             column = line.column;
             line = line.line;
         }
+
+        // line and column numbers should be explicit
+        assert(typeof line === 'number' && line > 0,
+            'Unable to add an error, `line` should be a number greater than 0 but ' + line + ' given');
+        assert(typeof column === 'number' && column >= 0,
+            'Unable to add an error, `column` should be a positive number but ' + column + ' given');
 
         if (!this._file.isEnabledRule(this._currentRule, line)) {
             return;
@@ -36,7 +43,7 @@ Errors.prototype = {
             rule: this._currentRule,
             message: this._verbose ? this._currentRule + ': ' + message : message,
             line: line,
-            column: column || 0
+            column: column
         });
     },
 

--- a/lib/rules/disallow-mixed-spaces-and-tabs.js
+++ b/lib/rules/disallow-mixed-spaces-and-tabs.js
@@ -51,7 +51,7 @@ module.exports.prototype = {
 
         lines.forEach(function(line, i) {
             if (line.match(test)) {
-                errors.add('Mixed spaces and tabs found', i + 1);
+                errors.add('Mixed spaces and tabs found', i + 1, 0);
             }
         });
     }

--- a/test/errors.js
+++ b/test/errors.js
@@ -88,4 +88,34 @@ describe('modules/errors', function() {
 
         assert.ok(errors.isEmpty());
     });
+
+    describe('add', function() {
+        var errors;
+        before(function() {
+            errors = checker.checkString('yay');
+        });
+
+        it('should throw an error on invalid line', function() {
+            assert.throws(function() {
+                errors.add('msg', 0);
+            });
+        });
+
+        it('should throw an error on invalid column', function() {
+            assert.throws(function() {
+                errors.add('msg', 1, '2');
+            });
+        });
+
+        it('should not throw with good parameters', function() {
+            errors.setCurrentRule('anyRule');
+            errors.add('msg', 1, 0);
+
+            var error = errors.getErrorList()[0];
+
+            assert.equal(error.rule, 'anyRule');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 0);
+        });
+    });
 });

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -143,6 +143,8 @@ describe('modules/string-checker', function() {
             parse: function() {
                 var error = new Error();
                 error.description = customDescription;
+                error.lineNumber = 1;
+                error.column = 0;
 
                 throw error;
             }


### PR DESCRIPTION
To simplify rules debugging, prevent dumb mistakes and crashes in error reporters.
