### PR TITLE
disallowNewlineBeforeBlockStatements: check if prevToken is defined so t...

### DIFF
--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -91,18 +91,17 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType('BlockStatement', function(node) {
-            var tokens = file.getTokens();
-
-            var openingBracePos = file.getTokenPosByRangeStart(node.range[0]);
-            var openingBrace = tokens[openingBracePos];
-            var prevToken = tokens[openingBracePos - 1];
-
-            if (openingBrace.loc.start.line !== prevToken.loc.start.line) {
-                errors.add(
-                    'Newline before curly brace for block statement is disallowed',
-                    node.loc.start
-                );
+            var openingBrace = file.getFirstNodeToken(node);
+            var prevToken = file.getPrevToken(openingBrace);
+            if (!prevToken) {
+                return;
             }
+
+            errors.assert.sameLine({
+                token: prevToken,
+                nextToken: openingBrace,
+                message: 'Newline before curly brace for block statement is disallowed'
+            });
         });
     }
 };

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -91,18 +91,17 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType('BlockStatement', function(node) {
-            var tokens = file.getTokens();
-
-            var openingBracePos = file.getTokenPosByRangeStart(node.range[0]);
-            var openingBrace = tokens[openingBracePos];
-            var prevToken = tokens[openingBracePos - 1];
-
-            if (openingBrace.loc.start.line === prevToken.loc.start.line) {
-                errors.add(
-                    'Missing newline before curly brace for block statement',
-                    node.loc.start
-                );
+            var openingBrace = file.getFirstNodeToken(node);
+            var prevToken = file.getPrevToken(openingBrace);
+            if (!prevToken) {
+                return;
             }
+
+            errors.assert.differentLine({
+                token: prevToken,
+                nextToken: openingBrace,
+                message: 'Missing newline before curly brace for block statement'
+            });
         });
     }
 };

--- a/test/rules/disallow-newline-before-block-statements.js
+++ b/test/rules/disallow-newline-before-block-statements.js
@@ -51,5 +51,9 @@ describe('rules/disallow-newline-before-block-statements', function() {
                 'function test(){\nif(true){\nreturn {\nval:1\n}\n}\nvar obj = \n{a:1,\nb:2,\nc:3\n};\n}')
                 .isEmpty());
         });
+
+        it('should not report disallowed newline if file begins with block statement', function() {
+            assert(checker.checkString('{}').isEmpty());
+        });
     });
 });

--- a/test/rules/require-newline-before-block-statements.js
+++ b/test/rules/require-newline-before-block-statements.js
@@ -49,5 +49,9 @@ describe('rules/require-newline-before-block-statements', function() {
             assert(checker.checkString('function test()\n{\nif(true)\n{\nreturn 1;\n}\nfor(var i in [1,2,3])\n{\n}\n}')
                 .isEmpty());
         });
+
+        it('should not report missing newline if file begins with block statement', function() {
+            assert(checker.checkString('{}').isEmpty());
+        });
     });
 });


### PR DESCRIPTION
...hat files starting with block statement don't throw error

Fixes: #887