### PR TITLE
Failing test for exprima harmony parsing.

### DIFF
--- a/test/js-file.js
+++ b/test/js-file.js
@@ -1,8 +1,21 @@
 var assert = require('assert');
 var esprima = require('esprima');
+var harmonyEsprima = require('esprima-harmony-jscs');
 var JsFile = require('../lib/js-file');
 
 describe('modules/js-file', function() {
+    it('should return valid list of VariableDeclaration', function() {
+        var str = 'export function foo() { var a = "b"; }; function bar() { var b = "c"; }';
+        var file = new JsFile(null, str, harmonyEsprima.parse(str, {loc: true, range: true, tokens: true}));
+
+        var count = 0;
+        file.iterateNodesByType('VariableDeclaration', function(node) {
+            count++;
+        });
+
+        assert.equal(count, 2);
+    });
+
     it('should fix token array for object keys', function() {
         var str = '({ for: 42 })';
         var file = new JsFile(null, str, esprima.parse(str, {loc: true, range: true, tokens: true}));


### PR DESCRIPTION
It appears that something is going on with the parsing of `export function foo() { };` statements with harmony esprima builds.

I am not terribly familiar with how this works internally, so hopefully this failing test points someone in the right direction.  Also, it is entirely possible that this has nothing to do with JSCS (and is an issue upstream with esprima harmony branch somehow), if that is the case feel free to close this.
