### PR TITLE
airbnb: Remove incorrect requireMultipleVarDecl rule

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -30,7 +30,6 @@
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
-    "requireMultipleVarDecl": "onevar",
     "requireBlocksOnNewline": 1,
     "requireCommaBeforeLineBreak": true,
     "requireSpaceBeforeBinaryOperators": true,


### PR DESCRIPTION
Hey guys,

Thanks for the excellent style checker. Minor issue I ran into: airbnb preset specifies `requireMultipleVarDecl: 'onevar'`, but this is [explicitly prohibited in the airbnb style guide](https://github.com/airbnb/javascript/tree/c72908364549e74150eb28465c6d0be5cafc9224#variables). Unfortunately, no value of `requireMultipleVarDecl` enforces what the airbnb style guide suggests (which is never joining var declarations) so makes sense to remove it for now IMO. Can I put together a PR that adds a new rule for `requireMultipleVarDecl` that matches airbnb's style guide?