### PR TITLE
New rule: requireQuotedKeysInObjects

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -539,6 +539,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-space-after-object-keys'));
     this.registerRule(require('../rules/disallow-space-before-object-values'));
     this.registerRule(require('../rules/disallow-quoted-keys-in-objects'));
+    this.registerRule(require('../rules/require-quoted-keys-in-objects'));
     this.registerRule(require('../rules/disallow-dangling-underscores'));
     this.registerRule(require('../rules/require-aligned-object-values'));
 

--- a/lib/rules/require-quoted-keys-in-objects.js
+++ b/lib/rules/require-quoted-keys-in-objects.js
@@ -1,0 +1,63 @@
+/**
+ * Requires quoted keys in objects.
+ *
+ * Type: `Boolean`
+ *
+ * Values:
+ *
+ *  - `true` for strict mode
+ *
+ * #### Example
+ *
+ * ```js
+ * "requiresQuotedKeysInObjects": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+  * var x = { 'a': { "default": 1 } };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var x = { a: 1 };
+ * ```
+ */
+
+var assert = require('assert');
+var utils = require('../utils');
+
+module.exports = function() { };
+
+module.exports.prototype = {
+
+    configure: function(requireQuotedKeysInObjects) {
+        assert(
+            typeof requireQuotedKeysInObjects === 'boolean',
+            this.getOptionName() + ' option requires boolean value'
+        );
+        assert(
+            requireQuotedKeysInObjects === true,
+            this.getOptionName() + ' option requires true value or should be removed'
+        );
+
+        this._mode = requireQuotedKeysInObjects;
+    },
+
+    getOptionName: function() {
+        return 'requireQuotedKeysInObjects';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            node.properties.forEach(function(prop) {
+                var key = prop.key;
+                if (!(typeof key.value === 'string' && key.type === 'Literal')) {
+                    errors.add('Object key without surrounding quotes', prop.loc.start);
+                }
+            });
+        });
+    }
+};

--- a/test/rules/require-quoted-keys-in-objects.js
+++ b/test/rules/require-quoted-keys-in-objects.js
@@ -1,0 +1,64 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-quoted-keys-in-objects', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requireQuotedKeysInObjects: true });
+    });
+
+    it('should report for object keys without quotes', function() {
+        assert(checker.checkString('var x = { a: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { B: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { _a: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { _abc_: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { _a1: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { a_a: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { 12: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { $: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { 0: 1 }').getErrorCount() === 1);
+        assert(checker.checkString('var x = { 6b2ea258-cf24-44fe-b857-c4e37e105d6f: 1 }').getErrorCount() === 1);
+    });
+
+    it('should not report if the key is surrounded by quotes', function() {
+        assert(checker.checkString('var x = { "a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "A": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "_abc": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "_a1": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "_abc_": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a_a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "12": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "$1": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a$b": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a 1": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a  a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a-a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a+a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { ".": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a..a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "a/a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "1a": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "1$": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "010": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "6b2ea258-cf24-44fe-b857-c4e37e105d6f": 1 }').isEmpty());
+        assert(checker.checkString('var x = { "default": 1, "class": "foo" }').isEmpty());
+        assert(checker.checkString('var x = { "null": 1, "undefined": "foo" }').isEmpty());
+    });
+
+    it('should check all keys in object', function() {
+        assert(checker.checkString('var x = { a: 1, "b": 2, c: 3 }').getErrorCount() === 2);
+    });
+
+    it('should correctly identify the error', function() {
+        var errors = checker.checkString('var x = { a: 1 }');
+        assert(errors.getErrorCount() === 1);
+
+        var error = errors.getErrorList()[0];
+        assert(error.message === 'Object key without surrounding quotes');
+        assert(error.line === 1);
+        assert(error.column === 10);
+    });
+});


### PR DESCRIPTION
If set to 'true', requires all object keys to be surrounded in
quotes. This is the opposite of disallowQuotedKeysInObjects.

Fixes #360 

Notes:
- This is my first PR to jscs, so please be liberal with the feedback. 
- I assume with the new website code, the documentation will get automatically picked up from the source file?