### PR TITLE
requireOperatorBeforeLineBreak: Use the new assertion framework

### DIFF
--- a/lib/rules/require-operator-before-line-break.js
+++ b/lib/rules/require-operator-before-line-break.js
@@ -81,16 +81,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
         var throughTokens = ['?', ','];
 
-        function errorIfApplicable(token, prevToken) {
-            if (prevToken && prevToken.loc.end.line !== token.loc.start.line) {
-                var loc = token.loc.start;
-
-                errors.add(
-                    'Operator ' + token.value + ' should not be on a new line',
-                    loc.line,
-                    tokenHelper.getPointerEntities(loc.column, token.value.length)
-                );
-            }
+        function errorIfApplicable(operatorToken, prevToken) {
+            errors.assert.sameLine({
+                token: prevToken,
+                nextToken: operatorToken,
+                message: 'Operator ' + operatorToken.value + ' should not be on a new line'
+            });
         }
 
         throughTokens = throughTokens.filter(function(operator) {

--- a/lib/token-helper.js
+++ b/lib/token-helper.js
@@ -105,13 +105,3 @@ exports.getTokenByRangeStartIfPunctuator = function(file, range, operator, backw
 
     return null;
 };
-
-/**
- * Get column for long entities
- * @param {Number} column
- * @param {Number} length
- * @return {Number}
- */
-exports.getPointerEntities = function(column, length) {
-    return column - 1 + Math.ceil(length / 2);
-};


### PR DESCRIPTION
Update requireOperatorBeforeLineBreak to use the new assertion framework and remove the call to getPointerEntities since it's no longer used anywhere.