### PR TITLE
new rule values: emptyLines for disableTrailingWhitespace and validateIndentation

### DIFF
--- a/lib/rules/disallow-trailing-whitespace.js
+++ b/lib/rules/disallow-trailing-whitespace.js
@@ -1,9 +1,11 @@
 /**
  * Requires all lines to end on a non-whitespace character
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `String`
  *
- * Values: `true`
+ * Values:
+ *  - `true`
+ *  - `"ignoreEmptyLines"`: (default: `false`) allow whitespace on empty lines
  *
  * JSHint: [`trailing`](http://jshint.com/docs/options/#trailing)
  *
@@ -24,6 +26,22 @@
  * ```js
  * var foo = "blah blah"; //<-- whitespace character here
  * ```
+ *
+ * ##### Valid for `true`
+ *
+ * ```js
+ * foo = 'bar';
+ *
+ * foo = 'baz';
+ * ```
+ *
+ * ##### Invalid for `true` but Valid for `ignoreEmptyLines`
+ *
+ * ```js
+ * foo = 'bar';
+ * \t
+ * foo = 'baz';
+ * ```
  */
 
 var assert = require('assert');
@@ -34,13 +52,10 @@ module.exports.prototype = {
 
     configure: function(disallowTrailingWhitespace) {
         assert(
-            typeof disallowTrailingWhitespace === 'boolean',
-            'disallowTrailingWhitespace option requires boolean value'
+            disallowTrailingWhitespace === true || disallowTrailingWhitespace === 'ignoreEmptyLines',
+            'disallowTrailingWhitespace option requires true value or "ignoreEmptyLines" string'
         );
-        assert(
-            disallowTrailingWhitespace === true,
-            'disallowTrailingWhitespace option requires true value or should be removed'
-        );
+        this._ignoreEmptyLines = disallowTrailingWhitespace === 'ignoreEmptyLines';
     },
 
     getOptionName: function() {
@@ -48,9 +63,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var ignoreEmptyLines = this._ignoreEmptyLines;
+
         var lines = file.getLines();
         for (var i = 0, l = lines.length; i < l; i++) {
-            if (lines[i].match(/\s$/)) {
+            if (lines[i].match(/\s$/) && !(ignoreEmptyLines && lines[i].match(/^\s*$/))) {
                 errors.add('Illegal trailing whitespace', i + 1, lines[i].length);
             }
         }

--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -1,9 +1,14 @@
 /**
  * Validates indentation for switch statements and block statements
  *
- * Type: `Integer` or `String`
+ * Type: `Integer` or `String` or `Object`
  *
- * Values: A positive integer or `"\t"`
+ * Values:
+ *  - `Integer`: A positive number of spaces
+ *  - `String`: `"\t"` for tab indentation
+ *  - `Object`:
+ *     - `value`: (required) the same effect as the non-object values
+ *     - `includeEmptyLines`: (default: `false`) require empty lines to be indented
  *
  * JSHint: [`indent`](http://jshint.com/docs/options/#indent)
  *
@@ -35,7 +40,7 @@
  * }
  * ```
  *
- * ##### Valid example for mode "\t"
+ * ##### Valid example for mode `"\t"`
  *
  * ```js
  * if (a) {
@@ -46,7 +51,7 @@
  * }
  * ```
  *
- * ##### Invalid example for mode "\t"
+ * ##### Invalid example for mode `"\t"`
  *
  * ```js
  * if (a) {
@@ -55,6 +60,28 @@
  *            e=f;
  *  }
  * }
+ * ```
+ *
+ * ##### Valid example for mode `{ "value": "\t", "includeEmptyLines": true }`
+ * ```js
+ * if (a) {
+ *     b=c;
+ *     function(d) {
+ *         e=f;
+ *     }
+ *
+ * } // single tab character on previous line
+ * ```
+ *
+ * ##### Invalid example for mode `{ "value": "\t", "includeEmptyLines": true }`
+ * ```js
+ * if (a) {
+ *     b=c;
+ *     function(d) {
+ *         e=f;
+ *     }
+ *
+ * } // no tab character on previous line
  * ```
  */
 
@@ -79,10 +106,18 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(validateIndentation) {
+        this._includeEmptyLines = false;
+
+        if (typeof validateIndentation === 'object') {
+            this._includeEmptyLines = (validateIndentation.includeEmptyLines === true);
+            validateIndentation = validateIndentation.value;
+        }
+
         assert(
             validateIndentation === '\t' ||
                 (typeof validateIndentation === 'number' && validateIndentation > 0),
-            'validateIndentation option requires a positive number of spaces or "\\t"'
+            'validateIndentation option requires a positive number of spaces or "\\t"' +
+            ' or options object with "value" property'
         );
 
         if (typeof validateIndentation === 'number') {
@@ -213,7 +248,10 @@ module.exports.prototype = {
 
         function getIndentationFromLine(i) {
             var rNotIndentChar = new RegExp('[^' + indentChar + ']');
-            var firstContent = Math.max(lines[i].search(rNotIndentChar), 0);
+            var firstContent = lines[i].search(rNotIndentChar);
+            if (firstContent === -1) {
+                firstContent = lines[i].length;
+            }
             return firstContent;
         }
 
@@ -361,6 +399,14 @@ module.exports.prototype = {
             file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
                 markPushAlt(node);
             });
+
+            if (_this._includeEmptyLines) {
+                file.getLines().forEach(function(line, i) {
+                    if (line.match(/^\s*$/)) {
+                        linesToCheck[i].check = true;
+                    }
+                });
+            }
         }
 
         var _this = this;

--- a/test/rules/disallow-trailing-whitespace.js
+++ b/test/rules/disallow-trailing-whitespace.js
@@ -7,26 +7,46 @@ describe('rules/disallow-trailing-whitespace', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ disallowTrailingWhitespace: true });
     });
 
-    it('should report trailing spaces', function() {
-        assert(checker.checkString('var x; ').getErrorCount() === 1);
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({ disallowTrailingWhitespace: true });
+        });
+
+        it('should report trailing spaces', function() {
+            assert(checker.checkString('var x; ').getErrorCount() === 1);
+        });
+
+        it('should report trailing tabs', function() {
+            assert(checker.checkString('var x;\t').getErrorCount() === 1);
+        });
+
+        it('should report trailing whitespace on empty lines', function() {
+            assert(checker.checkString('if(a){\n\tb=c;\n\t\n}').getErrorCount() === 1);
+        });
+
+        it('should report once for each line', function() {
+            assert(checker.checkString('var x;\t\nvar y;\t').getErrorCount() === 2);
+        });
+
+        it('should not report multiline strings with trailing whitespace', function() {
+            assert(checker.checkString('var x = \' \\\n \';').isEmpty());
+        });
+
+        it('should not report when there is no trailing whitespace', function() {
+            assert(checker.checkString('var x;').isEmpty());
+        });
     });
 
-    it('should report trailing tabs', function() {
-        assert(checker.checkString('var x;\t').getErrorCount() === 1);
+    describe('ignoreEmptyLines', function() {
+        beforeEach(function() {
+            checker.configure({ disallowTrailingWhitespace: 'ignoreEmptyLines' });
+        });
+
+        it('should not report trailing whitespace on empty lines', function() {
+            assert(checker.checkString('if(a){\n\tb=c;\n\t\n}').isEmpty());
+        });
     });
 
-    it('should report once for each line', function() {
-        assert(checker.checkString('var x;\t\nvar y;\t').getErrorCount() === 2);
-    });
-
-    it('should not report multiline strings with trailing whitespace', function() {
-        assert(checker.checkString('var x = \' \\\n \';').isEmpty());
-    });
-
-    it('should not report when there is no trailing whitespace', function() {
-        assert(checker.checkString('var x;').isEmpty());
-    });
 });

--- a/test/rules/validate-indentation.js
+++ b/test/rules/validate-indentation.js
@@ -125,6 +125,31 @@ describe('rules/validate-indentation', function() {
         ]);
     });
 
+    describe('includeEmptyLines', function() {
+        it('should validate indentation on an empty line when includeEmptyLines is true', function() {
+            checker.configure({
+                validateIndentation: {
+                    value: '\t',
+                    includeEmptyLines: true
+                }
+            });
+
+            assert(checker.checkString('if (a){\n\tb=c;\n\n}').getErrorCount() === 1);
+            assert(checker.checkString('if (a){\n\t\n}').isEmpty());
+        });
+
+        it('should not validate indentation on an empty line when includeEmptyLines is false', function() {
+            checker.configure({
+                validateIndentation: {
+                    value: '\t',
+                    includeEmptyLines: false
+                }
+            });
+
+            assert(checker.checkString('if (a){\n\tb=c;\n\n}').isEmpty());
+        });
+    });
+
     describe('switch identation', function() {
         beforeEach(function() {
             checker.configure({ validateIndentation: 4 });


### PR DESCRIPTION
Fixes #719 

The new rule value `ignoreEmptyLines` for `disableTrailingWhitespace` allows for indentation (any other trailing whitespace) on lines that have no other content. This allows for a block to continually have the same indentation, even over empty lines.  This new value also match's jshint's old functionality [of skipping empty lines](https://github.com/jshint/jshint/commit/0c0e19319b276b019d285bdfd2cfc49126abd814#diff-ffa5bd6fde803b83317a7f9e87b5bbe1L1320).

The new rule value `includeEmptyLines` for `validateIndentation` requires indentation on lines that have no other content. This is similar to the ignoreEmptyLines above, but instead of not throwing an error on empty lines that have whitespace, this throws errors for empty lines that do not match the current indentation.

I battled with the thought of breaking out these two new rule values into separate rules (`(disallow|require)IndentationOnEmptyLines`) but after putting some thought and code into it, I decided the above way would be better. If they were rules, they would both need to know what the indentation config was set to, would require very similar code to `validateIndentation`, would conflict with `disableTrailingWhitespace`, change the original meaning of the two other rules, and just wasn't a good way to approach the problem.

My only small problem was that for doc changes, jscs would complain for my example trailing whitespace. I used `"\t"` in one place and a comment in the other to overcome that, but I wasn't sure how you would want that invisible character represented.

Thanks!