### PR TITLE
Removed requireMultipleVarDecl option

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -30,7 +30,6 @@
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,
-    "requireMultipleVarDecl": "onevar",
     "requireBlocksOnNewline": 1,
     "requireCommaBeforeLineBreak": true,
     "requireSpaceBeforeBinaryOperators": true,


### PR DESCRIPTION
Looking at [here](https://github.com/airbnb/javascript#variables) it seems that it's not required to have only one `var` declaration, but the opposite.
  