### PR TITLE
 requireSpace(AfterPrefix|BeforePostfix)UnaryOperators: use tokenAssert ...

### DIFF
--- a/lib/rules/require-space-after-prefix-unary-operators.js
+++ b/lib/rules/require-space-after-prefix-unary-operators.js
@@ -61,9 +61,8 @@ module.exports.prototype = {
             // Check "node.prefix" for prefix type of (inc|dec)rement
             if (node.prefix && operatorIndex[node.operator]) {
                 var argument = node.argument.type;
-                var operatorTokenIndex = file.getTokenPosByRangeStart(node.range[0]);
-                var operatorToken = tokens[operatorTokenIndex];
-                var nextToken = tokens[operatorTokenIndex + 1];
+                var operatorToken = file.getFirstNodeToken(node);
+                var nextToken = file.getNextToken(operatorToken);
 
                 // Do not report consecutive operators (#405)
                 if (
@@ -73,9 +72,12 @@ module.exports.prototype = {
                     return;
                 }
 
-                if (operatorToken.range[1] === nextToken.range[0]) {
-                    errors.add('Operator ' + node.operator + ' should not stick to operand', node.loc.start);
-                }
+                errors.assert.whitespaceBetween({
+                    token: operatorToken,
+                    nextToken: nextToken,
+                    message: 'Operator ' + node.operator + ' should not stick to operand',
+                    spaces: 1
+                });
             }
         });
     }

--- a/lib/rules/require-space-before-postfix-unary-operators.js
+++ b/lib/rules/require-space-before-postfix-unary-operators.js
@@ -17,6 +17,7 @@
  * ```js
  * x = y ++; y = z --;
  * ```
+ *
  * ##### Invalid
  *
  * ```js
@@ -61,13 +62,14 @@ module.exports.prototype = {
         file.iterateNodesByType('UpdateExpression', function(node) {
             // "!node.prefix" means postfix type of (inc|dec)rement
             if (!node.prefix && operatorIndex[node.operator]) {
-                var operatorStartPos = node.range[1] - node.operator.length;
-                var operatorTokenIndex = file.getTokenPosByRangeStart(operatorStartPos);
-                var operatorToken = tokens[operatorTokenIndex];
-                var prevToken = tokens[operatorTokenIndex - 1];
-                if (operatorToken.range[0] === prevToken.range[1]) {
-                    errors.add('Operator ' + node.operator + ' should not stick to operand', node.loc.start);
-                }
+                var operatorToken = file.getLastNodeToken(node);
+
+                errors.assert.whitespaceBetween({
+                    token: file.getPrevToken(operatorToken),
+                    nextToken: operatorToken,
+                    message: 'Operator ' + node.operator + ' should not stick to operand',
+                    spaces: 1
+                });
             }
         });
     }

--- a/test/rules/require-space-after-prefix-unary-operators.js
+++ b/test/rules/require-space-after-prefix-unary-operators.js
@@ -23,18 +23,21 @@ describe('rules/require-space-after-prefix-unary-operators', function() {
                     assert(checker.checkString(sticked).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notSticked + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterPrefixUnaryOperators: value });
                     assert(checker.checkString(notSticked).isEmpty());
                 }
             );
+
             it('should report sticky operator for ' + stickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterPrefixUnaryOperators: value });
                     assert(checker.checkString(stickedWithParenthesis).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notStickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceAfterPrefixUnaryOperators: value });
@@ -48,6 +51,7 @@ describe('rules/require-space-after-prefix-unary-operators', function() {
         checker.configure({ requireSpaceAfterPrefixUnaryOperators: ['-', '~', '!', '++'] });
         assert(checker.checkString('var x = ~(0); ++(((x))); -( x ); !(++( x ));').getErrorCount() === 5);
     });
+
     it('should not report consecutive operators (#405)', function() {
         checker.configure({ requireSpaceAfterPrefixUnaryOperators: ['!'] });
         assert(checker.checkString('!~test;').isEmpty());

--- a/test/rules/require-space-before-postfix-unary-operators.js
+++ b/test/rules/require-space-before-postfix-unary-operators.js
@@ -23,18 +23,21 @@ describe('rules/require-space-before-postfix-unary-operators', function() {
                     assert(checker.checkString(sticked).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notSticked + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceBeforePostfixUnaryOperators: value });
                     assert(checker.checkString(notSticked).isEmpty());
                 }
             );
+
             it('should report sticky operator for ' + stickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceBeforePostfixUnaryOperators: value });
                     assert(checker.checkString(stickedWithParenthesis).getErrorCount() === 1);
                 }
             );
+
             it('should not report sticky operator for ' + notStickedWithParenthesis + ' with ' + value + ' option',
                 function() {
                     checker.configure({ requireSpaceBeforePostfixUnaryOperators: value });
@@ -48,10 +51,12 @@ describe('rules/require-space-before-postfix-unary-operators', function() {
         checker.configure({ requireSpaceBeforePostfixUnaryOperators: ['++', '--'] });
         assert(checker.checkString('var x = 2; x++; x--;').getErrorCount() === 2);
     });
+
     it('should report sticky operator if operand in parentheses', function() {
         checker.configure({ requireSpaceBeforePostfixUnaryOperators: ['++', '--'] });
         assert(checker.checkString('var x = 2; ( x )++; (((x)))--;').getErrorCount() === 2);
     });
+
     it('should not report separated operator', function() {
         checker.configure({ requireSpaceBeforePostfixUnaryOperators: ['++', '--'] });
         assert(checker.checkString('var x = 2; x ++; x --;').isEmpty());


### PR DESCRIPTION
...methods

Refactoring to use

```js
file.getFirstNodeToken(node);
file.getNextToken(node);
errors.assert.whitespaceBetween({});
```

Also newlines in the test files