### PR TITLE
Perf: remove regenerate dependency

### DIFF
--- a/lib/rules/disallow-capitalized-comments.js
+++ b/lib/rules/disallow-capitalized-comments.js
@@ -1,13 +1,16 @@
 var assert = require('assert');
-var regenerate = require('regenerate');
-var Lu = require('unicode-6.3.0/categories/Lu/code-points');
-var Ll = require('unicode-6.3.0/categories/Ll/code-points');
-var Lt = require('unicode-6.3.0/categories/Lt/code-points');
-var Lm = require('unicode-6.3.0/categories/Lm/code-points');
-var Lo = require('unicode-6.3.0/categories/Lo/code-points');
+var Lu = require('unicode-6.3.0/categories/Lu/regex');
+var Ll = require('unicode-6.3.0/categories/Ll/regex');
+var Lt = require('unicode-6.3.0/categories/Lt/regex');
+var Lm = require('unicode-6.3.0/categories/Lm/regex');
+var Lo = require('unicode-6.3.0/categories/Lo/regex');
 
-var letterPattern = regenerate(Lu, Ll, Lt, Lm, Lo).toRegExp();
-var lowerCasePattern = regenerate(Ll).toRegExp();
+function letterPattern(char) {
+    return Lu.test(char) || Ll.test(char) || Lt.test(char) || Lm.test(char) || Lo.test(char);
+}
+function lowerCasePattern(char) {
+    return Ll.test(char);
+}
 
 module.exports = function() {};
 
@@ -28,7 +31,7 @@ module.exports.prototype = {
             var stripped = comment.value.replace(/[\n\s\*]/g, '');
             var firstChar = stripped[0];
 
-            if (letterPattern.test(firstChar) && !lowerCasePattern.test(firstChar)) {
+            if (letterPattern(firstChar) && !lowerCasePattern(firstChar)) {
                 errors.add(
                     'Comments must start with a lowercase letter',
                     comment.loc.start

--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -1,13 +1,16 @@
 var assert = require('assert');
-var regenerate = require('regenerate');
-var Lu = require('unicode-6.3.0/categories/Lu/code-points');
-var Ll = require('unicode-6.3.0/categories/Ll/code-points');
-var Lt = require('unicode-6.3.0/categories/Lt/code-points');
-var Lm = require('unicode-6.3.0/categories/Lm/code-points');
-var Lo = require('unicode-6.3.0/categories/Lo/code-points');
+var Lu = require('unicode-6.3.0/categories/Lu/regex');
+var Ll = require('unicode-6.3.0/categories/Ll/regex');
+var Lt = require('unicode-6.3.0/categories/Lt/regex');
+var Lm = require('unicode-6.3.0/categories/Lm/regex');
+var Lo = require('unicode-6.3.0/categories/Lo/regex');
 
-var letterPattern = regenerate(Lu, Ll, Lt, Lm, Lo).toRegExp();
-var upperCasePattern = regenerate(Lu).toRegExp();
+function letterPattern(char) {
+    return Lu.test(char) || Ll.test(char) || Lt.test(char) || Lm.test(char) || Lo.test(char);
+}
+function upperCasePattern(char) {
+    return Lu.test(char);
+}
 
 module.exports = function() {};
 
@@ -29,14 +32,14 @@ module.exports.prototype = {
         file.getComments().forEach(function(comment) {
             var stripped = comment.value.replace(/[\n\s\*]/g, '');
             var firstChar = stripped[0];
-            var isLetter = firstChar && letterPattern.test(firstChar);
+            var isLetter = firstChar && letterPattern(firstChar);
 
             if (!isLetter) {
                 inTextBlock = false;
                 return;
             }
 
-            var isUpperCase = upperCasePattern.test(firstChar);
+            var isUpperCase = upperCasePattern(firstChar);
             var isValid = isUpperCase || (inTextBlock && !isUpperCase);
 
             if (!isValid) {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "vow-fs": "~0.3.1",
     "xmlbuilder": "~2.4.0",
     "supports-color": "~1.2.0",
-    "unicode-6.3.0": "~0.1.5",
-    "regenerate": "~1.0.1"
+    "unicode-6.3.0": "~0.1.5"
   },
   "devDependencies": {
     "browserify": "~7.0.3",


### PR DESCRIPTION
Hi,

Having big performance issues by only creating a tiny gulp task, I decided to investigate.

My example:

``` js
var gulp = require('gulp');
var jscs = require('gulp-jscs');

gulp.task('cs', function() {
  return gulp.src('index.js')
    .pipe(jscs())
  ;
});
```

The content of index.js (yes, it is a very big file):

``` js
angular.module('my-app', [])
  .factory('$i18nCache', function($cacheFactory) {
    return $cacheFactory('i18n');
  })
;
```

… so nothing out of the ordinary.

I time the execution. The result: **3s on my desktop machine**… WTF?! O_O

So I profile the process to see what is going on. I stumble on this:

```
 [JavaScript]:
   ticks  total  nonlib   name
   1056   26.1%   58.3%  LazyCompile: dataAdd /home/etienne/work/glou/example/angular.app/node_modules/gulp-jscs/node_modules/jscs/node_modules/regenerate/regenerate.js:222
    262    6.5%   14.5%  Stub: KeyedLoadElementStub {1}
     92    2.3%    5.1%  RegExp: ^(\\/?|)([\\s\\S]*?)((?:\\.{1\,2}|[^\\/]+?|)(\\.[^.\\/]*|))(?:[\\/]*)$
     60    1.5%    3.3%  KeyedLoadIC: args_count: 0 {1}
     16    0.4%    0.9%  LazyCompile: Join native array.js:119
     13    0.3%    0.7%  LazyCompile: extend.add /home/etienne/work/glou/example/angular.app/node_modules/gulp-jscs/node_modules/jscs/node_modules/regenerate/regenerate.js:947
     12    0.3%    0.7%  Builtin: A builtin from the snapshot {1}
     10    0.2%    0.6%  Stub: CEntryStub
     10    0.2%    0.6%  RegExp: ^(\\/?|)([\\s\\S]*?)((?:\\.{1\,2}|[^\\/]+?|)(\\.[^.\\/]*|))(?:[\\/]*)$ {1}
      6    0.1%    0.3%  Stub: SubStringStub
      6    0.1%    0.3%  Stub: CompareICStub
```

etc…

**1056 ticks on the library: `regenerate`!
58.3% of total user execution!**

As I look into the only 2 rules using `regenerate`, maybe my understanding is wrong, but it seems that `regenerate` is unnecessary as the proper regexp are shipped along with `unicode`…

The fun thing? This tiny little patch improves the overall performance of JSCS **by a factor > 200** :)
