### PR TITLE
Preset: Fix crockford rules.

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -59,6 +59,7 @@
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
+    "disallowYodaConditions": true,
     "disallowNewlineBeforeBlockStatements": true,
     "disallowMultipleLineStrings": true
 }


### PR DESCRIPTION
Found some issues with the Crockford rules, so I fixed them.

Changes and justifications are summarized below:
- `requireBlocksOnNewline` should be true.

The from Code Conventions for the JavaScript Programming Language, the specification for functions is:

> There should be no space between the name of a function and the ( (left parenthesis) of its parameter list. There should be one space between the ) (right parenthesis) and the { (left curly brace) that begins the statement body. The body itself is indented four spaces. The } (right curly brace) is aligned with the line containing the beginning of the declaration of the function.

It makes no exception for slick one-liners. It asserts "The body itself is indented four spaces." Therefore, allowing the body of a block not to be indented 4 spaces is a style error.
- `disallowSpaceAfterObjectKeys` should not be specified.

Code Conventions does not mention this. Crockford sometimes uses spaces for alignment, as in [jslint.js](https://github.com/douglascrockford/JSLint/blob/master/jslint.js#L288).
- `disallowQuotedKeysInObjects` should not be specified.

Code Conventions does not mention this.
- Add `continue` to the disallowed keywords.

Code Conventions says:

> Avoid use of the continue statement. It tends to obscure the control flow of the function.

Because it is discouraged, transgressors can use jscs disabling comments judiciously, and otherwise still be warned.
- `disallowMultipleLineStrings` should be enabled.

Code Conventions does not mention this, though [Crockford warns strongly against it](http://youtu.be/_EANG8ZZbRs?t=33m32s).
- `validateQuoteMarks` should not be specified.

Code Conventions does not mandate one type of quotation mark, nor is Crockford adding it to JSLint, and he uses the two types interchangeably.
- `disallowYodaConditions` should not be specified.

Code Conventions does not mention this.
- `requireCamelCaseOrUpperCaseIdentifiers` should not be specified.

Code Conventions does not mandate this, nor is Crockford adding it to JSLint, and he uses underscores to separate words.
