### PR TITLE
Rule of Silence - do not print to console if there are no errors

### DIFF
--- a/lib/reporters/console.js
+++ b/lib/reporters/console.js
@@ -22,7 +22,9 @@ module.exports = function(errorsCollection) {
          * Printing summary.
          */
         console.log('\n' + errorCount + ' code style ' + (errorCount === 1 ? 'error' : 'errors') + ' found.');
-    } else {
-        console.log('No code style errors found.');
     }
+
+    /**
+     * "Rule of Silence": When we have nothing interesting to say, say nothing.
+     */
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -44,7 +44,7 @@ describe('modules/cli', function() {
             var stderr = process.stderr.write.getCall(0) ? process.stderr.write.getCall(0).args[0] : '';
             assert.equal(
                 stdout,
-                'No code style errors found.\n',
+                '',
                 stderr
             );
             rAfter();

--- a/test/reporters/console.js
+++ b/test/reporters/console.js
@@ -19,11 +19,10 @@ describe('reporters/console', function() {
         console.log.restore();
     });
 
-    it('should correctly reports no errors', function() {
+    it('should not call console.log when there are no errors', function() {
         consoleReporter([checker.checkString('a++;')]);
 
-        assert.equal(console.log.getCall(0).args[0], 'No code style errors found.');
-        assert(console.log.calledOnce);
+        assert(console.log.notCalled);
     });
 
     it('should correctly report 1 error', function() {


### PR DESCRIPTION
> The rule of silence, also referred to as the silence is golden rule, is an important part of the Unix philosophy that states that when a program has nothing surprising, interesting or useful to say, it should say nothing. It means that well-behaved programs should treat their users' attention and concentration as being valuable and thus perform their tasks as unobtrusively as possible. That is, silence in itself is a virtue. (http://www.linfo.org/rule_of_silence.html)

Fixes #962 - jscs violates the Rule of Silence