### PR TITLE
New rule: disallowCurlyBraces

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -518,6 +518,7 @@ Configuration.prototype.registerDefaultRules = function() {
     */
 
     this.registerRule(require('../rules/require-curly-braces'));
+    this.registerRule(require('../rules/disallow-curly-braces'));
     this.registerRule(require('../rules/require-multiple-var-decl'));
     this.registerRule(require('../rules/disallow-multiple-var-decl'));
     this.registerRule(require('../rules/disallow-empty-blocks'));

--- a/lib/rules/disallow-curly-braces.js
+++ b/lib/rules/disallow-curly-braces.js
@@ -1,0 +1,121 @@
+/**
+ * Disallows curly braces after statements.
+ *
+ * Type: `Array` or `Boolean`
+ *
+ * Values: Array of quoted keywords or `true` to disallow curly braces after the following keywords:
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowCurlyBraces": [
+ *     "if",
+ *     "else",
+ *     "while",
+ *     "for",
+ *     "do",
+ *     "with"
+ * ]
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * if (x) x++;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (x) {
+ *     x++;
+ * }
+ * ```
+ */
+
+var assert = require('assert');
+var defaultKeywords = require('../utils').curlyBracedKeywords;
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(statementTypes) {
+        assert(
+            Array.isArray(statementTypes) || statementTypes === true,
+            this.getOptionName() + ' option requires array or true value'
+        );
+
+        if (statementTypes === true) {
+            statementTypes = defaultKeywords;
+        }
+
+        this._typeIndex = {};
+        statementTypes.forEach(function(type) {
+            this._typeIndex[type] = true;
+        }.bind(this));
+    },
+
+    getOptionName: function() {
+        return 'disallowCurlyBraces';
+    },
+
+    check: function(file, errors) {
+
+        function isSingleBlockStatement(node) {
+            return node && node.type === 'BlockStatement' &&
+            node.body.length === 1;
+        }
+
+        function addError(typeString, entity) {
+            errors.add(
+                typeString + ' statement with extra curly braces',
+                entity.loc.start.line,
+                entity.loc.start.column
+            );
+        }
+
+        function checkBody(type, typeString) {
+            file.iterateNodesByType(type, function(node) {
+                if (isSingleBlockStatement(node.body)) {
+                    addError(typeString, node);
+                }
+            });
+        }
+
+        var typeIndex = this._typeIndex;
+
+        if (typeIndex['if'] || typeIndex['else']) {
+            file.iterateNodesByType('IfStatement', function(node) {
+                if (typeIndex['if'] && isSingleBlockStatement(node.consequent)) {
+                    addError('If', node);
+                }
+                if (typeIndex['else'] && isSingleBlockStatement(node.alternate)) {
+                    addError('Else', file.findPrevToken(
+                        file.getTokenByRangeStart(node.alternate.range[0]),
+                        'Keyword',
+                        'else'
+                    ));
+                }
+            });
+        }
+
+        if (typeIndex['while']) {
+            checkBody('WhileStatement', 'While');
+        }
+
+        if (typeIndex['for']) {
+            checkBody('ForStatement', 'For');
+            checkBody('ForInStatement', 'For in');
+        }
+
+        if (typeIndex['do']) {
+            checkBody('DoWhileStatement', 'Do while');
+        }
+
+        if (typeIndex['with']) {
+            checkBody('WithStatement', 'With');
+        }
+    }
+
+};

--- a/test/rules/disallow-curly-braces.js
+++ b/test/rules/disallow-curly-braces.js
@@ -1,0 +1,149 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-curly-braces', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    it('should not report missing `if` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['if'] });
+        assert(checker.checkString('if (x) x++;').isEmpty());
+    });
+
+    it('should report `if` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['if'] });
+        assert(checker.checkString('if (x) { x++; }').getErrorCount() === 1);
+    });
+
+    it('should not report missing `else` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['else'] });
+        assert(checker.checkString('if (x) x++; else x--;').isEmpty());
+    });
+
+    it('should report `else` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['else'] });
+        assert(checker.checkString('if (x) x++; else { x--; }').getErrorCount() === 1);
+    });
+
+    it('should not report missing `while` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['while'] });
+        assert(checker.checkString('while (x) x++;').isEmpty());
+    });
+
+    it('should report `while` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['while'] });
+        assert(checker.checkString('while (x) { x++; }').getErrorCount() === 1);
+    });
+
+    it('should not report missing `for` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['for'] });
+        assert(checker.checkString('for (;;) x++;').isEmpty());
+    });
+
+    it('should report `for` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['for'] });
+        assert(checker.checkString('for (;;) { x++; }').getErrorCount() === 1);
+    });
+
+    it('should not report missing `for in` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['for'] });
+        assert(checker.checkString('for (i in z) x++;').isEmpty());
+    });
+
+    it('should report `for in` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['for'] });
+        assert(checker.checkString('for (i in z) { x++; }').getErrorCount() === 1);
+    });
+
+    it('should not report missing `do` braces', function() {
+        checker.configure({ disallowCurlyBraces: ['do'] });
+        assert(checker.checkString('do x++; while (x);').isEmpty());
+    });
+
+    it('should report `do` with braces', function() {
+        checker.configure({ disallowCurlyBraces: ['do'] });
+        assert(checker.checkString('do { x++; } while (x);').getErrorCount() === 1);
+    });
+
+    it('should ignore method name if it\'s a reserved word (#180)', function() {
+        checker.configure({ disallowCurlyBraces: ['catch'] });
+        assert(checker.checkString('promise.catch()').isEmpty());
+    });
+
+    it('should report on all optionally curly braced keywords if a value of true is supplied', function() {
+        checker.configure({ disallowCurlyBraces: true });
+
+        assert(!checker.checkString('if (x) {x++;}').isEmpty());
+        assert(!checker.checkString('if (x) x++; else {x--;}').isEmpty());
+        assert(!checker.checkString('for (x = 0; x < 10; x++) {x++;}').isEmpty());
+        assert(!checker.checkString('while (x) {x++;}').isEmpty());
+        assert(!checker.checkString('do {x++;} while(x < 5);').isEmpty());
+        assert(!checker.checkString('with(x) {console.log(toString());}').isEmpty());
+    });
+
+    it('should correctly set pointer (#799)', function() {
+        checker.configure({ disallowCurlyBraces: ['else'] });
+
+        // jscs:disable
+        var error = checker.checkString(function foo() {
+            if (foo === 1)
+                return 1;
+            else {
+                return 3;
+            }
+        }.toString()).getErrorList()[ 0 ];
+        // jscs:enable
+
+        assert(error.line === 4);
+        assert(error.column === 12);
+    });
+
+    it('should report for a block with 1 line', function() {
+        checker.configure({ disallowCurlyBraces: true });
+
+        assert(checker.checkString([
+        'if (x) {',
+            'a();',
+        '}'
+        ].join('\n')).getErrorCount() === 1);
+    });
+
+    it('should not report for a block with 2 lines', function() {
+        checker.configure({ disallowCurlyBraces: true });
+
+        assert(checker.checkString([
+        'if (x) {',
+            'a();',
+            'b();',
+        '}'
+        ].join('\n')).isEmpty());
+    });
+
+    it('should not report for a block with 3 lines', function() {
+        checker.configure({ disallowCurlyBraces: true });
+
+        assert(checker.checkString([
+        'if (x) {',
+            'a();',
+            'b();',
+            'c();',
+        '}'
+        ].join('\n')).isEmpty());
+    });
+
+    it('should report for a block with 3 lines that is a single statement', function() {
+        checker.configure({ disallowCurlyBraces: true });
+
+        assert(checker.checkString([
+        'if (a) {',
+            'a = [',
+                '\'b\'',
+            '];',
+        '}'
+        ].join('\n')).getErrorCount() === 1);
+    });
+});


### PR DESCRIPTION
#726 

The same as requireCurlyBraces except `addError` on `=== 'BlockStatement'` instead of on `!== 'BlockStatement'`. 