### PR TITLE
Speed up builds by using Docker-based Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: node_js
 
 script: "npm run travis"


### PR DESCRIPTION
It should reduce the build time down to ~20s. More details are at http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/