### PR TITLE
Update wikimedia preset

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -8,20 +8,8 @@
         "try",
         "catch"
     ],
-    "requireSpaceAfterKeywords": [
-        "if",
-        "else",
-        "for",
-        "while",
-        "do",
-        "switch",
-        "case",
-        "return",
-        "try",
-        "catch",
-        "function",
-        "typeof"
-    ],
+    "requireSpaceBeforeKeywords": true,
+    "requireSpaceAfterKeywords": true,
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
@@ -31,52 +19,51 @@
     "disallowSpacesInFunctionDeclaration": {
         "beforeOpeningRoundBrace": true
     },
+    "disallowSpacesInCallExpression": true,
     "requireMultipleVarDecl": "onevar",
     "requireBlocksOnNewline": 1,
     "disallowEmptyBlocks": true,
     "requireSpacesInsideObjectBrackets": "all",
     "requireSpacesInsideArrayBrackets": "all",
-    "disallowQuotedKeysInObjects": true,
+    "requireSpacesInsideParentheses": "all",
+    "disallowQuotedKeysInObjects": "allButReserved",
     "disallowDanglingUnderscores": true,
     "disallowSpaceAfterObjectKeys": true,
+    "requireSpaceBeforeObjectValues": true,
     "requireCommaBeforeLineBreak": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "disallowSpaceBeforeBinaryOperators": [
         ","
     ],
-    "requireSpaceBeforeBinaryOperators": [
-        "=",
-        "+=",
-        "-=",
-        "+",
-        "-",
-        "*",
-        "/",
-        "&&",
-        "||",
-        "===",
-        "==",
-        ">=",
-        "<=",
-        ">",
-        "<",
-        "!=",
-        "!=="
-    ],
+    "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceAfterBinaryOperators": true,
+    "disallowImplicitTypeConversion": [
+        "binary",
+        "string"
+    ],
     "requireCamelCaseOrUpperCaseIdentifiers": true,
-    "disallowKeywords": [ "with" ],
+    "disallowKeywords": [
+        "with"
+    ],
     "disallowMultipleLineBreaks": true,
-    "validateLineBreaks": "LF",
-    "validateQuoteMarks": "'",
-    "validateIndentation": "\t",
     "disallowMixedSpacesAndTabs": true,
+    "disallowOperatorBeforeLineBreak": [
+        "."
+    ],
     "disallowTrailingWhitespace": true,
     "disallowTrailingComma": true,
-    "disallowKeywordsOnNewLine": [ "else" ],
+    "disallowKeywordsOnNewLine": [
+        "else"
+    ],
+    "requireLineBreakAfterVariableAssignment": true,
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
-    "disallowYodaConditions": true
+    "disallowYodaConditions": true,
+    "requireSpaceAfterLineComment": true,
+    "disallowNewlineBeforeBlockStatements": true,
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": "'",
+    "validateIndentation": "\t"
 }

--- a/test/data/options/preset/wikimedia.js
+++ b/test/data/options/preset/wikimedia.js
@@ -2,7 +2,13 @@
 	var APP,
 		hasOwn = Object.prototype.hasOwnProperty;
 
+	// Empty function declaration
 	function upHere() {}
+
+	// Non-empty function declaration
+	function upHereAlso( y ) {
+		return y;
+	}
 
 	/**
 	 * Example description.
@@ -19,10 +25,14 @@
 
 		this.total = upHere() + id;
 
-		name = options.bar ? upHere( id ) : id;
+		name = options.bar ? upHereAlso( id ) : id;
 
 		if ( options.quux ) {
 			name += options.quux;
+		} else if ( options.quux ) {
+			name += options.quux;
+		} else {
+			name += 'default';
 		}
 
 		if ( bar &&
@@ -32,6 +42,16 @@
 		) {
 			return;
 		}
+
+		// One line function
+		inline = function ( items ) { return items.slice(); };
+
+		// Multi-line function
+		inline = function ( items ) {
+			items = items.slice();
+			items.pop();
+			return items;
+		};
 
 		inline = function named( items ) {
 			try {
@@ -49,6 +69,7 @@
 
 	APP.loop = function ( items ) {
 		var i, len, item, key,
+			j = 1,
 			ret = {};
 
 		for ( i = 0, len = items.length; i < len; i++ ) {
@@ -68,6 +89,11 @@
 			}
 		}
 
+		do {
+			j = i++;
+			APP.fall( --j );
+		} while ( i < 5 );
+
 		return ret;
 	};
 
@@ -80,11 +106,34 @@
 		}
 	};
 
+	APP.cast = function ( options, val ) {
+		options.enable = !!val;
+		options.disable = Boolean( val );
+
+		options.posX = +val;
+		options.posY = Number( val );
+
+		options.title = String( val );
+
+		return options.title.indexOf( '.' ) !== -1;
+	};
+
 	APP.example = new APP.Example( 'banana', {
 		first: 'Who',
 		second: 'What',
-		third: 'I don\'t know'
+		third: 'I don\'t know',
+		'default': 'Legacy'
 	} );
+
+	APP.example( 'banana' )
+		.done( function () { } );
+
+	APP.example( 'banana' )
+		.done( function () {} )
+		.fail( function () {} );
+
+	APP.$head
+		.appendTo( APP.$element );
 
 	global.APP = APP;
 


### PR DESCRIPTION
Preset:
- requireSpaceBeforeKeywords: Add.
- requireSpaceAfterKeywords: Simplify by using true.
- disallowSpacesInCallExpression: Add.
- requireSpacesInsideParentheses: Add.
- disallowQuotedKeysInObjects: Change from all to allButReserved for ES3.
- requireSpaceBeforeBinaryOperators: Simplify by using true.  It was hardcoded as it used include ",", but that was fixed.
- disallowImplicitTypeConversion: Add, require explicit '!== -1'
  and String().
- disallowOperatorBeforeLineBreak: Add, place dots in chaining
  before line break.
- requireLineBreakAfterVariableAssignment: Add.
- requireSpaceAfterLineComment: Add.
- disallowNewlineBeforeBlockStatements: Add.

Test:
- Add example of space before keyword 'empty' and 'while'.
- Add example of one-line block.
- Add example of quoted ES3 reserved word object key.
- Add example of type converstion and method chaining.
