### PR TITLE
Preset: add 'catch' to "disallowKeywordsOnNewLine" rule for Wikimedia

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -54,7 +54,8 @@
     "disallowTrailingWhitespace": true,
     "disallowTrailingComma": true,
     "disallowKeywordsOnNewLine": [
-        "else"
+        "else",
+        "catch"
     ],
     "requireLineBreakAfterVariableAssignment": true,
     "requireLineFeedAtFileEnd": true,


### PR DESCRIPTION
We missed this one. :-)