### PR TITLE
Added rules `requireNamedUnassignedFunctions` and `disallowNamedUnassignedFunctions`. Fixes #655, #834.

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -665,6 +665,8 @@ Configuration.prototype.registerDefaultRules = function() {
 
     this.registerRule(require('../rules/require-anonymous-functions'));
     this.registerRule(require('../rules/disallow-anonymous-functions'));
+    this.registerRule(require('../rules/require-named-unassigned-functions'));
+    this.registerRule(require('../rules/disallow-named-unassigned-functions'));
 
     this.registerRule(require('../rules/require-function-declarations'));
     this.registerRule(require('../rules/disallow-function-declarations'));

--- a/lib/rules/disallow-named-unassigned-functions.js
+++ b/lib/rules/disallow-named-unassigned-functions.js
@@ -1,0 +1,61 @@
+/**
+ * Disallows unassigned functions to be named inline
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowNamedUnassignedFunctions": true
+ * ```
+ *
+ * ##### Valid
+ * ```js
+ * [].forEach(function () {});
+ * var x = function() {};
+ * function y() {}
+ * ```
+ *
+ * ##### Invalid
+ * ```js
+ * [].forEach(function x() {});
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires true value'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowNamedUnassignedFunctions';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('FunctionExpression', function(node) {
+            // If the function has been named via left hand assignment, skip it
+            //   e.g. `var hello = function() {`, `foo.bar = function() {`
+            if (node.parentNode.type.match(/VariableDeclarator|Property|AssignmentExpression/)) {
+                return;
+            }
+
+            // If the function has not been named, skip it
+            //   e.g. `[].forEach(function() {`
+            if (node.id === null) {
+                return;
+            }
+
+            // Otherwise, complain that it is being named
+            errors.add('Inline functions cannot be named', node.loc.start);
+        });
+    }
+};

--- a/lib/rules/require-named-unassigned-functions.js
+++ b/lib/rules/require-named-unassigned-functions.js
@@ -1,0 +1,130 @@
+/**
+ * Require unassigned functions to be named inline
+ *
+ * Types: `Boolean` or `Object`
+ *
+ * Values:
+ *  - `true`
+ *  - `Object`:
+ *     - `allExcept`: array of quoted identifiers
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireNamedUnassignedFunctions": { "allExcept": ["describe", "it"] }
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * [].forEach(function x() {});
+ * var y = function() {};
+ * function z() {}
+ * it(function () {});
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * [].forEach(function () {});
+ * before(function () {});
+ * ```
+ */
+
+var assert = require('assert');
+var pathval = require('pathval');
+
+function getNodeName(node) {
+    if (node.type === 'Identifier') {
+        return node.name;
+    } else {
+        return node.value;
+    }
+}
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true ||
+            typeof options === 'object',
+            this.getOptionName() + ' option requires true value ' +
+            'or an object with String[] `allExcept` property'
+        );
+
+        // verify first item in `allExcept` property in object (if it's an object)
+        assert(
+            typeof options !== 'object' ||
+            Array.isArray(options.allExcept) &&
+            typeof options.allExcept[0] === 'string',
+            'Property `allExcept` in ' + this.getOptionName() + ' should be an array of strings'
+        );
+
+        if (options.allExcept) {
+            this._allExceptItems = options.allExcept.map(function(item) {
+                var parts = pathval.parse(item).map(function extractPart (part) {
+                    return part.i !== undefined ? part.i : part.p;
+                });
+                return JSON.stringify(parts);
+            });
+        }
+    },
+
+    getOptionName: function() {
+        return 'requireNamedUnassignedFunctions';
+    },
+
+    check: function(file, errors) {
+        var _this = this;
+        file.iterateNodesByType('FunctionExpression', function(node) {
+            var parentNode = node.parentNode;
+            // If the function has been named via left hand assignment, skip it
+            //   e.g. `var hello = function() {`, `foo.bar = function() {`
+            if (parentNode.type.match(/VariableDeclarator|Property|AssignmentExpression/)) {
+                return;
+            }
+
+            // If the function has been named, skip it
+            //   e.g. `[].forEach(function hello() {`
+            if (node.id !== null) {
+                return;
+            }
+
+            // If we have exceptions and the function is being invoked, detect whether we excepted it
+            if (_this._allExceptItems && parentNode.type === 'CallExpression') {
+                // Determine the path that resolves to our call expression
+                // We must cover both direct calls (e.g. `it(function() {`) and
+                //   member expressions (e.g. `foo.bar(function() {`)
+                var memberNode = parentNode.callee;
+                var canBeRepresented = true;
+                var fullpathParts = [];
+                while (memberNode) {
+                    if (memberNode.type.match(/Identifier|Literal/)) {
+                        fullpathParts.unshift(getNodeName(memberNode));
+                    } else if (memberNode.type === 'MemberExpression') {
+                        fullpathParts.unshift(getNodeName(memberNode.property));
+                    } else {
+                        canBeRepresented = false;
+                        break;
+                    }
+                    memberNode = memberNode.object;
+                }
+
+                // If the path is not-dynamic (i.e. can be represented by static parts),
+                //   then check it against our exceptions
+                if (canBeRepresented) {
+                    var fullpath = JSON.stringify(fullpathParts);
+                    for (var i = 0, l = _this._allExceptItems.length; i < l; i++) {
+                        if (fullpath === _this._allExceptItems[i]) {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // Complain that this function must be named
+            errors.add('Inline functions need to be named', node.loc.start);
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "glob": "^5.0.1",
     "lodash.assign": "~3.0.0",
     "minimatch": "~2.0.1",
+    "pathval": "~0.1.1",
     "prompt": "~0.2.14",
     "strip-json-comments": "~1.0.2",
     "vow": "~0.4.8",

--- a/test/specs/rules/disallow-named-unassigned-functions.js
+++ b/test/specs/rules/disallow-named-unassigned-functions.js
@@ -1,0 +1,40 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-named-unassigned-functions', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({
+                disallowNamedUnassignedFunctions: true
+            });
+        });
+
+        it('should not report on unnamed unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function(){});').isEmpty());
+        });
+
+        it('should report on named unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function named(){});').getErrorCount() === 1);
+        });
+
+        it('should not report on named function declarations', function() {
+            assert(checker.checkString('function named(){};').isEmpty());
+        });
+
+        it('should not report on assigned function expressions', function() {
+            assert(checker.checkString('var x = function(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function() {};').isEmpty());
+            assert(checker.checkString('var x = function named(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function named() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function named() {};').isEmpty());
+        });
+    });
+});

--- a/test/specs/rules/require-named-unassigned-functions.js
+++ b/test/specs/rules/require-named-unassigned-functions.js
@@ -1,0 +1,103 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-named-unassigned-functions', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireNamedUnassignedFunctions: true
+            });
+        });
+
+        it('should report on unnamed unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function(){});').getErrorCount() === 1);
+        });
+
+        it('should not report on named unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function named(){});').isEmpty());
+        });
+
+        it('should not report on function declarations', function() {
+            assert(checker.checkString('function named(){};').isEmpty());
+        });
+
+        it('should not report on assigned function expressions', function() {
+            assert(checker.checkString('var x = function(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function() {};').isEmpty());
+            assert(checker.checkString('var x = function named(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function named() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function named() {};').isEmpty());
+        });
+    });
+
+    describe('option value allExcept', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireNamedUnassignedFunctions: {
+                    allExcept: ['it', 'it.skip', 'x.y.z', 'x[1]', 'x[0].z']
+                }
+            });
+        });
+
+        it('should report on unnamed unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function(){});').getErrorCount() === 1);
+        });
+
+        it('should not report on named unassigned function expressions', function() {
+            assert(checker.checkString('$("hi").click(function named(){});').isEmpty());
+        });
+
+        it('should not report on function declarations', function() {
+            assert(checker.checkString('function named(){};').isEmpty());
+        });
+
+        it('should not report on assigned function expressions', function() {
+            assert(checker.checkString('var x = function(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function() {};').isEmpty());
+            assert(checker.checkString('var x = function named(){};').isEmpty());
+            assert(checker.checkString('var foo = {bar: function named() {}};').isEmpty());
+            assert(checker.checkString('foo.bar = function named() {};').isEmpty());
+        });
+
+        it('should not report on excepted unnamed unassigned function expressions', function() {
+            assert(checker.checkString('it(function (){});').isEmpty());
+            assert(checker.checkString('it.skip(function () {});').isEmpty());
+            assert(checker.checkString('x.y.z(function () {});').isEmpty());
+            assert(checker.checkString('x[1](function () {});').isEmpty());
+            assert(checker.checkString('x[0].z(function () {});').isEmpty());
+        });
+
+        it('should not report on excepted unnamed unassigned using bracket notation', function() {
+            assert(checker.checkString('it[\'skip\'](function () {});').isEmpty());
+        });
+
+        it('doesn\'t explode on literals/constructors', function() {
+            assert(checker.checkString('[0].forEach(function () {});').getErrorCount() === 1);
+            assert(checker.checkString('(new Item()).forEach(function () {});').getErrorCount() === 1);
+        });
+    });
+
+    describe('option value allExcept bad array', function() {
+        it('raises an assertion error', function() {
+            try {
+                checker.configure({
+                    requireNamedUnassignedFunctions: {
+                        allExcept: 'unexpected content'
+                    }
+                });
+            } catch (err) {
+                return;
+            }
+            assert.fail('`checker.configure` should have raised an error for an invalid type');
+        });
+    });
+});


### PR DESCRIPTION
As discussed in #655 and #834, there is no middle ground for requiring names on anonymous functions/not. These new rules aim to fix that by only requiring naming if the function has not been named by other means (i.e. no left hand assignment). In this PR:

- Added `requireNamedUnassignedFunctions` and `disallowNamedUnassignedFunctions` rules
- Added tests

**Missing:**

## Documentation
I couldn't find a place to put descriptions for the new rules. However, they would read something like:

### requireNamedUnassignedFunctions
Require inline name for any function that has not been assigned via a left-hand operator.

Type: `Boolean` or `Object`

Values:

- `true`
- `Object`:
    - `allExcept`: array of function names/methods to skip over if `function` is used as a parameter

**Example**

```js
"requireNamedUnassignedFunctions": { allExcept: ["describe", "describe.skip", "it", "it.skip"] }
```

**Valid**

```js
var foo = function() {};
[1].forEach(function iterateItems() {});
it(function() {}); // Valid because of `allExcept`
```

**Invalid**

```js
[1].forEach(function() {});
before(function() {});
```

### disallowNamedUnassignedFunctions
Disallow inline name for any function that has not been assigned via a left-hand operator.

Type: `Boolean`

Values: `true`

**Example**

```js
"disallowNamedUnassignedFunctions": true
```

**Valid**

```js
var foo = function() {};
[1].forEach(function() {});
before(function() {});
```

**Invalid**

```js
[1].forEach(function iterateItems() {});
before(function setupServer() {});
```

## Wildcards
It is possible people will want to use wildcards (e.g. `it.*`). However, this is an edge case on top of an edge case. It is hard to know exactly the use case so I have decided to defer implementation until someone brings it up as a necessity.