### PR TITLE
disallowSpaceBeforeBlockStatements: fix if/else

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,8 @@ Values: `true`
 ```js
 if (cond){
     foo();
+} else{
+    bar();
 }
 
 for (var e in elements){
@@ -594,6 +596,8 @@ while (cond){
 ```js
 if (cond) {
     foo();
+} else {
+    bar();
 }
 
 for (var e in elements) {

--- a/lib/rules/disallow-space-before-block-statements.js
+++ b/lib/rules/disallow-space-before-block-statements.js
@@ -19,12 +19,15 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var tokens = file.getTokens();
-
         file.iterateNodesByType('BlockStatement', function(node) {
-            var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.range[0] - 1);
-            var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-            if (!tokenBeforeBody) {
+            var body = file.getTokenByRangeStart(node.range[0]);
+            var previous = file.getPrevToken(body);
+
+            // A bare block can start the file with no space before it
+            var noSpaceBeforeFirstTokenInFile = !previous && body.range[0] > 0;
+            var noSpaceBeforeToken = previous && previous.range[1] !== body.range[0];
+
+            if (noSpaceBeforeToken || noSpaceBeforeFirstTokenInFile) {
                 errors.add(
                     'Extra space before opening curly brace for block expressions',
                     node.loc.start

--- a/test/rules/disallow-space-before-block-statements.js
+++ b/test/rules/disallow-space-before-block-statements.js
@@ -16,6 +16,69 @@ describe('rules/disallow-space-before-block-statements', function() {
         assert(checker.checkString('if (true){ var a = false; }').getErrorCount() === 0);
     });
 
+    it('should report missing space for control structures with multiple branches', function() {
+        assert(checker.checkString(
+          'if (true) {\n' +
+          '    var a = false;\n' +
+          '} else {\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 2, 'incorrect if and else');
+
+        assert(checker.checkString(
+          'if (true) {\n' +
+          '    var a = false;\n' +
+          '}\n' +
+          'else{\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 1, 'incorrect if, correct else');
+
+        assert(checker.checkString(
+          'if (true) {\n' +
+          '    var a = false;\n' +
+          '}\n' +
+          'else if (true) {\n' +
+          '    var b = false;\n' +
+          '}\n' +
+          'else{\n' +
+          '    var c = false;\n' +
+          '}').getErrorCount() === 2, 'incorrect if & else if, correct else');
+
+        assert(checker.checkString(
+          'if (true){\n' +
+          '    var a = false;\n' +
+          '}\n' +
+          'else {\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 1, 'correct if, incorrect else');
+
+        assert(checker.checkString(
+          'if (true){\n' +
+          '    var a = false;\n' +
+          '}else{\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 0, 'no spaces: correct if and else');
+
+        assert(checker.checkString(
+          'if (true){\n' +
+          '    var a = false;\n' +
+          '}\n' +
+          'else{\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 0, 'stroustrup: correct if and else');
+
+        assert(checker.checkString(
+          'if (true){\n' +
+          '    var a = false;\n' +
+          '} else{\n' +
+          '    var b = false;\n' +
+          '}').getErrorCount() === 0, '1tbs: correct if and else');
+    });
+
+    it('should report missing space for bare blocks', function() {
+        assert(checker.checkString(' {}').getErrorCount() === 1);
+        assert(checker.checkString('{}').getErrorCount() === 0);
+    });
+
     it('should report missing space for loops', function() {
         assert(checker.checkString('while (true) { var a = false; }').getErrorCount() === 1);
         assert(checker.checkString('while (true)\n{ var a = false; }').getErrorCount() === 1);


### PR DESCRIPTION
This rule did not correctly handle the case where there was an `if` with an
`else` or an `else if`. It also did not handle the rarer case where the file
started with a block.

Fixes #832