### PR TITLE
Autofixing: assertions

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var colors = require('colors');
+var TokenAssert = require('./token-assert');
 
 /**
  * Set of errors for specified file.
@@ -13,6 +14,13 @@ var Errors = function(file, verbose) {
     this._file = file;
     this._currentRule = '';
     this._verbose = verbose || false;
+
+    /**
+     * @type {TokenAssert}
+     * @public
+     */
+    this.assert = new TokenAssert(file);
+    this.assert.on('error', this._addError.bind(this));
 };
 
 Errors.prototype = {
@@ -35,16 +43,30 @@ Errors.prototype = {
         assert(typeof column === 'number' && column >= 0,
             'Unable to add an error, `column` should be a positive number but ' + column + ' given');
 
-        if (!this._file.isEnabledRule(this._currentRule, line)) {
+        this._addError({
+            message: message,
+            line: line,
+            column: column
+        });
+    },
+
+    /**
+     * Adds error to error list.
+     *
+     * @param {Object} errorInfo
+     * @private
+     */
+    _addError: function(errorInfo) {
+        if (!this._file.isEnabledRule(this._currentRule, errorInfo.line)) {
             return;
         }
 
         this._errorList.push({
             filename: this._file.getFilename(),
             rule: this._currentRule,
-            message: this._verbose ? this._currentRule + ': ' + message : message,
-            line: line,
-            column: column
+            message: this._verbose ? this._currentRule + ': ' + errorInfo.message : errorInfo.message,
+            line: errorInfo.line,
+            column: errorInfo.column
         });
     },
 

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -1,6 +1,14 @@
 var treeIterator = require('./tree-iterator');
 
 /**
+ * Operator list which are represented as keywords in token list.
+ */
+var KEYWORD_OPERATORS = {
+    'instanceof': true,
+    'in': true
+};
+
+/**
  * File representation for JSCS.
  *
  * @name JsFile
@@ -10,7 +18,8 @@ var JsFile = function(filename, source, tree) {
     this._source = source;
     this._tree = tree || {tokens: []};
     this._lines = source.split(/\r\n|\r|\n/);
-    this._tokenIndex = null;
+    this._tokenRangeStartIndex = null;
+    this._tokenRangeEndIndex = null;
     var index = this._index = {};
     var _this = this;
 
@@ -111,8 +120,6 @@ JsFile.prototype = {
         rulesStr = rulesStr || '*';
 
         rulesStr.split(',').forEach(function(rule) {
-            var ruleLength;
-
             rule = rule.trim();
 
             if (!rule) {
@@ -132,12 +139,15 @@ JsFile.prototype = {
      */
     _buildTokenIndex: function() {
         var tokens = this._tree.tokens;
-        var tokenIndex = {};
+        var tokenRangeStartIndex = {};
+        var tokenRangeEndIndex = {};
         for (var i = 0, l = tokens.length; i < l; i++) {
-            tokenIndex[tokens[i].range[0]] = i;
+            tokenRangeStartIndex[tokens[i].range[0]] = i;
+            tokenRangeEndIndex[tokens[i].range[1]] = i;
             tokens[i]._tokenIndex = i;
         }
-        this._tokenIndex = tokenIndex;
+        this._tokenRangeStartIndex = tokenRangeStartIndex;
+        this._tokenRangeEndIndex = tokenRangeEndIndex;
     },
     /**
      * Returns token position using range start from the index.
@@ -145,7 +155,7 @@ JsFile.prototype = {
      * @returns {Object}
      */
     getTokenPosByRangeStart: function(start) {
-        return this._tokenIndex[start];
+        return this._tokenRangeStartIndex[start];
     },
     /**
      * Returns token using range start from the index.
@@ -153,17 +163,35 @@ JsFile.prototype = {
      * @returns {Object|undefined}
      */
     getTokenByRangeStart: function(start) {
-        var tokenIndex = this._tokenIndex[start];
+        var tokenIndex = this._tokenRangeStartIndex[start];
         return tokenIndex === undefined ? undefined : this._tree.tokens[tokenIndex];
     },
     /**
-     * Returns first token for the node from the AST.
+     * Returns token using range end from the index.
+     *
+     * @returns {Object|undefined}
+     */
+    getTokenByRangeEnd: function(end) {
+        var tokenIndex = this._tokenRangeEndIndex[end];
+        return tokenIndex === undefined ? undefined : this._tree.tokens[tokenIndex];
+    },
+    /**
+     * Returns the first token for the node from the AST.
      *
      * @param {Object} node
      * @returns {Object}
      */
     getFirstNodeToken: function(node) {
         return this.getTokenByRangeStart(node.range[0]);
+    },
+    /**
+     * Returns the last token for the node from the AST.
+     *
+     * @param {Object} node
+     * @returns {Object}
+     */
+    getLastNodeToken: function(node) {
+        return this.getTokenByRangeEnd(node.range[1]);
     },
     /**
      * Returns the first token before the given.
@@ -222,6 +250,26 @@ JsFile.prototype = {
         return nextToken;
     },
     /**
+     * Returns the first token before the given which matches type (and value).
+     *
+     * @param {Object} token
+     * @param {String} value
+     * @returns {Object|undefined}
+     */
+    findPrevOperatorToken: function(token, value) {
+        return this.findPrevToken(token, value in KEYWORD_OPERATORS ? 'Keyword' : 'Punctuator', value);
+    },
+    /**
+     * Returns the first token after the given which matches type (and value).
+     *
+     * @param {Object} token
+     * @param {String} value
+     * @returns {Object|undefined}
+     */
+    findNextOperatorToken: function(token, value) {
+        return this.findNextToken(token, value in KEYWORD_OPERATORS ? 'Keyword' : 'Punctuator', value);
+    },
+    /**
      * Iterates through the token tree using tree iterator.
      * Calls passed function for every token.
      *
@@ -238,19 +286,16 @@ JsFile.prototype = {
      */
     getNodeByRange: function(number) {
         var result = {};
-
         this.iterate(function(node) {
             if (node && node.range) {
                 if (number > node.range[0] && number < node.range[1]) {
                     result = node;
                 }
-
                 if (number < node.range[0]) {
                     return false;
                 }
             }
         });
-
         return result;
     },
     /**

--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -20,16 +20,13 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateTokensByType('Punctuator', function(token, i, tokens) {
+        file.iterateTokensByType('Punctuator', function(token) {
             if (token.value === ',') {
-                var nextToken = tokens[i + 1];
-                if (nextToken && nextToken.loc.start.line !== token.loc.end.line) {
-                    errors.add(
-                        'Commas should be placed on new line',
-                        token.loc.end.line,
-                        token.loc.end.column
-                    );
-                }
+                errors.assert.sameLine({
+                    token: token,
+                    nextToken: file.getNextToken(token),
+                    message: 'Commas should be placed on new line'
+                });
             }
         });
     }

--- a/lib/rules/disallow-space-after-binary-operators.js
+++ b/lib/rules/disallow-space-after-binary-operators.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 var allOperators = require('../utils').binaryOperators;
 
 module.exports = function() {};
@@ -30,29 +29,16 @@ module.exports.prototype = {
     check: function(file, errors) {
         var operators = this._operatorIndex;
 
-        function errorIfApplicable(token, i, tokens, operator) {
-            var nextToken = tokens[i + 1];
-
-            if (nextToken && nextToken.range[0] !== token.range[1]) {
-                var loc = token.loc.start;
-
-                errors.add(
-                    'Operator ' + operator + ' should stick to following expression',
-                    loc.line,
-                    tokenHelper.getPointerEntities(loc.column, token.value.length)
-                );
-            }
-        }
-
         // Comma
         if (operators[',']) {
-            file.iterateTokensByType('Punctuator', function(token, i, tokens) {
-                var operator = token.value;
-                if (operator !== ',') {
-                    return;
+            file.iterateTokensByType('Punctuator', function(token) {
+                if (token.value === ',') {
+                    errors.assert.noWhitespaceBetween({
+                        token: token,
+                        nextToken: file.getNextToken(token),
+                        message: 'Operator , should stick to following expression'
+                    });
                 }
-
-                errorIfApplicable(token, i, tokens, operator);
             });
         }
 
@@ -60,36 +46,34 @@ module.exports.prototype = {
         file.iterateNodesByType(
             ['BinaryExpression', 'AssignmentExpression', 'VariableDeclarator', 'LogicalExpression'],
             function(node) {
-                var isDec = node.type === 'VariableDeclarator';
-                var operator = isDec ? '=' : node.operator;
+                var operator;
+                var expression;
 
-                if (!operators[operator] || node.init === null) {
+                if (node.type === 'VariableDeclarator') {
+                    expression = node.init;
+                    operator = '=';
+                } else {
+                    operator = node.operator;
+                    expression = node.right;
+                }
+
+                if (expression === null) {
                     return;
                 }
 
-                var range = (isDec ? node.init : node.right).range[0];
-
-                var indent = tokenHelper.isTokenParenthesis(file, range - 1, true) ?
-                    operator.length + 1 :
-                    operator.length;
-
-                var part = tokenHelper.getTokenByRangeStartIfPunctuator(
-                    file,
-                    range - indent,
-                    operator,
-                    true
+                var operatorToken = file.findPrevOperatorToken(
+                    file.getFirstNodeToken(expression),
+                    operator
                 );
 
-                if (!part) {
-                    var loc = tokenHelper.findOperatorByRangeStart(
-                        file, range, operator, true
-                    ).loc.start;
+                var nextToken = file.getNextToken(operatorToken);
 
-                    errors.add(
-                        'Operator ' + operator + ' should stick to following expression',
-                        loc.line,
-                        tokenHelper.getPointerEntities(loc.column, operator.length)
-                    );
+                if (operators[operator]) {
+                    errors.assert.noWhitespaceBetween({
+                        token: operatorToken,
+                        nextToken: nextToken,
+                        message: 'Operator ' + node.operator + ' should stick to following expression'
+                    });
                 }
             }
         );

--- a/lib/rules/disallow-space-before-binary-operators.js
+++ b/lib/rules/disallow-space-before-binary-operators.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 var allOperators = require('../utils').binaryOperators;
 
 module.exports = function() {};
@@ -31,33 +30,15 @@ module.exports.prototype = {
     check: function(file, errors) {
         var operators = this._operatorIndex;
 
-        function errorIfApplicable(token, i, tokens, operator) {
-            var prevToken = tokens[i - 1];
-
-            if (prevToken && prevToken.range[1] !== token.range[0]) {
-                var loc = token.loc.start;
-
-                errors.add(
-                    'Operator ' + operator + ' should stick to preceding expression',
-                    loc.line,
-                    tokenHelper.getPointerEntities(loc.column, token.value.length)
-                );
-            }
-        }
-
         // Comma
         if (operators[',']) {
-            file.iterateTokensByType('Punctuator', function(token, i, tokens) {
-                var operator = token.value;
-                if (operator !== ',') {
-                    return;
-                }
-
-                var prevToken = tokens[i - 1];
-
-                // Do not report error if comma not on the same line with the first operand #467
-                if (token.loc.start.line === prevToken.loc.start.line) {
-                    errorIfApplicable(token, i, tokens, operator);
+            file.iterateTokensByType('Punctuator', function(token) {
+                if (token.value === ',') {
+                    errors.assert.noWhitespaceBetween({
+                        token: file.getPrevToken(token),
+                        nextToken: token,
+                        message: 'Operator , should stick to previous expression'
+                    });
                 }
             });
         }
@@ -66,24 +47,34 @@ module.exports.prototype = {
         file.iterateNodesByType(
             ['BinaryExpression', 'AssignmentExpression', 'VariableDeclarator', 'LogicalExpression'],
             function(node) {
-                var isDec = node.type === 'VariableDeclarator';
-                var operator = isDec ? '=' : node.operator;
+                var operator;
+                var expression;
 
-                // !node.init is it's an empty assignment
-                if (!operators[operator] || node.init === null) {
+                if (node.type === 'VariableDeclarator') {
+                    expression = node.init;
+                    operator = '=';
+                } else {
+                    operator = node.operator;
+                    expression = node.right;
+                }
+
+                if (expression === null) {
                     return;
                 }
 
-                var range = (isDec ? node.id : node.left).range;
-                var part = tokenHelper.getTokenByRangeStartIfPunctuator(file, range[1], operator);
+                var operatorToken = file.findPrevOperatorToken(
+                    file.getFirstNodeToken(expression),
+                    operator
+                );
 
-                if (!part) {
-                    errors.add(
-                        'Operator ' + node.operator + ' should stick to preceding expression',
-                        tokenHelper.findOperatorByRangeStart(
-                            file, range[0], operator
-                        ).loc.start
-                    );
+                var prevToken = file.getPrevToken(operatorToken);
+
+                if (operators[operator]) {
+                    errors.assert.noWhitespaceBetween({
+                        token: prevToken,
+                        nextToken: operatorToken,
+                        message: 'Operator ' + node.operator + ' should stick to previous expression'
+                    });
                 }
             }
         );

--- a/lib/rules/disallow-trailing-comma.js
+++ b/lib/rules/disallow-trailing-comma.js
@@ -19,17 +19,14 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateTokensByType('Punctuator', function(token, i, tokens) {
-            if (token.value === ',') {
-                var nextToken = tokens[i + 1];
-                if (nextToken && nextToken.type === 'Punctuator' &&
-                    (nextToken.value === '}' || nextToken.value === ']')) {
-                    errors.add(
-                        'Extra comma following the final element of an array or object literal',
-                        token.loc.start
-                    );
-                }
-            }
+        file.iterateNodesByType(['ObjectExpression', 'ArrayExpression'], function(node) {
+            var closingToken = file.getLastNodeToken(node);
+
+            errors.assert.noTokenBefore({
+                token: closingToken,
+                expectedTokenBefore: {type: 'Punctuator', value: ','},
+                message: 'Extra comma following the final element of an array or object literal'
+            });
         });
     }
 

--- a/lib/rules/require-comma-before-line-break.js
+++ b/lib/rules/require-comma-before-line-break.js
@@ -20,16 +20,13 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateTokensByType('Punctuator', function(token, i, tokens) {
+        file.iterateTokensByType('Punctuator', function(token) {
             if (token.value === ',') {
-                var prevToken = tokens[i - 1];
-                if (prevToken && prevToken.loc.end.line !== token.loc.start.line) {
-                    errors.add(
-                        'Commas should not be placed on new line',
-                        token.loc.start.line,
-                        token.loc.start.column
-                    );
-                }
+                errors.assert.sameLine({
+                    token: file.getPrevToken(token),
+                    nextToken: token,
+                    message: 'Commas should not be placed on new line'
+                });
             }
         });
     }

--- a/lib/rules/require-space-after-binary-operators.js
+++ b/lib/rules/require-space-after-binary-operators.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 var allOperators = require('../utils').binaryOperators;
 
 module.exports = function() {};
@@ -31,29 +30,16 @@ module.exports.prototype = {
     check: function(file, errors) {
         var operators = this._operatorIndex;
 
-        function errorIfApplicable(token, i, tokens, operator) {
-            var nextToken = tokens[i + 1];
-
-            if (token && nextToken && nextToken.range[0] === token.range[1]) {
-                var loc = token.loc.start;
-
-                errors.add(
-                    'Operator ' + operator + ' should not stick to following expression',
-                    loc.line,
-                    tokenHelper.getPointerEntities(loc.column, token.value.length)
-                );
-            }
-        }
-
         // Comma
         if (operators[',']) {
-            file.iterateTokensByType('Punctuator', function(token, i, tokens) {
-                var operator = token.value;
-                if (operator !== ',') {
-                    return;
+            file.iterateTokensByType('Punctuator', function(token) {
+                if (token.value === ',') {
+                    errors.assert.whitespaceBetween({
+                        token: token,
+                        nextToken: file.getNextToken(token),
+                        message: 'Operator , should not stick to following expression'
+                    });
                 }
-
-                errorIfApplicable(token, i, tokens, operator);
             });
         }
 
@@ -61,34 +47,34 @@ module.exports.prototype = {
         file.iterateNodesByType(
             ['BinaryExpression', 'AssignmentExpression', 'VariableDeclarator', 'LogicalExpression'],
             function(node) {
-                var isDec = node.type === 'VariableDeclarator';
-                var operator = isDec ? '=' : node.operator;
+                var operator;
+                var expression;
 
-                if (!operators[operator] || node.init === null) {
+                if (node.type === 'VariableDeclarator') {
+                    expression = node.init;
+                    operator = '=';
+                } else {
+                    operator = node.operator;
+                    expression = node.right;
+                }
+
+                if (expression === null) {
                     return;
                 }
 
-                var range = (isDec ? node.init : node.right).range[0];
-
-                var indent = tokenHelper.isTokenParenthesis(file, range - 1, true) ?
-                    operator.length + 1 :
-                    operator.length;
-
-                var part = tokenHelper.getTokenByRangeStartIfPunctuator(
-                    file,
-                    range - indent,
-                    operator,
-                    true
+                var operatorToken = file.findPrevOperatorToken(
+                    file.getFirstNodeToken(expression),
+                    operator
                 );
 
-                if (part) {
-                    var loc = part.loc.start;
+                var nextToken = file.getNextToken(operatorToken);
 
-                    errors.add(
-                        'Operator ' + operator + ' should not stick to following expression',
-                        loc.line,
-                        tokenHelper.getPointerEntities(loc.column, operator.length)
-                    );
+                if (operators[operator]) {
+                    errors.assert.whitespaceBetween({
+                        token: operatorToken,
+                        nextToken: nextToken,
+                        message: 'Operator ' + node.operator + ' should not stick to following expression'
+                    });
                 }
             }
         );

--- a/lib/rules/require-space-before-binary-operators.js
+++ b/lib/rules/require-space-before-binary-operators.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 var allOperators = require('../../lib/utils').binaryOperators.filter(function(operator) {
     return operator !== ',';
 });
@@ -33,29 +32,16 @@ module.exports.prototype = {
     check: function(file, errors) {
         var operators = this._operatorIndex;
 
-        function errorIfApplicable(token, i, tokens, operator) {
-            var prevToken = tokens[i - 1];
-
-            if (prevToken && prevToken.range[1] === token.range[0]) {
-                var loc = token.loc.start;
-
-                errors.add(
-                    'Operator ' + operator + ' should not stick to preceding expression',
-                    loc.line,
-                    tokenHelper.getPointerEntities(loc.column, token.value.length)
-                );
-            }
-        }
-
         // Comma
         if (operators[',']) {
-            file.iterateTokensByType('Punctuator', function(token, i, tokens) {
-                var operator = token.value;
-                if (operator !== ',') {
-                    return;
+            file.iterateTokensByType('Punctuator', function(token) {
+                if (token.value === ',') {
+                    errors.assert.whitespaceBetween({
+                        token: file.getPrevToken(token),
+                        nextToken: token,
+                        message: 'Operator , should not stick to preceding expression'
+                    });
                 }
-
-                errorIfApplicable(token, i, tokens, operator);
             });
         }
 
@@ -63,23 +49,34 @@ module.exports.prototype = {
         file.iterateNodesByType(
             ['BinaryExpression', 'AssignmentExpression', 'VariableDeclarator', 'LogicalExpression'],
             function(node) {
-                var isDec = node.type === 'VariableDeclarator';
-                var operator = isDec ? '=' : node.operator;
+                var operator;
+                var expression;
 
-                if (!operators[operator]) {
+                if (node.type === 'VariableDeclarator') {
+                    expression = node.init;
+                    operator = '=';
+                } else {
+                    operator = node.operator;
+                    expression = node.right;
+                }
+
+                if (expression === null) {
                     return;
                 }
 
-                var range = (isDec ? node.id : node.left).range[1];
-                var part = tokenHelper.getTokenByRangeStartIfPunctuator(file, range, operator);
+                var operatorToken = file.findPrevOperatorToken(
+                    file.getFirstNodeToken(expression),
+                    operator
+                );
 
-                if (part) {
-                    var loc = part.loc.start;
-                    errors.add(
-                        'Operator ' + operator + ' should not stick to following expression',
-                        loc.line,
-                        tokenHelper.getPointerEntities(loc.column, operator.length)
-                    );
+                var prevToken = file.getPrevToken(operatorToken);
+
+                if (operators[operator]) {
+                    errors.assert.whitespaceBetween({
+                        token: prevToken,
+                        nextToken: operatorToken,
+                        message: 'Operator ' + node.operator + ' should not stick to preceding expression'
+                    });
                 }
             }
         );

--- a/lib/rules/require-trailing-comma.js
+++ b/lib/rules/require-trailing-comma.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var tokenHelper = require('../token-helper');
 
 module.exports = function() {};
 
@@ -38,24 +37,27 @@ module.exports.prototype = {
 
         file.iterateNodesByType(['ObjectExpression', 'ArrayExpression'], function(node) {
             var isObject = node.type === 'ObjectExpression';
-            var message = 'Missing comma before closing ' + (isObject ? ' curly brace' : ' bracket');
             var entities = isObject ? node.properties : node.elements;
-            var last;
-            var hasTrailingComma;
 
-            if (entities.length) {
-                if (_this._ignoreSingleValue && entities.length === 1 ||
-                    _this._ignoreSingleLine && node.loc.start.line === node.loc.end.line) {
-                    return;
-                }
-
-                last = entities[entities.length - 1];
-                hasTrailingComma = tokenHelper.getTokenByRangeStartIfPunctuator(file, last.range[1], ',');
-
-                if (!hasTrailingComma) {
-                    errors.add(message, node.loc.end);
-                }
+            if (entities.length === 0) {
+                return;
             }
+
+            if (_this._ignoreSingleValue && entities.length === 1) {
+                return;
+            }
+
+            if (_this._ignoreSingleLine && node.loc.start.line === node.loc.end.line) {
+                return;
+            }
+
+            var closingToken = file.getLastNodeToken(node);
+
+            errors.assert.tokenBefore({
+                token: closingToken,
+                expectedTokenBefore: {type: 'Punctuator', value: ','},
+                message: 'Missing comma before closing ' + (isObject ? ' curly brace' : ' bracket')
+            });
         });
     }
 

--- a/lib/rules/validate-parameter-separator.js
+++ b/lib/rules/validate-parameter-separator.js
@@ -19,60 +19,49 @@ module.exports.prototype = {
 
     check: function(file, errors) {
 
-        var tokens = file.getTokens();
-        var validateTokens = this._separator.split('');
-        var separatorBefore = validateTokens[0];
-        var separatorAfter = validateTokens[validateTokens.length - 1];
+        var separators = this._separator.split(',');
+        var whitespaceBeforeComma = Boolean(separators.shift());
+        var whitespaceAfterComma = Boolean(separators.pop());
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
 
-            node.params.forEach(function(param) {
+            node.params.forEach(function(paramNode) {
 
-                var paramTokenPos = file.getTokenPosByRangeStart(param.range[0]);
-                var punctuatorToken = tokens[paramTokenPos + 1];
+                var prevParamToken = file.getFirstNodeToken(paramNode);
+                var punctuatorToken = file.getNextToken(prevParamToken);
 
                 if (punctuatorToken.value === ',') {
 
-                    var nextParamToken = tokens[paramTokenPos + 2];
-
-                    if (separatorBefore === ',' &&
-                        punctuatorToken.range[0] !== param.range[1] &&
-                        param.loc.start.line === nextParamToken.loc.start.line) {
-
-                        errors.add(
-                            'Unexpected space after function parameter \'' + param.name + '\'',
-                            punctuatorToken.loc.start
-                        );
-                    } else if (separatorBefore === ' ' && punctuatorToken.range[0] === param.range[1]) {
-                        errors.add(
-                            'Missing space after function parameter \'' + param.name + '\'',
-                            punctuatorToken.loc.start
-                        );
-                    } else if (separatorBefore === ' ' && (punctuatorToken.range[0] - param.range[1]) > 1) {
-                        errors.add(
-                            'Unexpected space before function parameter \'' + param.name + '\'',
-                            param.loc.start
-                        );
+                    if (whitespaceBeforeComma) {
+                        errors.assert.whitespaceBetween({
+                            token: prevParamToken,
+                            nextToken: punctuatorToken,
+                            spaces: 1,
+                            message: 'Missing space after function parameter \'' + prevParamToken.value + '\''
+                        });
+                    } else {
+                        errors.assert.noWhitespaceBetween({
+                            token: prevParamToken,
+                            nextToken: punctuatorToken,
+                            message: 'Unexpected space after function parameter \'' + prevParamToken.value + '\''
+                        });
                     }
 
-                    if (separatorAfter === ',' &&
-                        punctuatorToken.range[1] < nextParamToken.range[0] &&
-                        param.loc.start.line === nextParamToken.loc.start.line) {
+                    var nextParamToken = file.getNextToken(punctuatorToken);
 
-                        errors.add(
-                            'Unexpected space before function parameter \'' + nextParamToken.value + '\'',
-                            nextParamToken.loc.start
-                        );
-                    } else if (separatorAfter === ' ' && punctuatorToken.range[1] === nextParamToken.range[0]) {
-                        errors.add(
-                            'Missing space before function parameter \'' + nextParamToken.value + '\'',
-                            nextParamToken.loc.start
-                        );
-                    } else if (separatorAfter === ' ' && (nextParamToken.range[0] - punctuatorToken.range[1]) > 1) {
-                        errors.add(
-                            'Unexpected space before function parameter \'' + nextParamToken.value + '\'',
-                            nextParamToken.loc.start
-                        );
+                    if (whitespaceAfterComma) {
+                        errors.assert.whitespaceBetween({
+                            token: punctuatorToken,
+                            nextToken: nextParamToken,
+                            spaces: 1,
+                            message: 'Missing space before function parameter \'' + nextParamToken.value + '\''
+                        });
+                    } else {
+                        errors.assert.noWhitespaceBetween({
+                            token: punctuatorToken,
+                            nextToken: nextParamToken,
+                            message: 'Unexpected space before function parameter \'' + nextParamToken.value + '\''
+                        });
                     }
                 }
             });

--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -1,0 +1,164 @@
+var utils = require('util');
+var EventEmitter = require('events').EventEmitter;
+
+/**
+ * Token assertions class.
+ *
+ * @name {TokenAssert}
+ * @param {JsFile} file
+ */
+function TokenAssert(file) {
+    EventEmitter.call(this);
+
+    this._file = file;
+}
+
+utils.inherits(TokenAssert, EventEmitter);
+
+/**
+ * Requires to have whitespace between specified tokens.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.nextToken
+ * @param {String} [options.message]
+ * @param {Number} [options.spaces] Amount of spaces between tokens.
+ */
+TokenAssert.prototype.whitespaceBetween = function(options) {
+    var token = options.token;
+    var nextToken = options.nextToken;
+    if (options.hasOwnProperty('spaces')) {
+        var spaces = options.spaces;
+        if (nextToken.loc.start.line !== token.loc.end.line ||
+            (nextToken.loc.start.column - token.loc.end.column) !== spaces
+        ) {
+            this.emit('error', {
+                message: options.message ||
+                    spaces + ' spaces required between ' + token.value + ' and ' + nextToken.value,
+                line: token.loc.end.line,
+                column: token.loc.end.column
+            });
+        }
+    } else {
+        if (nextToken.range[0] === token.range[1]) {
+            this.emit('error', {
+                message: options.message || 'Missing space between ' + token.value + ' and ' + nextToken.value,
+                line: token.loc.end.line,
+                column: token.loc.end.column
+            });
+        }
+    }
+};
+
+/**
+ * Requires to have no whitespace between specified tokens.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.nextToken
+ * @param {String} [options.message]
+ * @param {Boolean} [options.disallowNewLine=false]
+ */
+TokenAssert.prototype.noWhitespaceBetween = function(options) {
+    var token = options.token;
+    var nextToken = options.nextToken;
+    if (nextToken.range[0] !== token.range[1] &&
+        (options.disallowNewLine || token.loc.end.line === nextToken.loc.start.line)
+    ) {
+        this.emit('error', {
+            message: options.message || 'Unexpected whitespace between ' + token.value + ' and ' + nextToken.value,
+            line: token.loc.end.line,
+            column: token.loc.end.column
+        });
+    }
+};
+
+/**
+ * Requires tokens to be on the same line.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.nextToken
+ * @param {String} [options.message]
+ */
+TokenAssert.prototype.sameLine = function(options) {
+    var token = options.token;
+    var nextToken = options.nextToken;
+    if (token.loc.end.line !== nextToken.loc.start.line) {
+        this.emit('error', {
+            message: options.message || token.value + ' and ' + nextToken.value + ' should be on the same line',
+            line: token.loc.end.line,
+            column: token.loc.end.column
+        });
+    }
+};
+
+/**
+ * Requires tokens to be on different lines.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.nextToken
+ * @param {Object} [options.message]
+ */
+TokenAssert.prototype.differentLine = function(options) {
+    var token = options.token;
+    var nextToken = options.nextToken;
+    if (token.loc.end.line === nextToken.loc.start.line) {
+        this.emit('error', {
+            message: options.message || token.value + ' and ' + nextToken.value + ' should be on different lines',
+            line: token.loc.end.line,
+            column: token.loc.end.column
+        });
+    }
+};
+
+/**
+ * Requires specific token before given.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.expectedTokenBefore
+ * @param {String} [options.message]
+ */
+TokenAssert.prototype.tokenBefore = function(options) {
+    var token = options.token;
+    var actualTokenBefore = this._file.getPrevToken(token);
+    var expectedTokenBefore = options.expectedTokenBefore;
+    if (
+        actualTokenBefore.type !== expectedTokenBefore.type ||
+        actualTokenBefore.value !== expectedTokenBefore.value
+    ) {
+        var message = options.message;
+        if (!message) {
+            var showTypes = expectedTokenBefore.value === actualTokenBefore.value;
+            message =
+                expectedTokenBefore.value + (showTypes ? ' (' + expectedTokenBefore.type + ')' : '') +
+                ' was expected before ' + token.value +
+                ' but ' + actualTokenBefore.value + (showTypes ? ' (' + actualTokenBefore.type + ')' : '') + ' found';
+        }
+        this.emit('error', {
+            message: message,
+            line: token.loc.start.line,
+            column: token.loc.start.column
+        });
+    }
+};
+/**
+ * Disallows specific token before given.
+ *
+ * @param {Object} options.token
+ * @param {Object} options.expectedTokenBefore
+ * @param {String} [options.message]
+ */
+TokenAssert.prototype.noTokenBefore = function(options) {
+    var token = options.token;
+    var actualTokenBefore = this._file.getPrevToken(token);
+    var expectedTokenBefore = options.expectedTokenBefore;
+    if (actualTokenBefore.type === expectedTokenBefore.type &&
+        actualTokenBefore.value === expectedTokenBefore.value
+    ) {
+        this.emit('error', {
+            message: options.message || 'Illegal ' + expectedTokenBefore.value + ' was found before ' + token.value,
+            line: token.loc.start.line,
+            column: token.loc.start.column
+        });
+    }
+};
+
+module.exports = TokenAssert;

--- a/test/rules/validate-parameter-separator.js
+++ b/test/rules/validate-parameter-separator.js
@@ -14,7 +14,7 @@ describe('rules/validate-parameter-separator', function() {
             ',',
             ' ,',
             ', ',
-            ' , ',
+            ' , '
         ];
 
         validSeparators.forEach(function(sep) {
@@ -30,7 +30,7 @@ describe('rules/validate-parameter-separator', function() {
             ',x',
             'x,x',
             '  ,',
-            ',  ',
+            ',  '
         ];
 
         invalidSeparators.forEach(function(sep) {

--- a/test/token-assert.js
+++ b/test/token-assert.js
@@ -1,0 +1,528 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var esprima = require('esprima');
+var JsFile = require('../lib/js-file');
+var TokenAssert = require('../lib/token-assert');
+
+describe('modules/token-assert', function() {
+
+    function createJsFile(sources) {
+        return new JsFile(
+            'example.js',
+            sources,
+            esprima.parse(sources, {loc: true, range: true, comment: true, tokens: true})
+        );
+    }
+
+    describe('whitespaceBetween', function() {
+        it('should trigger error on missing whitespace between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'Missing space between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should accept message for missing whitespace between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                message: 'Custom message'
+            });
+
+            assert(onError.getCall(0).args[0].message, 'Custom message');
+        });
+
+        it('should not trigger error on existing whitespace between tokens', function() {
+            var file = createJsFile('x = y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should trigger error on invalid space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                spaces: 2
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, '2 spaces required between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should trigger error on newline between tokens', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                spaces: 2
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, '2 spaces required between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on valid space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                spaces: 3
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for invalid space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                spaces: 2,
+                message: 'Custom message'
+            });
+
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+
+    describe('noWhitespaceBetween', function() {
+        it('should trigger error on existing whitespace between tokens', function() {
+            var file = createJsFile('x = y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noWhitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'Unexpected whitespace between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on newline between tokens', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noWhitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should trigger error on newline between tokens with disallowNewLine option', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noWhitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                disallowNewLine: true
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'Unexpected whitespace between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on missing whitespace between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noWhitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for existing space count between tokens', function() {
+            var file = createJsFile('x = y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noWhitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                message: 'Custom message'
+            });
+
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+
+    describe('sameLine', function() {
+        it('should trigger error on unexpected newline between tokens', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.sameLine({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'x and = should be on the same line');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on missing newline between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.sameLine({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for unexpected newline between tokens', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.sameLine({
+                token: tokens[0],
+                nextToken: tokens[1],
+                message: 'Custom message'
+            });
+
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+
+    describe('differentLine', function() {
+        it('should trigger error on missing newline between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.differentLine({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'x and = should be on different lines');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on existing newline between tokens', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.differentLine({
+                token: tokens[0],
+                nextToken: tokens[1]
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for missing newline between tokens', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.differentLine({
+                token: tokens[0],
+                nextToken: tokens[1],
+                message: 'Custom message'
+            });
+
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+
+    describe('tokenBefore', function() {
+        it('should trigger error on missing token value before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.tokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'z'
+                }
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'z was expected before = but x found');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should trigger error on missing token type before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.tokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Keyword',
+                    value: 'x'
+                }
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'x (Keyword) was expected before = but x (Identifier) found');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on correct token before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.tokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'x'
+                }
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for missing token before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.tokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'z'
+                },
+                message: 'Custom message'
+            });
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+
+    describe('noTokenBefore', function() {
+        it('should trigger error on illegal token value before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noTokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'x'
+                }
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'Illegal x was found before =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on missing token value before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noTokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'z'
+                }
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should not trigger error on missing token type before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noTokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Keyword',
+                    value: 'x'
+                }
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for illegal token before', function() {
+            var file = createJsFile('x=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.noTokenBefore({
+                token: tokens[1],
+                expectedTokenBefore: {
+                    type: 'Identifier',
+                    value: 'x'
+                },
+                message: 'Custom message'
+            });
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
+    });
+});


### PR DESCRIPTION
I attempted to start work on autofixing.

The main idea is to implement autofixing with least pain/overhead as it is possible. This is the very start of the work.

My plan:
- [x] 1. Asssertions in `Errors` object. Collecting use-cases for the assertions (which can be used for further autofixing) and implementing them. The assertions API must be as generic as possible (to be able to implement further autofixing in different ways).
- [x] 2. Integrate assertions into the rules (instead of `errors.add()`). I realize that is will not cover 100% of the cases, but it is OK for now.
- [x] 3. Cover assertions with tests.
- [x] 4. Merge this to JSCS code to allow people use better assertions.
- [ ] 5. Implement autofixing based on the assertions (join tokens on specified assertions). Introduce CLI option.
- [ ] 6. Cover autofixing with tests.

@mikesherov, @markelog, @mrjoelkemp, I need your attention, guys!

Relates to #516
