### PR TITLE
Add exceptions for require-padding-newlines-before-keyword

### DIFF
--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -24,6 +24,7 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var excludedTokens = [':', ',', '(', '='];
         var keywordIndex = this._keywordIndex;
 
         file.iterateTokensByType('Keyword', function(token, i, tokens) {
@@ -32,6 +33,9 @@ module.exports.prototype = {
 
                 // Handle special case of 'else if' construct.
                 if (token.value === 'if' && prevToken && prevToken.value === 'else') {
+                    return;
+                // Handling for special cases.
+                } else if (prevToken && excludedTokens.indexOf(prevToken.value) > -1) {
                     return;
                 }
 

--- a/test/rules/require-padding-newlines-before-keywords.js
+++ b/test/rules/require-padding-newlines-before-keywords.js
@@ -112,6 +112,40 @@ describe('rules/require-padding-newlines-before-keywords', function() {
             );
         });
 
+        it('should not report in object definitions', function() {
+            assert(
+                checker.checkString(
+                    'var obj = {\n' +
+                    '  foo: function x() { return; }\n' +
+                    '};'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report when parameter inside a function', function() {
+            assert(
+                checker.checkString(
+                    'watchlist.on( "watch", function () {} );'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report when assigned to a variable', function() {
+            assert(
+                checker.checkString(
+                    ' Router.prototype.getPath = function () {};'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report when used inside closure', function() {
+            assert(
+                checker.checkString(
+                    '( function ( $ ) {} )( jQuery );'
+                ).isEmpty()
+            );
+        });
+
         it('should report on matching return statement', function() {
             assert(
                 checker.checkString(


### PR DESCRIPTION
1) var x = {
    foo: function {}
};

2) watchlist.on( "watch", function () {} );
3) Router.prototype.getPath = function () {};
4) (function ( $ ) {} )( jQuery );
These should all not report errors.

Fixes: #779
