### PR TITLE
Relative path resolving fix. Fixes #829

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -49,12 +49,9 @@ Configuration.prototype.load = function(config) {
 
     var overrides = this._overrides;
     var currentConfig = {};
-    Object.keys(config).forEach(function(key) {
-        currentConfig[key] = config[key];
-    });
-    Object.keys(overrides).forEach(function(key) {
-        currentConfig[key] = overrides[key];
-    });
+
+    copyConfiguration(config, currentConfig);
+    copyConfiguration(overrides, currentConfig);
 
     var ruleSettings = this._processConfig(currentConfig);
     var processedSettings = {};
@@ -630,3 +627,12 @@ Configuration.prototype.registerDefaultPresets = function() {
 };
 
 module.exports = Configuration;
+
+function copyConfiguration(source, dest) {
+    Object.keys(source).forEach(function(key) {
+        dest[key] = source[key];
+    });
+    if (source.configPath) {
+        dest.configPath = source.configPath;
+    }
+}

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,7 +2,6 @@ var hooker = require('hooker');
 var sinon = require('sinon');
 var glob = require('glob');
 var assert = require('assert');
-var Vow = require('vow');
 var hasAnsi = require('has-ansi');
 var rewire = require('rewire');
 
@@ -41,7 +40,13 @@ describe('modules/cli', function() {
 
     function assertNoCliErrors(vow) {
         return vow.promise.always(function() {
-            assert(console.log.getCall(0).args[0] === 'No code style errors found.');
+            var stdout = process.stdout.write.getCall(0) ? process.stdout.write.getCall(0).args[0] : '';
+            var stderr = process.stderr.write.getCall(0) ? process.stderr.write.getCall(0).args[0] : '';
+            assert.equal(
+                stdout,
+                'No code style errors found.\n',
+                stderr
+            );
             rAfter();
         });
     }
@@ -578,7 +583,7 @@ describe('modules/cli', function() {
 
         it('should accept a relative path to a filter module', function() {
             return assertNoCliErrors(cli({
-                errorFilter: './test/data/error-filter.js',
+                errorFilter: '../error-filter.js',
                 args: ['test/data/cli/error.js'],
                 config: 'test/data/cli/cli.json'
             }));
@@ -624,6 +629,15 @@ describe('modules/cli', function() {
                 args: ['test/data/cli/esnext.js'],
                 esprima: 'esprima-harmony-jscs',
                 config: 'test/data/cli/cli.json'
+            }));
+        });
+    });
+
+    describe('additionalRules', function() {
+        it('should correctly handle additionalRules paths', function() {
+            return assertNoCliErrors(cli({
+                args: ['test/data/cli/success.js'],
+                config: 'test/data/configs/additionalRules/.jscsrc'
             }));
         });
     });

--- a/test/data/cli/errorFilter.json
+++ b/test/data/cli/errorFilter.json
@@ -1,4 +1,4 @@
 {
-  "errorFilter": "./test/data/error-filter.js",
+  "errorFilter": "../error-filter.js",
   "disallowKeywords": ["with"]
 }

--- a/test/data/configs/additionalRules/.jscs.json
+++ b/test/data/configs/additionalRules/.jscs.json
@@ -1,6 +1,0 @@
-{
-    "testAdditionalRules": true,
-    "additionalRules": [
-        "../../rules/*.js"
-    ]
-}

--- a/test/data/configs/additionalRules/.jscsrc
+++ b/test/data/configs/additionalRules/.jscsrc
@@ -1,0 +1,6 @@
+{
+    "successRule": true,
+    "additionalRules": [
+        "./success-rule.js"
+    ]
+}

--- a/test/data/configs/additionalRules/success-rule.js
+++ b/test/data/configs/additionalRules/success-rule.js
@@ -1,0 +1,12 @@
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function() {},
+
+    getOptionName: function() {
+        return 'successRule';
+    },
+
+    check: function(file, errors) {}
+};


### PR DESCRIPTION
Currently `configPath` was not copied because it was implemented as `property` :disappointed: 

I did not change the nature of `configPath`, but fixed its flow. Except `additionalRules` fix, I also fixed `errorFilter` tests, because they tested for the wrong behaviour.
