### PR TITLE
Ensure ES3 keywords `undefined` & `arguments` don't require dot notation

### DIFF
--- a/lib/rules/require-dot-notation.js
+++ b/lib/rules/require-dot-notation.js
@@ -37,7 +37,10 @@ module.exports.prototype = {
                 value === 'true' ||
                 value === 'false' ||
                 utils.isEs3Keyword(value) ||
-                utils.isEs3FutureReservedWord(value)
+                utils.isEs3FutureReservedWord(value) ||
+                // IE 6 - 8 throws a SyntaxError if arguments or undefined are used with dot notation
+                value === 'arguments' ||
+                value === 'undefined'
             ) {
                 return;
             }

--- a/test/rules/require-dot-notation.js
+++ b/test/rules/require-dot-notation.js
@@ -22,6 +22,8 @@ describe('rules/require-dot-notation', function() {
         assert(checker.checkString('var x = a["null"]').isEmpty());
         assert(checker.checkString('var x = a["true"]').isEmpty());
         assert(checker.checkString('var x = a["false"]').isEmpty());
+        assert(checker.checkString('var x = a["undefined"]').isEmpty());
+        assert(checker.checkString('var x = a["arguments"]').isEmpty());
     });
 
     it('should not report number subscription', function() {


### PR DESCRIPTION
Relates to #161.
