### PR TITLE
spaces* rules: use tokenAssert methods

### DIFF
--- a/lib/rules/disallow-padding-newlines-in-blocks.js
+++ b/lib/rules/disallow-padding-newlines-in-blocks.js
@@ -54,12 +54,10 @@ module.exports.prototype = {
         var tokens = file.getTokens();
 
         file.iterateNodesByType('BlockStatement', function(node) {
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
-            var openingBracket = tokens[openingBracketPos];
+            var openingBracket = file.getFirstNodeToken(node);
             var startLine = openingBracket.loc.start.line;
 
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
-            var closingBracket = tokens[closingBracketPos];
+            var closingBracket = file.getLastNodeToken(node);
             var closingLine = closingBracket.loc.start.line;
 
             if (startLine === closingLine) {

--- a/lib/rules/disallow-padding-newlines-in-objects.js
+++ b/lib/rules/disallow-padding-newlines-in-objects.js
@@ -56,10 +56,8 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
             var tokens = file.getTokens();
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
-
-            var openingBracket = tokens[openingBracketPos];
-            var nextToken = tokens[openingBracketPos + 1];
+            var openingBracket = file.getFirstNodeToken(node);
+            var nextToken = file.getNextToken(openingBracket);
 
             if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
                 return;
@@ -69,9 +67,8 @@ module.exports.prototype = {
                 errors.add('Illegal newline after opening curly brace', nextToken.loc.start);
             }
 
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
-            var closingBracket = tokens[closingBracketPos];
-            var prevToken = tokens[closingBracketPos - 1];
+            var closingBracket = file.getLastNodeToken(node);
+            var prevToken = file.getPrevToken(closingBracket);
 
             if (closingBracket.loc.start.line !== prevToken.loc.end.line) {
                 errors.add('Illegal newline before closing curly brace', closingBracket.loc.start);

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -46,12 +46,13 @@ module.exports.prototype = {
         var tokens = file.getTokens();
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                var key = property.key;
-                var keyPos = file.getTokenPosByRangeStart(key.range[0]);
-                var colon = tokens[keyPos + 1];
-                if (colon.range[0] !== key.range[1]) {
-                    errors.add('Illegal space after key', key.loc.end);
-                }
+                var token = file.getFirstNodeToken(property.key);
+                errors.assert.noWhitespaceBetween({
+                    token: token,
+                    nextToken: file.getNextToken(token),
+                    message: 'Illegal space after key',
+                    disallowNewLine: true
+                });
             });
         });
     }

--- a/lib/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -80,7 +80,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
             var parent = node.parentNode;
@@ -94,32 +93,21 @@ module.exports.prototype = {
             if (!node.id) {
 
                 if (beforeOpeningRoundBrace) {
-                    var nodeBeforeRoundBrace = node;
-
-                    var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                    var functionToken = tokens[functionTokenPos];
-
-                    var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                    var nextToken = tokens[nextTokenPos];
-
-                    if (!nextToken) {
-                        errors.add(
-                            'Illegal space before opening round brace',
-                            functionToken.loc.end
-                        );
-                    }
+                    var functionToken = file.getFirstNodeToken(node);
+                    errors.assert.noWhitespaceBetween({
+                        token: functionToken,
+                        nextToken: file.getNextToken(functionToken),
+                        message: 'Illegal space before opening round brace',
+                    });
                 }
 
                 if (beforeOpeningCurlyBrace) {
-                    var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                    var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                    if (!tokenBeforeBody) {
-                        errors.add(
-                            'Illegal space before opening curly brace',
-                            node.body.loc.start
-                        );
-                    }
+                    var bodyToken = file.getFirstNodeToken(node.body);
+                    errors.assert.noWhitespaceBetween({
+                        token: file.getPrevToken(bodyToken),
+                        nextToken: bodyToken,
+                        message: 'Illegal space before opening curly brace',
+                    });
                 }
             }
         });

--- a/lib/rules/disallow-spaces-in-function-declaration.js
+++ b/lib/rules/disallow-spaces-in-function-declaration.js
@@ -72,41 +72,26 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration'], function(node) {
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (!nextToken) {
-                    errors.add(
-                        'Illegal space before opening round brace',
-                        functionToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.noWhitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Illegal space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (!tokenBeforeBody) {
-                    errors.add(
-                        'Illegal space before opening curly brace',
-                        node.body.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.noWhitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Illegal space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/disallow-spaces-in-function-expression.js
+++ b/lib/rules/disallow-spaces-in-function-expression.js
@@ -74,7 +74,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType('FunctionExpression', function(node) {
             var parent = node.parentNode;
@@ -85,36 +84,22 @@ module.exports.prototype = {
             }
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (!nextToken) {
-                    errors.add(
-                        'Illegal space before opening round brace',
-                        functionToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.noWhitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Illegal space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (!tokenBeforeBody) {
-                    errors.add(
-                        'Illegal space before opening curly brace',
-                        node.body.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.noWhitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Illegal space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/disallow-spaces-in-function.js
+++ b/lib/rules/disallow-spaces-in-function.js
@@ -76,7 +76,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
             var parent = node.parentNode;
@@ -87,36 +86,22 @@ module.exports.prototype = {
             }
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (!nextToken) {
-                    errors.add(
-                        'Illegal space before opening round brace',
-                        functionToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.noWhitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Illegal space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (!tokenBeforeBody) {
-                    errors.add(
-                        'Illegal space before opening curly brace',
-                        node.body.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.noWhitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Illegal space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/disallow-spaces-in-named-function-expression.js
+++ b/lib/rules/disallow-spaces-in-named-function-expression.js
@@ -73,7 +73,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
 
@@ -81,32 +80,21 @@ module.exports.prototype = {
             if (node.id) {
 
                 if (beforeOpeningRoundBrace) {
-                    var nodeBeforeRoundBrace = node.id;
-
-                    var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                    var functionToken = tokens[functionTokenPos];
-
-                    var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                    var nextToken = tokens[nextTokenPos];
-
-                    if (!nextToken) {
-                        errors.add(
-                            'Illegal space before opening round brace',
-                            functionToken.loc.start
-                        );
-                    }
+                    var functionToken = file.getFirstNodeToken(node.id);
+                    errors.assert.noWhitespaceBetween({
+                        token: functionToken,
+                        nextToken: file.getNextToken(functionToken),
+                        message: 'Illegal space before opening round brace',
+                    });
                 }
 
                 if (beforeOpeningCurlyBrace) {
-                    var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                    var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                    if (!tokenBeforeBody) {
-                        errors.add(
-                            'Illegal space before opening curly brace',
-                            node.body.loc.start
-                        );
-                    }
+                    var bodyToken = file.getFirstNodeToken(node.body);
+                    errors.assert.noWhitespaceBetween({
+                        token: file.getPrevToken(bodyToken),
+                        nextToken: bodyToken,
+                        message: 'Illegal space before opening curly brace',
+                    });
                 }
             }
         });

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -84,8 +84,8 @@ module.exports.prototype = {
             }
 
             node.properties.forEach(function(property) {
-                var keyPos = file.getTokenPosByRangeStart(property.key.range[0]);
-                var colon = tokens[keyPos + 1];
+                var keyToken = file.getFirstNodeToken(property.key);
+                var colon = file.getNextToken(keyToken);
                 if (colon.loc.start.column !== maxKeyEndPos + 1) {
                     errors.add('Alignment required', colon.loc.start);
                 }

--- a/lib/rules/require-blocks-on-newline.js
+++ b/lib/rules/require-blocks-on-newline.js
@@ -72,18 +72,15 @@ module.exports.prototype = {
                 return;
             }
             var tokens = file.getTokens();
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
-
-            var openingBracket = tokens[openingBracketPos];
-            var nextToken = tokens[openingBracketPos + 1];
+            var openingBracket = file.getFirstNodeToken(node);
+            var nextToken = file.getNextToken(openingBracket);
 
             if (openingBracket.loc.start.line === nextToken.loc.start.line) {
                 errors.add('Missing newline after opening curly brace', openingBracket.loc.end);
             }
 
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
-            var closingBracket = tokens[closingBracketPos];
-            var prevToken = tokens[closingBracketPos - 1];
+            var closingBracket = file.getLastNodeToken(node);
+            var prevToken = file.getPrevToken(closingBracket);
 
             if (closingBracket.loc.start.line === prevToken.loc.start.line) {
                 errors.add('Missing newline before closing curly brace', prevToken.loc.end);

--- a/lib/rules/require-padding-newlines-in-objects.js
+++ b/lib/rules/require-padding-newlines-in-objects.js
@@ -55,11 +55,8 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
-            var tokens = file.getTokens();
-            var openingBracketPos = file.getTokenPosByRangeStart(node.range[0]);
-
-            var openingBracket = tokens[openingBracketPos];
-            var nextToken = tokens[openingBracketPos + 1];
+            var openingBracket = file.getFirstNodeToken(node);
+            var nextToken = file.getNextToken(openingBracket);
 
             if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
                 return;
@@ -69,9 +66,8 @@ module.exports.prototype = {
                 errors.add('Missing newline after opening curly brace', nextToken.loc.start);
             }
 
-            var closingBracketPos = file.getTokenPosByRangeStart(node.range[1] - 1);
-            var closingBracket = tokens[closingBracketPos];
-            var prevToken = tokens[closingBracketPos - 1];
+            var closingBracket = file.getLastNodeToken(node);
+            var prevToken = file.getPrevToken(closingBracket);
 
             if (closingBracket.loc.start.line === prevToken.loc.end.line) {
                 errors.add('Missing newline before closing curly brace', closingBracket.loc.start);

--- a/lib/rules/require-space-after-object-keys.js
+++ b/lib/rules/require-space-after-object-keys.js
@@ -46,12 +46,12 @@ module.exports.prototype = {
         var tokens = file.getTokens();
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                var key = property.key;
-                var keyPos = file.getTokenPosByRangeStart(key.range[0]);
-                var colon = tokens[keyPos + 1];
-                if (colon.range[0] === key.range[1]) {
-                    errors.add('Missing space after key', key.loc.end);
-                }
+                var token = file.getFirstNodeToken(property.key);
+                errors.assert.whitespaceBetween({
+                    token: token,
+                    nextToken: file.getNextToken(token),
+                    message: 'Missing space after key'
+                });
             });
         });
     }

--- a/lib/rules/require-space-after-prefix-unary-operators.js
+++ b/lib/rules/require-space-after-prefix-unary-operators.js
@@ -75,8 +75,7 @@ module.exports.prototype = {
                 errors.assert.whitespaceBetween({
                     token: operatorToken,
                     nextToken: nextToken,
-                    message: 'Operator ' + node.operator + ' should not stick to operand',
-                    spaces: 1
+                    message: 'Operator ' + node.operator + ' should not stick to operand'
                 });
             }
         });

--- a/lib/rules/require-space-before-postfix-unary-operators.js
+++ b/lib/rules/require-space-before-postfix-unary-operators.js
@@ -67,8 +67,7 @@ module.exports.prototype = {
                 errors.assert.whitespaceBetween({
                     token: file.getPrevToken(operatorToken),
                     nextToken: operatorToken,
-                    message: 'Operator ' + node.operator + ' should not stick to operand',
-                    spaces: 1
+                    message: 'Operator ' + node.operator + ' should not stick to operand'
                 });
             }
         });

--- a/lib/rules/require-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/require-spaces-in-anonymous-function-expression.js
@@ -80,7 +80,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
             var parent = node.parentNode;
@@ -93,32 +92,21 @@ module.exports.prototype = {
             if (!node.id) {
 
                 if (beforeOpeningRoundBrace) {
-                    var nodeBeforeRoundBrace = node;
-
-                    var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                    var functionToken = tokens[functionTokenPos];
-
-                    var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                    var nextToken = tokens[nextTokenPos];
-
-                    if (nextToken) {
-                        errors.add(
-                            'Missing space before opening round brace',
-                            nextToken.loc.start
-                        );
-                    }
+                    var functionToken = file.getFirstNodeToken(node);
+                    errors.assert.whitespaceBetween({
+                        token: functionToken,
+                        nextToken: file.getNextToken(functionToken),
+                        message: 'Missing space before opening round brace'
+                    });
                 }
 
                 if (beforeOpeningCurlyBrace) {
-                    var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                    var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                    if (tokenBeforeBody) {
-                        errors.add(
-                            'Missing space before opening curly brace',
-                            tokenBeforeBody.loc.start
-                        );
-                    }
+                    var bodyToken = file.getFirstNodeToken(node.body);
+                    errors.assert.whitespaceBetween({
+                        token: file.getPrevToken(bodyToken),
+                        nextToken: bodyToken,
+                        message: 'Missing space before opening curly brace'
+                    });
                 }
             }
         });

--- a/lib/rules/require-spaces-in-function-declaration.js
+++ b/lib/rules/require-spaces-in-function-declaration.js
@@ -72,41 +72,26 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration'], function(node) {
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (nextToken) {
-                    errors.add(
-                        'Missing space before opening round brace',
-                        nextToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.whitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Missing space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (tokenBeforeBody) {
-                    errors.add(
-                        'Missing space before opening curly brace',
-                        tokenBeforeBody.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.whitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Missing space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/require-spaces-in-function-expression.js
+++ b/lib/rules/require-spaces-in-function-expression.js
@@ -74,7 +74,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType('FunctionExpression', function(node) {
             var parent = node.parentNode;
@@ -85,36 +84,22 @@ module.exports.prototype = {
             }
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (nextToken) {
-                    errors.add(
-                        'Missing space before opening round brace',
-                        nextToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.whitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Missing space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (tokenBeforeBody) {
-                    errors.add(
-                        'Missing space before opening curly brace',
-                        tokenBeforeBody.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.whitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Missing space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/require-spaces-in-function.js
+++ b/lib/rules/require-spaces-in-function.js
@@ -76,7 +76,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
             var parent = node.parentNode;
@@ -87,36 +86,22 @@ module.exports.prototype = {
             }
 
             if (beforeOpeningRoundBrace) {
-                var nodeBeforeRoundBrace = node;
-                // named function
-                if (node.id) {
-                    nodeBeforeRoundBrace = node.id;
-                }
-
-                var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                var functionToken = tokens[functionTokenPos];
-
-                var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                var nextToken = tokens[nextTokenPos];
-
-                if (nextToken) {
-                    errors.add(
-                        'Missing space before opening round brace',
-                        nextToken.loc.start
-                    );
-                }
+                // for a named function, use node.id
+                var functionToken = file.getFirstNodeToken(node.id || node);
+                errors.assert.whitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Missing space before opening round brace',
+                });
             }
 
             if (beforeOpeningCurlyBrace) {
-                var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                if (tokenBeforeBody) {
-                    errors.add(
-                        'Missing space before opening curly brace',
-                        tokenBeforeBody.loc.start
-                    );
-                }
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.whitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Missing space before opening curly brace',
+                });
             }
         });
     }

--- a/lib/rules/require-spaces-in-named-function-expression.js
+++ b/lib/rules/require-spaces-in-named-function-expression.js
@@ -73,39 +73,27 @@ module.exports.prototype = {
     check: function(file, errors) {
         var beforeOpeningRoundBrace = this._beforeOpeningRoundBrace;
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
-        var tokens = file.getTokens();
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
 
             if (node.id) {
 
                 if (beforeOpeningRoundBrace) {
-                    var nodeBeforeRoundBrace = node.id;
-
-                    var functionTokenPos = file.getTokenPosByRangeStart(nodeBeforeRoundBrace.range[0]);
-                    var functionToken = tokens[functionTokenPos];
-
-                    var nextTokenPos = file.getTokenPosByRangeStart(functionToken.range[1]);
-                    var nextToken = tokens[nextTokenPos];
-
-                    if (nextToken) {
-                        errors.add(
-                            'Missing space before opening round brace',
-                            nextToken.loc.start
-                        );
-                    }
+                    var functionToken = file.getFirstNodeToken(node.id);
+                    errors.assert.whitespaceBetween({
+                        token: functionToken,
+                        nextToken: file.getNextToken(functionToken),
+                        message: 'Missing space before opening round brace',
+                    });
                 }
 
                 if (beforeOpeningCurlyBrace) {
-                    var tokenBeforeBodyPos = file.getTokenPosByRangeStart(node.body.range[0] - 1);
-                    var tokenBeforeBody = tokens[tokenBeforeBodyPos];
-
-                    if (tokenBeforeBody) {
-                        errors.add(
-                            'Missing space before opening curly brace',
-                            tokenBeforeBody.loc.start
-                        );
-                    }
+                    var bodyToken = file.getFirstNodeToken(node.body);
+                    errors.assert.whitespaceBetween({
+                        token: file.getPrevToken(bodyToken),
+                        nextToken: bodyToken,
+                        message: 'Missing space before opening curly brace',
+                    });
                 }
             }
         });


### PR DESCRIPTION
checked for anything like

```
var openingBracket = file.getTokenPosByRangeStart(node.range[0]);
openingBracket = tokens[openingBracketPos];
var nextToken = tokens[openingBracketPos + 1];
```
Used `file.get[First|Last]NodeToken` and `file.get[Next|Prev]Token` instead

I didn't change the IIFE rule since there's already a PR for that.

These methods definitely make it easier to read/create new whitespace rules!
