### PR TITLE
disallowMultipleVarDecl: add exception for undefined variable declaratio...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,11 @@ Disallows multiple `var` declaration (except for-loop).
 
 Type: `Boolean` or `String`
 
-Values: `true` or 'strict' (to disallow multiple variable declarations within a for loop)
+Values:
+
+- `true` disallows multiple variable declarations except within a for loop
+- 'strict' disallows all multiple variable declarations
+- 'exceptUndefined' allows declarations where all variables are not defined
 
 #### Example
 
@@ -1053,9 +1057,26 @@ Values: `true` or 'strict' (to disallow multiple variable declarations within a 
 "disallowMultipleVarDecl": true
 ```
 
-##### Valid
+##### Valid for `true`
 
 ```js
+var x = 1;
+var y = 2;
+
+for (var i = 0, j = arr.length; i < j; i++) {}
+```
+
+##### Valid for `strict`
+
+```js
+var x = 1;
+var y = 2;
+```
+
+##### Valid for `exceptUndefined`
+
+```js
+var a, b;
 var x = 1;
 var y = 2;
 
@@ -1067,6 +1088,8 @@ for (var i = 0, j = arr.length; i < j; i++) {}
 ```js
 var x = 1,
     y = 2;
+
+var x, y = 2, z;
 ```
 
 ### requireMultipleVarDecl

--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -6,11 +6,14 @@ module.exports.prototype = {
 
     configure: function(disallowMultipleVarDecl) {
         assert(
-            disallowMultipleVarDecl === true || disallowMultipleVarDecl === 'strict',
-            'disallowMultipleVarDecl option requires true or "strict" value'
+            disallowMultipleVarDecl === true ||
+            disallowMultipleVarDecl === 'strict' ||
+            disallowMultipleVarDecl === 'exceptUndefined',
+            'disallowMultipleVarDecl option requires true, "strict", or "exceptUndefined" value'
         );
 
         this.strictMode = disallowMultipleVarDecl === 'strict';
+        this.exceptUndefined = disallowMultipleVarDecl === 'exceptUndefined';
     },
 
     getOptionName: function() {
@@ -19,13 +22,27 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var inStrictMode = this.strictMode;
+        var exceptUndefined = this.exceptUndefined;
 
         file.iterateNodesByType('VariableDeclaration', function(node) {
-            // allow multiple var declarations in for statement unless we're in strict mode
-            // for (var i = 0, j = myArray.length; i < j; i++) {}
-            if (node.declarations.length > 1 && (inStrictMode || node.parentNode.type !== 'ForStatement')) {
-                errors.add('Multiple var declaration', node.loc.start);
+            var hasDefinedVariables = node.declarations.some(function(declaration) {
+                return !!declaration.init;
+            });
+
+            var isForStatement = node.parentNode.type === 'ForStatement';
+
+            // allow single var declarations
+            if (node.declarations.length === 1 ||
+                // allow multiple var declarations in for statement unless we're in strict mode
+                // for (var i = 0, j = myArray.length; i < j; i++) {}
+                !inStrictMode && isForStatement ||
+                // allow multiple var declarations with all undefined variables in exceptUndefined mode
+                // var a, b, c
+                exceptUndefined && !hasDefinedVariables) {
+                return;
             }
+
+            errors.add('Multiple var declaration', node.loc.start);
         });
     }
 

--- a/test/rules/disallow-multiple-var-decl.js
+++ b/test/rules/disallow-multiple-var-decl.js
@@ -9,28 +9,70 @@ describe('rules/disallow-multiple-var-decl', function() {
         checker.registerDefaultRules();
     });
 
-    it('should report multiple var decl', function() {
-        checker.configure({ disallowMultipleVarDecl: true });
-        assert(checker.checkString('var x, y;').getErrorCount() === 1);
+    describe('true', function() {
+        beforeEach(function() {
+            checker.configure({ disallowMultipleVarDecl: true });
+        });
+
+        it('should report multiple var decl', function() {
+            assert(checker.checkString('var x, y;').getErrorCount() === 1);
+        });
+
+        it('should report multiple var decl with assignment', function() {
+            assert(checker.checkString('var x = 1, y = 2;').getErrorCount() === 1);
+        });
+
+        it('should not report single var decl', function() {
+            assert(checker.checkString('var x;').isEmpty());
+        });
+
+        it('should not report separated var decl', function() {
+            assert(checker.checkString('var x; var y;').isEmpty());
+        });
+
+        it('should not report multiple var decl in for statement', function() {
+            assert(checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+        });
+
+        it('should report multiple var decl with some assignment', function() {
+            assert(checker.checkString('var x, y = 2, z;').getErrorCount() === 1);
+        });
     });
 
-    it('should not report single var decl', function() {
-        checker.configure({ disallowMultipleVarDecl: true });
-        assert(checker.checkString('var x;').isEmpty());
+    describe('strict', function() {
+        it('should report multiple var decl in a for statement if given the "strict" value (#46)', function() {
+            checker.configure({ disallowMultipleVarDecl: 'strict' });
+            assert(!checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+        });
     });
 
-    it('should not report separated var decl', function() {
-        checker.configure({ disallowMultipleVarDecl: true });
-        assert(checker.checkString('var x; var y;').isEmpty());
-    });
+    describe('exceptUndefined', function() {
+        beforeEach(function() {
+            checker.configure({ disallowMultipleVarDecl: 'exceptUndefined' });
+        });
 
-    it('should not report multiple var decl in for statement', function() {
-        checker.configure({ disallowMultipleVarDecl: true });
-        assert(checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
-    });
+        it('should not report multiple var decl', function() {
+            assert(checker.checkString('var x, y;').isEmpty());
+        });
 
-    it('should report multiple var decl in a for statement if given the "strict" value (#46)', function() {
-        checker.configure({ disallowMultipleVarDecl: 'strict' });
-        assert(!checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+        it('should report multiple var decl with assignment', function() {
+            assert(checker.checkString('var x = 1, y = 2;').getErrorCount() === 1);
+        });
+
+        it('should not report single var decl', function() {
+            assert(checker.checkString('var x;').isEmpty());
+        });
+
+        it('should not report separated var decl', function() {
+            assert(checker.checkString('var x; var y;').isEmpty());
+        });
+
+        it('should not report multiple var decl in for statement', function() {
+            assert(checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+        });
+
+        it('should report multiple var decl with some assignment', function() {
+            assert(checker.checkString('var x, y = 2, z;').getErrorCount() === 1);
+        });
     });
 });


### PR DESCRIPTION
...ns

Rather messy as boolean logic could be simpler?
Not sure about the option name `exceptUndefined` either.
#451
