### PR TITLE
disallowKeywordsOnNewLine: add special case for "else" without braces

### DIFF
--- a/lib/rules/disallow-keywords-on-new-line.js
+++ b/lib/rules/disallow-keywords-on-new-line.js
@@ -56,14 +56,18 @@ module.exports.prototype = {
 
         file.iterateTokensByType('Keyword', function(token, i, tokens) {
             if (keywordIndex[token.value]) {
-                var prevToken = tokens[i - 1];
-                if (prevToken && prevToken.loc.end.line !== token.loc.start.line) {
-                    errors.add(
-                        'Keyword `' + token.value + '` should not be placed on new line',
-                        token.loc.start.line,
-                        token.loc.start.column
-                    );
+                var prevToken = file.getPrevToken(token);
+
+                // Special case for #905, even though it contradicts rule meaning,
+                // it makes more sense that way.
+                if (token.value === 'else' && prevToken.value !== '}') {
+                    return;
                 }
+
+                errors.assert.sameLine({
+                    token: file.getPrevToken(token),
+                    subjectToken: token
+                });
             }
         });
     }

--- a/lib/rules/require-keywords-on-new-line.js
+++ b/lib/rules/require-keywords-on-new-line.js
@@ -56,14 +56,12 @@ module.exports.prototype = {
 
         file.iterateTokensByType('Keyword', function(token, i, tokens) {
             if (keywordIndex[token.value]) {
-                var prevToken = tokens[i - 1];
-                if (prevToken && prevToken.loc.end.line === token.loc.start.line) {
-                    errors.add(
-                        'Keyword `' + token.value + '` should be placed on new line',
-                        token.loc.start.line,
-                        token.loc.start.column
-                    );
-                }
+                var prevToken = file.getPrevToken(token);
+
+                errors.assert.differentLine({
+                    token: file.getPrevToken(token),
+                    subjectToken: token
+                });
             }
         });
     }

--- a/presets/google.json
+++ b/presets/google.json
@@ -23,6 +23,7 @@
     "disallowTrailingWhitespace": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowMultipleVarDecl": true,
+    "disallowKeywordsOnNewLine": ["else"],
 
     "requireSpaceAfterKeywords": [
       "if",

--- a/test/rules/disallow-keywords-on-new-line.js
+++ b/test/rules/disallow-keywords-on-new-line.js
@@ -42,5 +42,5 @@ describe('rules/disallow-keywords-on-new-line', function() {
                 'else funct[v] = "var";'
             ).isEmpty()
         );
-    })
+    });
 });

--- a/test/rules/disallow-keywords-on-new-line.js
+++ b/test/rules/disallow-keywords-on-new-line.js
@@ -7,6 +7,7 @@ describe('rules/disallow-keywords-on-new-line', function() {
         checker = new Checker();
         checker.registerDefaultRules();
     });
+
     it('should report illegal keyword placement', function() {
         checker.configure({ disallowKeywordsOnNewLine: ['else'] });
         assert(
@@ -20,6 +21,7 @@ describe('rules/disallow-keywords-on-new-line', function() {
             ).getErrorCount() === 1
         );
     });
+
     it('should not report legal keyword placement', function() {
         checker.configure({ disallowKeywordsOnNewLine: ['else'] });
         assert(
@@ -32,4 +34,13 @@ describe('rules/disallow-keywords-on-new-line', function() {
             ).isEmpty()
         );
     });
+
+    it('should not report special case for "else" statement without braces', function() {
+        assert(
+            checker.checkString(
+                'if (block) block[v]["(type)"] = "var";\n' +
+                'else funct[v] = "var";'
+            ).isEmpty()
+        );
+    })
 });


### PR DESCRIPTION
* Fixes #905

* Updates google preset with this option

* Switches to assert API for (require | disallow)KeywordsOnNewLine
