### PR TITLE
JSHint: remove "forin" option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,6 @@
     "bitwise"  : true,
     "undef"    : true,
     "eqeqeq"   : true,
-    "forin"    : true,
     "noarg"    : true,
     "mocha"    : true
 }


### PR DESCRIPTION
We do not and will never include any module that tamper
with the Object property, so this check is unnecessary
and will prevent us from achieving 100% code coverage.

/cc @mdevils @markelog 