### PR TITLE
Fix error messages for whitespaceBetween

### DIFF
--- a/lib/rules/disallow-space-before-block-statements.js
+++ b/lib/rules/disallow-space-before-block-statements.js
@@ -75,7 +75,6 @@ module.exports.prototype = {
             errors.assert.noWhitespaceBetween({
                 token: file.getPrevToken(first),
                 nextToken: first,
-                spaces: 1,
                 disallowNewLine: true,
                 message: 'Extra space before opening curly brace for block expressions'
             });

--- a/lib/rules/disallow-space-between-arguments.js
+++ b/lib/rules/disallow-space-between-arguments.js
@@ -59,7 +59,7 @@ module.exports.prototype = {
                     errors.assert.noWhitespaceBetween({
                         token: punctuatorToken,
                         nextToken: file.getNextToken(punctuatorToken),
-                        spaces: 1
+                        message: 'Illegal space between arguments'
                     });
                 }
             });

--- a/lib/rules/disallow-spaces-inside-array-brackets.js
+++ b/lib/rules/disallow-spaces-inside-array-brackets.js
@@ -110,7 +110,6 @@ module.exports.prototype = {
             errors.assert.noWhitespaceBetween({
                 token: token,
                 nextToken: nextToken,
-                spaces: 1,
                 message: 'Illegal space after opening bracket'
             });
         });
@@ -131,7 +130,6 @@ module.exports.prototype = {
             errors.assert.noWhitespaceBetween({
                 token: prevToken,
                 nextToken: token,
-                spaces: 1,
                 message: 'Illegal space before closing bracket'
             });
         });

--- a/lib/rules/disallow-spaces-inside-object-brackets.js
+++ b/lib/rules/disallow-spaces-inside-object-brackets.js
@@ -98,7 +98,6 @@ module.exports.prototype = {
             errors.assert.noWhitespaceBetween({
                 token: openingBracket,
                 nextToken: nextToken,
-                spaces: 1,
                 message: 'Illegal space after opening curly brace'
             });
 
@@ -112,7 +111,6 @@ module.exports.prototype = {
             errors.assert.noWhitespaceBetween({
                 token: prevToken,
                 nextToken: closingBracket,
-                spaces: 1,
                 message: 'Illegal space before closing curly brace'
             });
         });

--- a/lib/rules/require-spaces-in-for-statement.js
+++ b/lib/rules/require-spaces-in-for-statement.js
@@ -66,7 +66,7 @@ module.exports.prototype = {
                     token: prevToken,
                     nextToken: testToken,
                     spaces: 1,
-                    message: 'Missing space after semicolon'
+                    message: 'Require one space after semicolon'
                 });
             }
             if (node.update) {
@@ -76,7 +76,7 @@ module.exports.prototype = {
                     token: prevToken,
                     nextToken: updateToken,
                     spaces: 1,
-                    message: 'Missing space after semicolon'
+                    message: 'Require one space after semicolon'
                 });
             }
         });

--- a/lib/rules/require-spaces-inside-array-brackets.js
+++ b/lib/rules/require-spaces-inside-array-brackets.js
@@ -110,7 +110,7 @@ module.exports.prototype = {
                 token: token,
                 nextToken: nextToken,
                 spaces: 1,
-                message: 'Missing space after opening bracket'
+                message: 'Require one space after opening bracket'
             });
         });
 
@@ -131,7 +131,7 @@ module.exports.prototype = {
                 token: prevToken,
                 nextToken: token,
                 spaces: 1,
-                message: 'Missing space before closing bracket'
+                message: 'Require one space before closing bracket'
             });
         });
     }

--- a/lib/rules/require-spaces-inside-object-brackets.js
+++ b/lib/rules/require-spaces-inside-object-brackets.js
@@ -105,7 +105,7 @@ module.exports.prototype = {
                 token: openingBracket,
                 nextToken: nextToken,
                 spaces: 1,
-                message: 'Missing space after opening curly brace'
+                message: 'Require one space after opening curly brace'
             });
 
             var closingBracket = file.getLastNodeToken(node);
@@ -119,7 +119,7 @@ module.exports.prototype = {
                 token: prevToken,
                 nextToken: closingBracket,
                 spaces: 1,
-                message: 'Missing space before closing curly brace'
+                message: 'Require one space before closing curly brace'
             });
         });
     }

--- a/lib/rules/validate-parameter-separator.js
+++ b/lib/rules/validate-parameter-separator.js
@@ -68,7 +68,7 @@ module.exports.prototype = {
                             token: prevParamToken,
                             nextToken: punctuatorToken,
                             spaces: 1,
-                            message: 'Missing space after function parameter \'' + prevParamToken.value + '\''
+                            message: 'Require one space after function parameter \'' + prevParamToken.value + '\''
                         });
                     } else {
                         errors.assert.noWhitespaceBetween({
@@ -85,7 +85,7 @@ module.exports.prototype = {
                             token: punctuatorToken,
                             nextToken: nextParamToken,
                             spaces: 1,
-                            message: 'Missing space before function parameter \'' + nextParamToken.value + '\''
+                            message: 'Require one space before function parameter \'' + nextParamToken.value + '\''
                         });
                     } else {
                         errors.assert.noWhitespaceBetween({


### PR DESCRIPTION
For #949.

Since the rules enforce only one space.

Also removed `spaces: 1` for `noWhitespaceBetween` since it doesn't use that as an option?