### PR TITLE
requireMultipleVarDecl to disallowMultipleVarDecl

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -30,7 +30,7 @@
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
-    "requireMultipleVarDecl": "onevar",
+    "disallowMultipleVarDecl": true,
     "requireBlocksOnNewline": 1,
     "requireCommaBeforeLineBreak": true,
     "requireSpaceBeforeBinaryOperators": true,


### PR DESCRIPTION
Following new Aribnb variable guidelines as currently stated in https://github.com/airbnb/javascript#variables referred in this commit: https://github.com/airbnb/javascript/commit/8d51bd504b3d64e551f28a2b5bfbd98f1605f131
