### PR TITLE
disallowSpacesInsideArrayBrackets: fix rule name in example

### DIFF
--- a/lib/rules/disallow-spaces-inside-array-brackets.js
+++ b/lib/rules/disallow-spaces-inside-array-brackets.js
@@ -13,7 +13,7 @@
  *
  * // or
  *
- * "requireSpacesInsideArrayBrackets": {
+ * "disallowSpacesInsideArrayBrackets": {
  *     "allExcept": [ "[", "]", "{", "}" ]
  * }
  * ```


### PR DESCRIPTION
Found this small mistake in the examples of the `disallowSpacesInsideArrayBrackets` rule :)