### PR TITLE
Update airbnb.json

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -30,7 +30,7 @@
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
-    "requireMultipleVarDecl": "onevar",
+    "disallowMultipleVarDecl": true,
     "requireBlocksOnNewline": 1,
     "requireCommaBeforeLineBreak": true,
     "requireSpaceBeforeBinaryOperators": true,


### PR DESCRIPTION
Change `"requireMultipleVarDecl": "onevar",` to `"disallowMultipleVarDecl": true,`.

The new rule: http://jscs.info/rules.html#disallowmultiplevardecl

In order to actually follow the [AirBnB Style Guide](https://github.com/airbnb/javascript#variables) for variable declaration.