### PR TITLE
requireSpace(Before|After)BinaryOperators: Add tests for error column

### DIFF
--- a/test/rules/require-space-after-binary-operators.js
+++ b/test/rules/require-space-after-binary-operators.js
@@ -18,30 +18,42 @@ describe('rules/require-space-after-binary-operators', function() {
         var notStickedWithParenthesis = 'var test; (test) ' + operator + ' (2)';
 
         [[operator], true].forEach(function(value) {
+
             it('should report sticky operator for ' + sticked + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterBinaryOperators: [operator] });
                     assert(checker.checkString(sticked).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notSticked + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterBinaryOperators: [operator] });
                     assert(checker.checkString(notSticked).isEmpty());
                 }
             );
+
             it('should report sticky operator for ' + stickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterBinaryOperators: [operator] });
                     assert(checker.checkString(stickedWithParenthesis).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notStickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterBinaryOperators: [operator] });
                     assert(checker.checkString(notStickedWithParenthesis).isEmpty());
                 }
             );
+
+            it('should highlight the end of the ' + operator + ' operator', function() {
+                checker.configure({ requireSpaceAfterBinaryOperators: [operator] });
+                var error = checker.checkString(sticked).getErrorList()[0];
+                assert(error.line === 1);
+                assert(error.column === (14 + operator.length));
+                assert(error.message === ('Operator ' + operator + ' should not stick to following expression'));
+            });
         });
     });
 
@@ -49,34 +61,42 @@ describe('rules/require-space-after-binary-operators', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: [':'] });
         assert(checker.checkString('({ test:2 })').isEmpty());
     });
+
     it('should not report sticky operator ":" in ternary', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: [':'] });
         assert(checker.checkString('test?1:2').isEmpty());
     });
+
     it('should not report sticky operator "?" in ternary', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: ['?'] });
         assert(checker.checkString('test?1:2').isEmpty());
     });
+
     it('should not report assignment operator for "a=b" without option', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: [','] });
         assert(checker.checkString('a=b').isEmpty());
     });
+
     it('should report comma operator (as separator) in function argument', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: [','] });
         assert(checker.checkString('function test(a,b){}').getErrorCount() === 1);
     });
+
     it('should report for assignment expression', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: ['='] });
         assert(checker.checkString('var x=1').getErrorCount() === 1);
     });
+
     it('should report for assignment expressions', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: ['='] });
         assert(checker.checkString('var x=1, t=2').getErrorCount() === 2);
     });
+
     it('should not report for assignment expressions without "=" sign', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: ['='] });
         assert(checker.checkString('var x,z;').isEmpty());
     });
+
     it('should not report for assignment expressions if "=" is not specified', function() {
         checker.configure({ requireSpaceAfterBinaryOperators: [','] });
         assert(checker.checkString('var x=1;').isEmpty());

--- a/test/rules/require-space-before-binary-operators.js
+++ b/test/rules/require-space-before-binary-operators.js
@@ -20,30 +20,42 @@ describe('rules/require-space-before-binary-operators', function() {
         var notStickedWithParenthesis = 'var test; (test) ' + operator + ' (2)';
 
         [[operator], true].forEach(function(value) {
+
             it('should report sticky operator for ' + sticked + ' with ' + value + ' option',
                 function() {
-                    checker.configure({ requireSpaceBeforeBinaryOperators: value });
+                    checker.configure({ requireSpaceBeforeBinaryOperators: [operator] });
                     assert(checker.checkString(sticked).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notSticked + ' with ' + value + ' option',
                 function() {
-                    checker.configure({ requireSpaceBeforeBinaryOperators: value });
+                    checker.configure({ requireSpaceBeforeBinaryOperators: [operator] });
                     assert(checker.checkString(notSticked).isEmpty());
                 }
             );
+
             it('should report sticky operator for ' + stickedWithParenthesis + ' with ' + value + ' option',
                 function() {
-                    checker.configure({ requireSpaceBeforeBinaryOperators: value });
+                    checker.configure({ requireSpaceBeforeBinaryOperators: [operator] });
                     assert(checker.checkString(stickedWithParenthesis).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notStickedWithParenthesis + ' with ' + value + ' option',
                 function() {
-                    checker.configure({ requireSpaceBeforeBinaryOperators: value });
+                    checker.configure({ requireSpaceBeforeBinaryOperators: [operator] });
                     assert(checker.checkString(notStickedWithParenthesis).isEmpty());
                 }
             );
+
+            it('should highlight the end of the ' + operator + ' operator', function() {
+                checker.configure({ requireSpaceBeforeBinaryOperators: [operator] });
+                var error = checker.checkString(sticked).getErrorList()[0];
+                assert(error.line === 1);
+                assert(error.column === (14));
+                assert(error.message === ('Operator ' + operator + ' should not stick to preceding expression'));
+            });
         });
     });
 
@@ -51,38 +63,47 @@ describe('rules/require-space-before-binary-operators', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: [':'] });
         assert(checker.checkString('({ test:2 })').isEmpty());
     });
+
     it('should not report sticky operator ":" in ternary', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: [':'] });
         assert(checker.checkString('test?1:2').isEmpty());
     });
+
     it('should not report sticky operator "?" in ternary', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: ['?'] });
         assert(checker.checkString('test?1:2').isEmpty());
     });
+
     it('should not report assignment operator for "a=b" without option', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: [','] });
         assert(checker.checkString('a=b').isEmpty());
     });
+
     it('should report comma operator (as separator) in function argument', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: [','] });
         assert(checker.checkString('function test(a,b){}').getErrorCount() === 1);
     });
+
     it('should report for assignment expression', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: ['='] });
         assert(checker.checkString('var x=1').getErrorCount() === 1);
     });
+
     it('should report for assignment expressions', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: ['='] });
         assert(checker.checkString('var x=1, t=2').getErrorCount() === 2);
     });
+
     it('should not report for assignment expressions without "=" sign', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: ['='] });
         assert(checker.checkString('var x,z;').isEmpty());
     });
+
     it('should not report for assignment expressions if "=" is not specified', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: [','] });
         assert(checker.checkString('var x=1;').isEmpty());
     });
+
     it('should not report for comma with "true" value', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: true });
         assert(checker.checkString('1,2;').isEmpty());


### PR DESCRIPTION
Adds additional unit tests to verify the detected error's column value is correct for  requireSpace(Before|After)BinaryOperators, that is, it points to the beginning or end of the operator as appropriate.

Closes #756