### PR TITLE
Add support for custom esprima options; fixes #903

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -214,6 +214,20 @@ Value: `true`
 "esnext": true
 ```
 
+### esprimaOptions
+
+Custom `options` to be passed to `esprima.parse(code, options)`
+
+Type: `Object`
+
+Default: `{ "tolerant": true }`
+
+#### Example
+
+```js
+"esprimaOptions": { "tolerant": true }
+```
+
 ### errorFilter
 
 A filter function that determines whether or not to report an error.

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -38,6 +38,7 @@ function Configuration() {
     this._esnextEnabled = false;
     this._es3Enabled = true;
     this._esprima = null;
+    this._esprimaOptions = {};
     this._errorFilter = null;
 }
 
@@ -92,6 +93,7 @@ Configuration.prototype.getProcessedConfig = function() {
     result.esnext = this._esnextEnabled;
     result.es3 = this._es3Enabled;
     result.esprima = this._esprima;
+    result.esprimaOptions = this._esprimaOptions;
     result.errorFilter = this._errorFilter;
     return result;
 };
@@ -188,6 +190,15 @@ Configuration.prototype.hasCustomEsprima = function() {
  */
 Configuration.prototype.getCustomEsprima = function() {
     return this._esprima;
+};
+
+/**
+ * Returns custom Esprima options.
+ *
+ * @returns {Object}
+ */
+Configuration.prototype.getEsprimaOptions = function() {
+    return this._esprimaOptions;
 };
 
 /**
@@ -313,6 +324,10 @@ Configuration.prototype._processConfig = function(config) {
         this._loadEsprima(config.esprima);
     }
 
+    if (config.hasOwnProperty('esprimaOptions')) {
+        this._loadEsprimaOptions(config.esprimaOptions);
+    }
+
     if (config.hasOwnProperty('errorFilter')) {
         this._loadErrorFilter(config.errorFilter);
     }
@@ -366,6 +381,17 @@ Configuration.prototype._loadEsprima = function(esprima) {
         '`esprima` option requires a null value or an object with a parse function'
     );
     this._esprima = esprima;
+};
+
+/**
+ * Loads custom Esprima options.
+ *
+ * @param {Object} esprimaOptions
+ * @protected
+ */
+Configuration.prototype._loadEsprimaOptions = function(esprimaOptions) {
+    assert(typeof esprimaOptions === 'object' && esprimaOptions !== null, '`esprimaOptions` should be an object');
+    this._esprimaOptions = esprimaOptions;
 };
 
 /**

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -94,13 +94,23 @@ StringChecker.prototype = {
         // Strip special case code like iOS instrumentation imports: `#import 'abc.js';`
         str = str.replace(/^#!?[^\n]+\n/gm, '');
 
-        tree = this._esprima.parse(str, {
-            loc: true,
-            range: true,
-            comment: true,
-            tokens: true,
-            sourceType: 'module'
-        });
+        var esprimaOptions = {
+            tolerant: true
+        };
+        var esprimaOptionsFromConfig = this._configuration.getEsprimaOptions();
+        for (var key in esprimaOptionsFromConfig) {
+            if (esprimaOptionsFromConfig.hasOwnProperty(key)) {
+                esprimaOptions[key] = esprimaOptionsFromConfig[key];
+            }
+        }
+        // Set required options
+        esprimaOptions.loc = true;
+        esprimaOptions.range = true;
+        esprimaOptions.comment = true;
+        esprimaOptions.tokens = true;
+        esprimaOptions.sourceType = 'module';
+
+        tree = this._esprima.parse(str, esprimaOptions);
 
         // Remove the bin annotation comment
         if (hashbang) {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "colors": "~1.0.3",
     "commander": "~2.5.0",
     "esprima": "~1.2.2",
-    "esprima-harmony-jscs": "1.1.0-regex-token-fix",
+    "esprima-harmony-jscs": "1.1.0-tolerate-import",
     "estraverse": "~1.9.0",
     "exit": "~0.1.2",
     "glob": "~4.0.0",

--- a/test/config/configuration.js
+++ b/test/config/configuration.js
@@ -147,6 +147,36 @@ describe('modules/config/configuration', function() {
         });
     });
 
+    describe('getEsprimaOptions', function() {
+        function assertBadEsprimaOptions(esprimaOptions) {
+            assert.throws(function() {
+                configuration.load({esprimaOptions: esprimaOptions});
+            }, /^AssertionError: `esprimaOptions` should be an object$/);
+        }
+
+        it('should return the supplied esprima options', function() {
+            configuration.load({esprimaOptions: { foo: 'bar' }});
+            assert.deepEqual(configuration.getEsprimaOptions(), {foo: 'bar'});
+        });
+
+        it('should reject null as the esprima options', function() {
+            assertBadEsprimaOptions(null);
+        });
+
+        it('should reject booleans as the esprima options', function() {
+            assertBadEsprimaOptions(true);
+            assertBadEsprimaOptions(false);
+        });
+
+        it('should reject a number as the esprima options', function() {
+            assertBadEsprimaOptions(42.7);
+        });
+
+        it('should reject a string as the esprima options', function() {
+            assertBadEsprimaOptions('snafu');
+        });
+    });
+
     describe('hasPreset', function() {
         it('should return true if preset presents in collection', function() {
             var preset = {maxErrors: 5};

--- a/test/config/configuration.js
+++ b/test/config/configuration.js
@@ -383,7 +383,7 @@ describe('modules/config/configuration', function() {
             assert(spy.getCall(0).args[0] === configuration);
         });
 
-        it('should thow non-camelcase error for underscore-config', function() {
+        it('should throw non-camelcase error for underscore-config', function() {
             var rule = {
                 getOptionName: function() {
                     return 'ruleName';
@@ -409,7 +409,7 @@ describe('modules/config/configuration', function() {
             }
         });
 
-        it('should thow non-camelcase error with converted sub-configs', function() {
+        it('should throw non-camelcase error with converted sub-configs', function() {
             var rule = {
                 getOptionName: function() {
                     return 'ruleName';

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -1,5 +1,6 @@
 var Checker = require('../lib/checker');
 var assert = require('assert');
+var sinon = require('sinon');
 
 describe('modules/string-checker', function() {
     var checker;
@@ -204,6 +205,106 @@ describe('modules/string-checker', function() {
 
             assert(error.rule === 'parseError');
             assert(error.message !== customDescription);
+        });
+    });
+
+    describe('esprima options', function() {
+        var code = 'import { foo } from "bar";';
+        var customEsprima = {
+            parse: function(code, options) {
+                var error = new Error();
+                error.description = 'in no way a real error message';
+                error.lineNumber = 1;
+                error.column = 0;
+
+                throw error;
+            }
+        };
+
+        beforeEach(function() {
+            sinon.spy(customEsprima, 'parse');
+        });
+        afterEach(function() {
+            customEsprima.parse.restore();
+        });
+
+        it('sets the "tolerant" esprima option to true by default', function() {
+            checker = new Checker({ esprima: customEsprima });
+            checker.registerDefaultRules();
+
+            checker.checkString(code);
+
+            assert(customEsprima.parse.calledOnce);
+            assert(customEsprima.parse.calledWith(code, {
+                tolerant: true,
+                loc: true,
+                range: true,
+                comment: true,
+                tokens: true,
+                sourceType: 'module'
+            }));
+        });
+
+        it('allows the "tolerant" esprima option to be overridden', function() {
+            checker = new Checker({ esprima: customEsprima });
+            checker.registerDefaultRules();
+            checker.configure({ esprimaOptions: { tolerant: false } });
+
+            checker.checkString(code);
+
+            assert(customEsprima.parse.calledOnce);
+            assert(customEsprima.parse.calledWith(code, {
+                tolerant: false,
+                loc: true,
+                range: true,
+                comment: true,
+                tokens: true,
+                sourceType: 'module'
+            }));
+        });
+
+        it('uses custom esprima options when set in the config', function() {
+            checker = new Checker({ esprima: customEsprima });
+            checker.registerDefaultRules();
+            checker.configure({ esprimaOptions: { foobar: 'qux', barbaz: 'fred' } });
+
+            checker.checkString(code);
+
+            assert(customEsprima.parse.calledOnce);
+            assert(customEsprima.parse.calledWith(code, {
+                foobar: 'qux',
+                barbaz: 'fred',
+                tolerant: true,
+                loc: true,
+                range: true,
+                comment: true,
+                tokens: true,
+                sourceType: 'module'
+            }));
+        });
+
+        it('does not override required esprima options', function() {
+            checker = new Checker({ esprima: customEsprima });
+            checker.registerDefaultRules();
+            checker.configure({ esprimaOptions: {
+                loc: false,
+                range: false,
+                comment: false,
+                tokens: false,
+                sourceType: 'script'
+            }});
+
+            checker.checkString(code);
+
+            assert(customEsprima.parse.calledOnce);
+            assert(customEsprima.parse.calledWith(code, {
+                tolerant: true, // not required
+                loc: true,
+                range: true,
+                comment: true,
+                tokens: true,
+                sourceType: 'module'
+            }));
         });
     });
 


### PR DESCRIPTION
Work-in-progress attempt at fixing #903.
This seems to pass through the options properly. The 2 new tests currently fail because `esprima-harmony-jscs` is outdated and doesn't include https://github.com/ariya/esprima/commit/b1dd29e985b353648a6e0fa8b9f852cd2db228ac (Should I file an issue at https://github.com/jscs-dev/esprima-harmony for that?)