### PR TITLE
disallowStringLiteralStatements: create new rule

### DIFF
--- a/lib/rules/disallow-string-statements.js
+++ b/lib/rules/disallow-string-statements.js
@@ -1,0 +1,51 @@
+/**
+ * Disallows string literal statements.
+ *
+ * Type: `Boolean`
+ *
+ * Values: true
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowStringLiteralStatements": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * 'use strict';
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * 'use-strict';
+ * 'just a string';
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(disallowStringLiteralStatements) {
+        assert(disallowStringLiteralStatements, 'disallowStringLiteralStatements option requires true value');
+    },
+
+    getOptionName: function() {
+        return 'disallowStringLiteralStatements';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ExpressionStatement', function(node) {
+            var expr = node.expression;
+            if (expr.type === 'Literal' && typeof expr.value === 'string' && expr.value !== 'use strict') {
+                errors.add('Only \'use strict\' literal statement is allowed', node.loc.start);
+            }
+        });
+    }
+
+};

--- a/test/rules/disallow-string-statements.js
+++ b/test/rules/disallow-string-statements.js
@@ -1,0 +1,20 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-string-statements', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowStringLiteralStatements: true });
+    });
+
+    it('should not report strict directive', function() {
+        assert(checker.checkString('\'use strict\';').isEmpty());
+    });
+
+    it('should report a mis-spelled directive', function() {
+        assert(checker.checkString('\'use-strict\';').getErrorCount() === 1);
+    });
+});


### PR DESCRIPTION
A common error I see is a misspelled 'use strict' directive. By
adding a rule to not allow string literal statements, we can
avoid this whole class of errors.  This new rule causes an error
any time a string statement other than 'use strict' appears.