### PR TITLE
s/after/before

### DIFF
--- a/README.md
+++ b/README.md
@@ -1375,7 +1375,7 @@ Requires an empty line above the specified keywords unless the keyword is the fi
 
 Type: `Array` or `Boolean`
 
-Values: Array of quoted types or `true` to require padding new lines after all of the keywords below.
+Values: Array of quoted types or `true` to require padding new lines before all of the keywords below.
 
 #### Example
 


### PR DESCRIPTION
Now the copy correctly corresponds to the syntax of the rule.
