### PR TITLE
Add new values and deprecate some for (require | disallow)SpacesInsideObjectBrackets

### DIFF
--- a/lib/rules/disallow-spaces-inside-object-brackets.js
+++ b/lib/rules/disallow-spaces-inside-object-brackets.js
@@ -1,14 +1,20 @@
 /**
  * Disallows space after opening object curly brace and before closing.
  *
- * Type: `Boolean` or `String`
+ * Type: `Object`, `Boolean` or `String`
  *
- * Values: `"all"` or `true` for strict mode, `"nested"` ignores closing brackets in a row.
+ * Values: `"all"` or `true` for strict mode, `"nested"` (*deprecated* use `"allExcept": ['}']`)
+ * ignores closing brackets in a row.
  *
  * #### Example
  *
  * ```js
- * "disallowSpacesInsideObjectBrackets": "all"
+ * "disallowSpacesInsideObjectBrackets": {
+ *     "allExcept": [ "}", ")" ]
+ * }
+ *
+ * // or
+ * * "disallowSpacesInsideObjectBrackets": true | "all" | "nested"
  * ```
  *
  * ##### Valid for mode `"all"`
@@ -20,7 +26,13 @@
  * ##### Valid for mode `"nested"`
  *
  * ```js
- * var x = { a: {b: 1} };
+ * var x = {a: {b: 1} };
+ * ```
+ *
+ * ##### Valid for mode `"allExcept": ["}"]`
+ *
+ * ```js
+ * var x = {a: {b: 1} };
  * ```
  *
  * ##### Invalid
@@ -36,14 +48,40 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(disallowSpacesInsideObjectBrackets) {
-        assert(
-            disallowSpacesInsideObjectBrackets === true || disallowSpacesInsideObjectBrackets === 'all' ||
-            disallowSpacesInsideObjectBrackets === 'nested',
-            'disallowSpacesInsideObjectBrackets option requires "all"(true value) or "nested" string'
-        );
+    configure: function(value) {
+        var mode;
+        var modes = {
+            'all': true,
+            'nested': true
+        };
+        var isObject = typeof value === 'object';
 
-        this._mode = disallowSpacesInsideObjectBrackets === true ? 'all' : disallowSpacesInsideObjectBrackets;
+        var error = 'disallowSpacesInsideObjectBrackets rule' +
+        ' requires string "all" or "nested", true value or object';
+
+        if (typeof value === 'string' || value === true) {
+            assert(modes[ value === true ? 'all' : value], error);
+
+        } else if (isObject) {
+            assert('allExcept' in value, error);
+        } else {
+            assert(false, error);
+        }
+
+        this._exceptions = {};
+
+        if (isObject) {
+            (value.allExcept || []).forEach(function(value) {
+                this._exceptions[value] = true;
+            }, this);
+
+        } else {
+            mode = value;
+        }
+
+        if (mode === 'nested') {
+            this._exceptions['}'] = true;
+        }
     },
 
     getOptionName: function() {
@@ -51,44 +89,32 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var mode = this._mode;
+        var exceptions = this._exceptions;
 
         file.iterateNodesByType('ObjectExpression', function(node) {
-            var tokens = file.getTokens();
+            var openingBracket = file.getFirstNodeToken(node);
+            var nextToken = file.getNextToken(openingBracket);
 
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
+            errors.assert.noWhitespaceBetween({
+                token: openingBracket,
+                nextToken: nextToken,
+                spaces: 1,
+                message: 'Illegal space after opening curly brace'
+            });
 
-            var brackets = {
-                opening: tokens[openingBracketPos],
-                closing: tokens[closingBracketPos]
-            };
+            var closingBracket = file.getLastNodeToken(node);
+            var prevToken = file.getPrevToken(closingBracket);
 
-            var insideTokens = {
-                prev: tokens[closingBracketPos - 1],
-                next: tokens[openingBracketPos + 1]
-            };
-
-            if (mode === 'all') {
-                check(brackets, errors, insideTokens);
-
-            } else if (node.parentNode.type === 'Property') {
-                check(brackets, errors, insideTokens);
+            if (prevToken.value in exceptions) {
+                return;
             }
+
+            errors.assert.noWhitespaceBetween({
+                token: prevToken,
+                nextToken: closingBracket,
+                spaces: 1,
+                message: 'Illegal space before closing curly brace'
+            });
         });
     }
 };
-
-function check(brackets, errors, insideTokens) {
-    if (brackets.opening.loc.start.line === insideTokens.next.loc.start.line &&
-        brackets.opening.range[1] !== insideTokens.next.range[0]
-    ) {
-        errors.add('Illegal space after opening curly brace', brackets.opening.loc.end);
-    }
-
-    if (brackets.closing.loc.start.line === insideTokens.prev.loc.start.line &&
-        brackets.closing.range[0] !== insideTokens.prev.range[1]
-    ) {
-        errors.add('Illegal space before closing curly brace', insideTokens.prev.loc.end);
-    }
-}

--- a/lib/rules/require-spaces-inside-object-brackets.js
+++ b/lib/rules/require-spaces-inside-object-brackets.js
@@ -1,14 +1,20 @@
 /**
  * Requires space after opening object curly brace and before closing.
  *
- * Type: `String`
+ * Type: `Object` or `String`
  *
- * Values: `"all"` for strict mode, `"allButNested"` ignores closing brackets in a row.
+ * Values: `"all"` for strict mode, `"allButNested"` (*deprecated* use `"allExcept": ['}']`)
+ * ignores closing brackets in a row.
  *
  * #### Example
  *
  * ```js
- * "requireSpacesInsideObjectBrackets": "all"
+ * "requireSpacesInsideObjectBrackets": {
+ *     "allExcept": [ "}", ")" ]
+ * }
+ *
+ * // or
+ * "requireSpacesInsideObjectBrackets": true | "all" | "allButNested"
  * ```
  *
  * ##### Valid for mode `"all"`
@@ -20,6 +26,13 @@
  * ##### Valid for mode `"allButNested"`
  *
  * ```js
+ * var x = { a: { b: 1 }};
+ * ```
+ *
+ * ##### Valid for mode `"allExcept": [ "}", ")" ]`
+ *
+ * ```js
+ * var x = { a: (b ? 1 : 2)};
  * var x = { a: { b: 1 }};
  * ```
  *
@@ -36,17 +49,40 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(mode) {
+    configure: function(value) {
+        var mode;
         var modes = {
             'all': true,
             'allButNested': true
         };
-        assert(
-            typeof mode === 'string' &&
-            modes[mode],
-            'requireSpacesInsideObjectBrackets option requires string value \'all\' or \'allButNested\''
-        );
-        this._mode = mode;
+        var isObject = typeof value === 'object';
+
+        var error = 'requireSpacesInsideObjectBrackets rule' +
+        ' requires string value \'all\' or \'allButNested\' or object';
+
+        if (typeof value === 'string') {
+            assert(modes[value], error);
+
+        } else if (isObject) {
+            assert('allExcept' in value, error);
+        } else {
+            assert(false, error);
+        }
+
+        this._exceptions = {};
+
+        if (isObject) {
+            (value.allExcept || []).forEach(function(value) {
+                this._exceptions[value] = true;
+            }, this);
+
+        } else {
+            mode = value;
+        }
+
+        if (mode === 'allButNested') {
+            this._exceptions['}'] = true;
+        }
     },
 
     getOptionName: function() {
@@ -54,33 +90,37 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var mode = this._mode;
+        var exceptions = this._exceptions;
+
         file.iterateNodesByType('ObjectExpression', function(node) {
-            var tokens = file.getTokens();
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
+            var openingBracket = file.getFirstNodeToken(node);
+            var nextToken = file.getNextToken(openingBracket);
 
-            var openingBracket = tokens[openingBracketPos];
-            var nextToken = tokens[openingBracketPos + 1];
-
-            if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
+            // Don't check empty object
+            if (nextToken.value === '}') {
                 return;
             }
 
-            if (openingBracket.range[1] === nextToken.range[0]) {
-                errors.add('Missing space after opening curly brace', nextToken.loc.start);
+            errors.assert.whitespaceBetween({
+                token: openingBracket,
+                nextToken: nextToken,
+                spaces: 1,
+                message: 'Missing space after opening curly brace'
+            });
+
+            var closingBracket = file.getLastNodeToken(node);
+            var prevToken = file.getPrevToken(closingBracket);
+
+            if (prevToken.value in exceptions) {
+                return;
             }
 
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
-            var closingBracket = tokens[closingBracketPos];
-            var prevToken = tokens[closingBracketPos - 1];
-            var isNested = mode === 'allButNested' &&
-                           prevToken.type === 'Punctuator' &&
-                           prevToken.value === '}';
-
-            if (closingBracket.range[0] === prevToken.range[1] && !isNested) {
-                errors.add('Missing space before closing curly brace', closingBracket.loc.start);
-            }
+            errors.assert.whitespaceBetween({
+                token: prevToken,
+                nextToken: closingBracket,
+                spaces: 1,
+                message: 'Missing space before closing curly brace'
+            });
         });
     }
-
 };

--- a/test/rules/disallow-spaces-inside-object-brackets.js
+++ b/test/rules/disallow-spaces-inside-object-brackets.js
@@ -57,9 +57,6 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
             checker.configure({ disallowSpacesInsideObjectBrackets: 'nested' });
         });
 
-        it('should not report illegal space for not nested object', function() {
-            assert(checker.checkString('var x = { 1 : 2 };').isEmpty());
-        });
         it('should report illegal space after opening brace for nested object', function() {
             assert(checker.checkString('var x = {1: { 1 : 2}};').getErrorCount() === 1);
         });
@@ -73,7 +70,50 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
             assert(checker.checkString('var x = {1: { 1 : 2 }, 2: { 3 : 4 }};').getErrorCount() === 4);
         });
         it('should not report illegal space in both cases for nested object', function() {
-            assert(checker.checkString('var x = { 1: {1 : 2} };').isEmpty());
+            assert(checker.checkString('var x = {1: {1 : 2}};').isEmpty());
+        });
+    });
+
+    describe('exceptions', function() {
+        it('should report for function', function() {
+            checker.configure({
+                disallowSpacesInsideObjectBrackets: {
+                    allExcept: ['}']
+                }
+            });
+
+            assert(checker.checkString('var x = {a: []};').isEmpty());
+            assert(checker.checkString('var x = { a: function() {} };').getErrorCount() === 1);
+        });
+        it('should report for array literal', function() {
+            checker.configure({
+                disallowSpacesInsideObjectBrackets: {
+                    allExcept: [']']
+                }
+            });
+
+            assert(checker.checkString('var x = {a: {b: 2} };').getErrorCount() === 1);
+            assert(checker.checkString('var x = {a: [] };').isEmpty());
+        });
+        it('should report for parentheses', function() {
+            checker.configure({
+                disallowSpacesInsideObjectBrackets: {
+                    allExcept: [')']
+                }
+            });
+
+            assert(checker.checkString('var x = {a: {b: 2} };').getErrorCount() === 1);
+            assert(checker.checkString('var x = {a: (1) };').isEmpty());
+        });
+        it('should report for object literal', function() {
+            checker.configure({
+                disallowSpacesInsideObjectBrackets: {
+                    allExcept: ['}']
+                }
+            });
+
+            assert(checker.checkString('var x = {a: {b: 2} };').isEmpty());
+            assert(checker.checkString('var x = { a: { b: 1} };').getErrorCount() === 2);
         });
     });
 });

--- a/test/rules/disallow-spaces-inside-object-brackets.js
+++ b/test/rules/disallow-spaces-inside-object-brackets.js
@@ -16,15 +16,19 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
         it('should report illegal space after opening brace, with true value', function() {
             assert(checker.checkString('var x = { a: 1};').getErrorCount() === 1);
         });
+
         it('should report illegal space before closing brace, with true value', function() {
             assert(checker.checkString('var x = {a: 1 };').getErrorCount() === 1);
         });
+
         it('should report illegal space in both cases, with true value', function() {
             assert(checker.checkString('var x = { a: 1 };').getErrorCount() === 2);
         });
+
         it('should report illegal space for nested braces too, with true value', function() {
             assert(checker.checkString('var x = { test: { a: 1 } };').getErrorCount() === 4);
         });
+
         it('should not report with no spaces, with true value', function() {
             assert(checker.checkString('var x = {a: 1};').isEmpty());
         });
@@ -38,15 +42,19 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
         it('should report illegal space after opening brace, with "all" value', function() {
             assert(checker.checkString('var x = { a: 1};').getErrorCount() === 1);
         });
+
         it('should report illegal space before closing brace, with "all" value', function() {
             assert(checker.checkString('var x = {a: 1 };').getErrorCount() === 1);
         });
+
         it('should report illegal space in both cases, with "all" value', function() {
             assert(checker.checkString('var x = { a: 1 };').getErrorCount() === 2);
         });
+
         it('should report illegal space for nested braces too, with "all" value', function() {
             assert(checker.checkString('var x = { test: { a: 1 } };').getErrorCount() === 4);
         });
+
         it('should not report with no spaces, with "all" value', function() {
             assert(checker.checkString('var x = {a: 1};').isEmpty());
         });
@@ -60,15 +68,19 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
         it('should report illegal space after opening brace for nested object', function() {
             assert(checker.checkString('var x = {1: { 1 : 2}};').getErrorCount() === 1);
         });
+
         it('should report illegal space before closing brace for nested object', function() {
             assert(checker.checkString('var x = {1: {1 : 2 }};').getErrorCount() === 1);
         });
+
         it('should report illegal space in both cases for nested object', function() {
             assert(checker.checkString('var x = {1: { 1 : 2 }};').getErrorCount() === 2);
         });
+
         it('should report illegal space in both cases for multiple nested object', function() {
             assert(checker.checkString('var x = {1: { 1 : 2 }, 2: { 3 : 4 }};').getErrorCount() === 4);
         });
+
         it('should not report illegal space in both cases for nested object', function() {
             assert(checker.checkString('var x = {1: {1 : 2}};').isEmpty());
         });
@@ -85,6 +97,7 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
             assert(checker.checkString('var x = {a: []};').isEmpty());
             assert(checker.checkString('var x = { a: function() {} };').getErrorCount() === 1);
         });
+
         it('should report for array literal', function() {
             checker.configure({
                 disallowSpacesInsideObjectBrackets: {
@@ -95,6 +108,7 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
             assert(checker.checkString('var x = {a: {b: 2} };').getErrorCount() === 1);
             assert(checker.checkString('var x = {a: [] };').isEmpty());
         });
+
         it('should report for parentheses', function() {
             checker.configure({
                 disallowSpacesInsideObjectBrackets: {
@@ -105,6 +119,7 @@ describe('rules/disallow-spaces-inside-object-brackets', function() {
             assert(checker.checkString('var x = {a: {b: 2} };').getErrorCount() === 1);
             assert(checker.checkString('var x = {a: (1) };').isEmpty());
         });
+
         it('should report for object literal', function() {
             checker.configure({
                 disallowSpacesInsideObjectBrackets: {

--- a/test/rules/require-spaces-inside-object-brackets.js
+++ b/test/rules/require-spaces-inside-object-brackets.js
@@ -16,30 +16,39 @@ describe('rules/require-spaces-inside-object-brackets', function() {
         it('should report missing space after opening brace', function() {
             assert(checker.checkString('var x = {a: 1 };').getErrorCount() === 1);
         });
+
         it('should report missing space before closing brace', function() {
             assert(checker.checkString('var x = { a: 1};').getErrorCount() === 1);
         });
+
         it('should report missing space in both cases', function() {
             assert(checker.checkString('var x = {a: 1};').getErrorCount() === 2);
         });
+
         it('should not report with spaces', function() {
             assert(checker.checkString('var x = { a: 1 };').isEmpty());
         });
+
         it('should not report for empty object', function() {
             assert(checker.checkString('var x = {};').isEmpty());
         });
+
         it('should report for nested object', function() {
             assert(checker.checkString('var x = { a: { b: 1 }};').getErrorCount() === 1);
         });
+
         it('should report anything for empty object', function() {
             assert(checker.checkString('var x = {};').isEmpty());
         });
+
         it('should report for function value', function() {
             assert(checker.checkString('var x = { a: function() {}};').getErrorCount() === 1);
         });
+
         it('should report for array literal', function() {
             assert(checker.checkString('var x = { a: []};').getErrorCount() === 1);
         });
+
         it('should report for parentheses', function() {
             assert(checker.checkString('var x = { a: (1)};').getErrorCount() === 1);
         });
@@ -53,21 +62,27 @@ describe('rules/require-spaces-inside-object-brackets', function() {
         it('should report missing space after opening brace', function() {
             assert(checker.checkString('var x = {a: 1 };').getErrorCount() === 1);
         });
+
         it('should report missing space before closing brace', function() {
             assert(checker.checkString('var x = { a: 1};').getErrorCount() === 1);
         });
+
         it('should report missing space in both cases', function() {
             assert(checker.checkString('var x = {a: 1};').getErrorCount() === 2);
         });
+
         it('should not report with spaces', function() {
             assert(checker.checkString('var x = { a: 1 };').isEmpty());
         });
+
         it('should not report for nested object', function() {
             assert(checker.checkString('var x = { a: { b: 1 }};').isEmpty());
         });
+
         it('should not report illegal space between closing braces for nested object', function() {
             assert(checker.checkString('var x = { a: { b: 1 } };').isEmpty());
         });
+
         it('should report not anything for empty object', function() {
             assert(checker.checkString('var x = { a: {}};').isEmpty());
         });

--- a/test/rules/require-spaces-inside-object-brackets.js
+++ b/test/rules/require-spaces-inside-object-brackets.js
@@ -34,6 +34,15 @@ describe('rules/require-spaces-inside-object-brackets', function() {
         it('should report anything for empty object', function() {
             assert(checker.checkString('var x = {};').isEmpty());
         });
+        it('should report for function value', function() {
+            assert(checker.checkString('var x = { a: function() {}};').getErrorCount() === 1);
+        });
+        it('should report for array literal', function() {
+            assert(checker.checkString('var x = { a: []};').getErrorCount() === 1);
+        });
+        it('should report for parentheses', function() {
+            assert(checker.checkString('var x = { a: (1)};').getErrorCount() === 1);
+        });
     });
 
     describe('"allButNested"', function() {
@@ -59,8 +68,36 @@ describe('rules/require-spaces-inside-object-brackets', function() {
         it('should not report illegal space between closing braces for nested object', function() {
             assert(checker.checkString('var x = { a: { b: 1 } };').isEmpty());
         });
-        it('should report anything for empty object', function() {
+        it('should report not anything for empty object', function() {
             assert(checker.checkString('var x = { a: {}};').isEmpty());
+        });
+    });
+
+    describe('exceptions', function() {
+        describe('"}", "]", ")"', function() {
+            beforeEach(function() {
+                checker.configure({
+                    requireSpacesInsideObjectBrackets: {
+                        allExcept: ['}', ']', ')']
+                    }
+                });
+            });
+
+            it('should report missing spaces', function() {
+                assert(checker.checkString('var x = {a: 1};').getErrorCount() === 2);
+            });
+            it('should not report for function', function() {
+                assert(checker.checkString('var x = { a: function() {}};').isEmpty());
+            });
+            it('should not report for array literal', function() {
+                assert(checker.checkString('var x = { a: []};').isEmpty());
+            });
+            it('should not report for parentheses', function() {
+                assert(checker.checkString('var x = { a: (1)};').isEmpty());
+            });
+            it('should not report for object literal', function() {
+                assert(checker.checkString('var x = { a: { b: 1 }};').isEmpty());
+            });
         });
     });
 });


### PR DESCRIPTION
See https://github.com/jscs-dev/node-jscs/issues/721, although without `only` but with `allExcept` for both