### PR TITLE
Added test and patch for `finally` as a spaced keyword

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,6 +78,7 @@ exports.spacedKeywords = [
     'case',
     'try',
     'catch',
+    'finally',
     'void',
     'while',
     'with',

--- a/test/rules/require-space-after-keywords.js
+++ b/test/rules/require-space-after-keywords.js
@@ -91,6 +91,7 @@ describe('rules/require-space-after-keywords', function() {
         assert(!checker.checkString('switch (){ case\'4\': break;}').isEmpty());
         assert(!checker.checkString('try{}').isEmpty());
         assert(!checker.checkString('try {} catch{}').isEmpty());
+        assert(!checker.checkString('try {} catch (e) {} finally{}').isEmpty());
         assert(!checker.checkString('void(0)').isEmpty());
         assert(!checker.checkString('while(x) {}').isEmpty());
         assert(!checker.checkString('with(){}').isEmpty());


### PR DESCRIPTION
While generating a new `.jscsrc` for personal use, I noticed that `finally` is not in the list of spaced keyword for `requireSpaceAfterKeywords`

https://github.com/twolfson/node-jscs/tree/v1.7.3#requirespaceafterkeywords

Upon evaluation of the source code, I didn't find it inside of `spacedKeywords` either. To remedy this, I have added a test and added `finally` to the list.
