### PR TITLE
requireCapitalizedConstructors: accept list of exempt constructors

### DIFF
--- a/lib/rules/require-capitalized-constructors.js
+++ b/lib/rules/require-capitalized-constructors.js
@@ -1,9 +1,9 @@
 /**
  * Requires constructors to be capitalized (except for `this`)
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `Object`
  *
- * Values: `true`
+ * Values: `true` or Object with `allExcept` Array of quoted identifiers which are exempted
  *
  * JSHint: [`newcap`](http://jshint.com/docs/options/#newcap)
  *
@@ -11,6 +11,9 @@
  *
  * ```js
  * "requireCapitalizedConstructors": true
+ * "requireCapitalizedConstructors": {
+ *     allExcept: ["somethingNative"]
+ * }
  * ```
  *
  * ##### Valid
@@ -18,6 +21,7 @@
  * ```js
  * var a = new B();
  * var c = new this();
+ * var d = new somethingNative();
  * ```
  *
  * ##### Invalid
@@ -32,16 +36,19 @@ var assert = require('assert');
 module.exports = function() {};
 
 module.exports.prototype = {
-
     configure: function(requireCapitalizedConstructors) {
         assert(
-            typeof requireCapitalizedConstructors === 'boolean',
-            'requireCapitalizedConstructors option requires boolean value'
+            requireCapitalizedConstructors === true || Array.isArray(requireCapitalizedConstructors.allExcept),
+            'requireCapitalizedConstructors option requires object of exceptions or true value'
         );
-        assert(
-            requireCapitalizedConstructors === true,
-            'requireCapitalizedConstructors option requires true value or should be removed'
-        );
+        this._allowedConstructors = {};
+
+        var allExcept = requireCapitalizedConstructors.allExcept;
+        if (allExcept) {
+            for (var i = 0, l = allExcept.length; i < l; i++) {
+                this._allowedConstructors[allExcept[i]] = true;
+            }
+        }
     },
 
     getOptionName: function() {
@@ -49,8 +56,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var allowedConstructors = this._allowedConstructors;
+
         file.iterateNodesByType('NewExpression', function(node) {
             if (node.callee.type === 'Identifier' &&
+                !allowedConstructors[node.callee.name] &&
                 node.callee.name[0].toUpperCase() !== node.callee.name[0]
             ) {
                 errors.add(

--- a/test/rules/require-capitalized-constructors.js
+++ b/test/rules/require-capitalized-constructors.js
@@ -4,25 +4,50 @@ var assert = require('assert');
 describe('rules/require-capitalized-constructors', function() {
     var checker;
 
+    function baseCases() {
+        it('should report uncapitalized construction', function() {
+            assert(checker.checkString('var x = new y();').getErrorCount() === 1);
+        });
+
+        it('should not report capitalized construction', function() {
+            assert(checker.checkString('var x = new Y();').isEmpty());
+        });
+
+        it('should not report member expression construction', function() {
+            assert(checker.checkString('var x = new ns.y();').isEmpty());
+        });
+
+        it('should not report construction with "this" keyword', function() {
+            assert(checker.checkString('var x = new this();').isEmpty());
+        });
+    }
+
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requireCapitalizedConstructors: true });
     });
 
-    it('should report uncapitalized construction', function() {
-        assert(checker.checkString('var x = new y();').getErrorCount() === 1);
+    describe('with `true` value', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedConstructors: true });
+        });
+
+        baseCases();
     });
 
-    it('should not report capitalized construction', function() {
-        assert(checker.checkString('var x = new Y();').isEmpty());
-    });
+    describe('with `allExcept` value', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireCapitalizedConstructors: {
+                    allExcept: ['somethingNative']
+                }
+            });
+        });
 
-    it('should not report member expression construction', function() {
-        assert(checker.checkString('var x = new ns.y();').isEmpty());
-    });
+        baseCases();
 
-    it('should not report construction with "this" keyword', function() {
-        assert(checker.checkString('var x = new this();').isEmpty());
+        it('should not report exempted construction', function() {
+            assert(checker.checkString('var x = new somethingNative();').isEmpty());
+        });
     });
 });


### PR DESCRIPTION
This allows requireCapitalizedConstructors to accept either `true`
or a list of constructors that are allowed to remain uncapitalized
By passing a list of identifiers, `true` is assumed.

fixes #390