### PR TITLE
Update: .editorconfig - fix for invalid indent_style value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = spaces
+indent_style = space
 indent_size = 4
 
 [package.json]


### PR DESCRIPTION
@mikesherov 
`indent_style` value - `spaces` is not valid,
changed to `space`