### PR TITLE
Presets: Remove use of outdated validateJSDoc rule

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -57,12 +57,6 @@
     "disallowSpacesInsideArrayBrackets": "all",
     "disallowSpacesInsideParentheses": true,
 
-
-    "validateJSDoc": {
-        "checkParamNames": true,
-        "requireParamTypes": true
-    },
-
     "disallowMultipleLineBreaks": true,
     "disallowNewlineBeforeBlockStatements": true
 }

--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -85,11 +85,6 @@
     "disallowSpacesInsideObjectBrackets": true,
     "disallowQuotedKeysInObjects": true,
 
-    "validateJSDoc": {
-        "checkParamNames": true,
-        "requireParamTypes": true
-    },
-
     "maximumLineLength": {
         "value": 120,
         "allowUrlComments": true


### PR DESCRIPTION
The rule has a bug that prevents ordinary use of docblocks claiming that
a param type is incorrect. It's better to use the actual jscs-jsdoc plugin.

Fixes #778
