### PR TITLE
requireParenthesesAroundIIFE: ensure to get the closingToken

### DIFF
--- a/lib/rules/require-parentheses-around-iife.js
+++ b/lib/rules/require-parentheses-around-iife.js
@@ -61,7 +61,10 @@ module.exports.prototype = {
             var openingToken = file.getTokenPosByRangeStart(node.range[0]);
             var closingToken = file.getTokenPosByRangeStart(node.range[1] - 1);
 
-            return tokens[openingToken - 1].value + tokens[closingToken + 1].value === '()';
+            var closingTokenValue = tokens[closingToken + 1] ?
+                tokens[closingToken + 1].value : undefined;
+
+            return tokens[openingToken - 1].value + closingTokenValue === '()';
         }
 
         file.iterateNodesByType('CallExpression', function(node) {

--- a/test/rules/require-parentheses-around-iife.js
+++ b/test/rules/require-parentheses-around-iife.js
@@ -22,6 +22,13 @@ describe('rules/require-parentheses-around-iife', function() {
         assert(checker.checkString('var d = function(){return d;}.apply(this, args);').getErrorCount() === 1);
     });
 
+    it('should report iife invoked with no trailing semicolon', function() {
+        assert(checker.checkString('+function(){return 1;}()').getErrorCount() === 1);
+        assert(checker.checkString('var a = function(){return 1;}()').getErrorCount() === 1);
+        assert(checker.checkString('var c = function(){return 3;}.call(this, arg1)').getErrorCount() === 1);
+        assert(checker.checkString('var d = function(){return d;}.apply(this, args)').getErrorCount() === 1);
+    });
+
     it('should not report non-iife function expressions', function() {
         assert(checker.checkString('var a = function(){return 1;};').isEmpty());
     });


### PR DESCRIPTION
This fixes bug for checking string with no trailing semicolon
since the closing token is not reachable.

Fixes #965