### PR TITLE
Fixed false positive during for `require-space-after-keywords` test

### DIFF
--- a/test/rules/require-space-after-keywords.js
+++ b/test/rules/require-space-after-keywords.js
@@ -90,7 +90,7 @@ describe('rules/require-space-after-keywords', function() {
         assert(!checker.checkString('switch(){ case 4: break;}').isEmpty());
         assert(!checker.checkString('switch (){ case\'4\': break;}').isEmpty());
         assert(!checker.checkString('try{}').isEmpty());
-        assert(!checker.checkString('try {} catch{}').isEmpty());
+        assert(!checker.checkString('try {} catch(e){}').isEmpty());
         assert(!checker.checkString('void(0)').isEmpty());
         assert(!checker.checkString('while(x) {}').isEmpty());
         assert(!checker.checkString('with(){}').isEmpty());


### PR DESCRIPTION
During the creation of #782, I noticed a false positive for the test above it. The following statement is not asserting the expected error but a parsing error:

``` js
console.log(checker.checkString('try {} catch{}'));
{ _errorList: 
   [ { filename: 'input',
       rule: 'parseError',
       message: 'Unexpected token {',
       line: 1,
       column: 13 } ],
  _file: 
   { _filename: 'input',
     _source: 'try {} catch{}',
     _tree: { tokens: [] },
     _lines: [ 'try {} catch{}' ],
     _tokenIndex: {},
     _index: {},
     _disabledRuleIndex: [] },
  _currentRule: 'parseError',
  _verbose: false }
```

Upon introducing an error variable (i.e. `CatchClause`), the error message goes to the proper form:

``` js
console.log(checker.checkString('try {} catch(e){}'));
{ _errorList: 
   [ { filename: 'input',
       rule: 'requireSpaceAfterKeywords',
       message: 'Missing space after "catch" keyword',
       line: 1,
       column: 12 } ],
  _file: 
   { _filename: 'input',
     _source: 'try {} catch(e){}',
     _tree: 
      { type: 'Program',
        body: [Object],
        range: [Object],
        loc: [Object],
        comments: [],
        tokens: [Object],
        parentNode: undefined,
        parentCollection: undefined },
     _lines: [ 'try {} catch(e){}' ],
     _tokenIndex: 
      { '0': 0,
        '4': 1,
        '5': 2,
        '7': 3,
        '12': 4,
        '13': 5,
        '14': 6,
        '15': 7,
        '16': 8 },
     _index: 
      { Program: [Object],
        TryStatement: [Object],
        BlockStatement: [Object],
        CatchClause: [Object] },
     _disabledRuleIndex: [] },
  _currentRule: 'requireSpaceAfterKeywords',
  _verbose: false }
```
