### PR TITLE
requireOperatorBeforeLineBreak: bug fix

### DIFF
--- a/lib/rules/require-operator-before-line-break.js
+++ b/lib/rules/require-operator-before-line-break.js
@@ -35,9 +35,7 @@ module.exports.prototype = {
         var tokens = file.getTokens();
         var throughTokens = ['?', ','];
 
-        function errorIfApplicable(token, i, tokens) {
-            var prevToken = tokens[i - 1];
-
+        function errorIfApplicable(token, prevToken) {
             if (prevToken && prevToken.loc.end.line !== token.loc.start.line) {
                 var loc = token.loc.start;
 
@@ -60,7 +58,7 @@ module.exports.prototype = {
                 if (throughTokens.every(function() {
                     return throughTokens.indexOf(operator) >= 0;
                 })) {
-                    errorIfApplicable(token, i, tokens, operator);
+                    errorIfApplicable(token, tokens[i - 1]);
                 }
             });
         }
@@ -76,14 +74,14 @@ module.exports.prototype = {
 
                 var token = tokenHelper.findOperatorByRangeStart(
                     file,
-                    node.left.argument ? node.left.argument.range[0] : node.left.range[0],
-                    operator
+                    node.argument ? node.argument.range[0] : node.right.range[0],
+                    operator,
+                    true
                 );
 
                 errorIfApplicable(
                     token,
-                    tokens.indexOf(token),
-                    tokens
+                    tokens[tokens.indexOf(token) - 1]
                 );
             }
         );

--- a/test/rules/require-operator-before-line-break.js
+++ b/test/rules/require-operator-before-line-break.js
@@ -61,4 +61,8 @@ describe('rules/require-operator-before-line-break', function() {
         checker.configure({ requireOperatorBeforeLineBreak: ['?', '+'] });
         assert(checker.checkString('test === "null" \n? +test + "" : test').getErrorCount() === 1);
     });
+    it('should report after a binary operator with a literal on the left hand side #733', function() {
+        checker.configure({ requireOperatorBeforeLineBreak: true });
+        assert(checker.checkString('var err = "Cannot call " + modelName \n + " !";').getErrorCount() === 1);
+    });
 });


### PR DESCRIPTION
It failed to detect the binary operator after a literal and a line break

Fixes #733
