### PR TITLE
(require|disallow)NewlineBeforeBlockStatements: Fine-grained control

### DIFF
--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -184,8 +184,8 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var setting = this._setting;
-        if (setting === true) {
-            file.iterateNodesByType('BlockStatement', function(node) {
+        file.iterateNodesByType('BlockStatement', function(node) {
+            if (setting === true || setting.indexOf(getBlockType(node)) !== -1) {
                 var openingBrace = file.getFirstNodeToken(node);
                 var prevToken = file.getPrevToken(openingBrace);
 
@@ -194,22 +194,8 @@ module.exports.prototype = {
                     nextToken: openingBrace,
                     message: 'Newline before curly brace for block statement is disallowed'
                 });
-            });
-        } else {
-            file.iterateNodesByType(['BlockStatement'], function(node) {
-                var type = getBlockType(node);
-                if (setting.indexOf(type) !== -1) {
-                    var openingBrace = file.getFirstNodeToken(node);
-                    var prevToken = file.getPrevToken(openingBrace);
-
-                    errors.assert.sameLine({
-                        token: prevToken,
-                        nextToken: openingBrace,
-                        message: 'Newline before curly brace for "' + type + '" block statement is disallowed'
-                    });
-                }
-            });
-        }
+            }
+        });
     }
 };
 

--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -67,22 +67,113 @@
  *     foo();
  * }
  * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowNewlineBeforeBlockStatements": ["if", "else", "for"]
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * if (i > 0) {
+ *     positive = true;
+ * }
+ *
+ * if (i < 0) {
+ *     negative = true;
+ * } else {
+ *     negative = false;
+ * }
+ *
+ * for (var i = 0, len = myList.length; i < len; ++i) {
+ *     newList.push(myList[i]);
+ * }
+ *
+ * // this is fine, since "function" wasn't configured
+ * function myFunc(x)
+ * {
+ *     return x + 1;
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (i < 0)
+ * {
+ *     negative = true;
+ * }
+ *
+ * if (i < 0)
+ * {
+ *     negative = true;
+ * }
+ * else
+ * {
+ *     negative = false;
+ * }
+ *
+ * for (var i = 0, len = myList.length; i < len; ++i)
+ * {
+ *     newList.push(myList[i]);
+ * }
+ * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowNewlineBeforeBlockStatements": ["function", "while"]
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * function myFunc(x) {
+ *     return x + 1;
+ * }
+ *
+ * var z = function(x) {
+ *     return x - 1;
+ * }
+ *
+ * // this is fine, since "for" wasn't configured
+ * for (var i = 0, len = myList.length; i < len; ++i)
+ * {
+ *     newList.push(myList[i]);
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function myFunc(x)
+ * {
+ *     return x + 1;
+ * }
+ *
+ * var z = function(x)
+ * {
+ *     return x - 1;
+ * }
+ * ```
  */
 
 var assert = require('assert');
 
+var allowedKeywords = ['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function'];
+
 module.exports = function() {};
 
 module.exports.prototype = {
-    configure: function(disallowNewlineBeforeBlockStatements) {
+    configure: function(settingValue) {
         assert(
-            typeof disallowNewlineBeforeBlockStatements === 'boolean',
-            'disallowNewlineBeforeBlockStatements option requires boolean value'
+            Array.isArray(settingValue) && settingValue.length || settingValue === true,
+            'disallowNewlineBeforeBlockStatements option requires non-empty array value or true value'
         );
-        assert(
-            disallowNewlineBeforeBlockStatements === true,
-            'disallowNewlineBeforeBlockStatements option requires true value or should be removed'
-        );
+
+        this._setting = settingValue;
     },
 
     getOptionName: function() {
@@ -90,15 +181,82 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateNodesByType('BlockStatement', function(node) {
+        if (this._setting === true) {
+            checkAll(file, errors);
+        } else {
+            checkSpecificTypes(file, errors, this._setting);
+        }
+    }
+};
+
+function checkAll(file, errors) {
+    file.iterateNodesByType('BlockStatement', function(node) {
+        var openingBrace = file.getFirstNodeToken(node);
+        var prevToken = file.getPrevToken(openingBrace);
+
+        errors.assert.sameLine({
+            token: prevToken,
+            nextToken: openingBrace,
+            message: 'Newline before curly brace for block statement is disallowed'
+        });
+    });
+}
+
+function checkSpecificTypes(file, errors, types) {
+    file.iterateNodesByType(['BlockStatement'], function(node) {
+        var type = getBlockType(node);
+        if (types.indexOf(type) !== -1) {
             var openingBrace = file.getFirstNodeToken(node);
             var prevToken = file.getPrevToken(openingBrace);
 
             errors.assert.sameLine({
                 token: prevToken,
                 nextToken: openingBrace,
-                message: 'Newline before curly brace for block statement is disallowed'
+                message: 'Newline before curly brace for "' + type + '" block statement is disallowed'
             });
-        });
+        }
+    });
+}
+
+function getBlockType(node) {
+    var parentType = node.parentNode.type;
+    var blockType;
+    switch (parentType) {
+        case 'IfStatement':
+            if (node.parentNode.alternate === node) {
+                blockType = 'else';
+            } else {
+                blockType = 'if';
+            }
+            break;
+        case 'FunctionDeclaration':
+        case 'FunctionExpression':
+            blockType = 'function';
+            break;
+        case 'ForStatement':
+        case 'ForInStatement':
+        case 'ForOfStatement':
+            blockType = 'for';
+            break;
+        case 'WhileStatement':
+            blockType = 'while';
+            break;
+        case 'DoWhileStatement':
+            blockType = 'do';
+            break;
+        case 'TryStatement':
+            if (node.parentNode.finalizer === node) {
+                blockType = 'finally';
+            } else {
+                blockType = 'try';
+            }
+            break;
+        case 'CatchClause':
+            blockType = 'catch';
+            break;
+        default:
+            blockType = 'other';
+            break;
     }
-};
+    return blockType;
+}

--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -7,6 +7,7 @@
  *
  * - `true` always disallows newline before curly brace of block statements
  * - `Array` specifies block-type keywords after which newlines are disallowed before curly brace
+ *     - Valid types include: `['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function']`
  *
  * #### Example
  *
@@ -165,8 +166,6 @@
 
 var assert = require('assert');
 
-var allowedKeywords = ['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function'];
-
 module.exports = function() {};
 
 module.exports.prototype = {
@@ -184,82 +183,57 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        if (this._setting === true) {
-            checkAll(file, errors);
+        var setting = this._setting;
+        if (setting === true) {
+            file.iterateNodesByType('BlockStatement', function(node) {
+                var openingBrace = file.getFirstNodeToken(node);
+                var prevToken = file.getPrevToken(openingBrace);
+
+                errors.assert.sameLine({
+                    token: prevToken,
+                    nextToken: openingBrace,
+                    message: 'Newline before curly brace for block statement is disallowed'
+                });
+            });
         } else {
-            checkSpecificTypes(file, errors, this._setting);
+            file.iterateNodesByType(['BlockStatement'], function(node) {
+                var type = getBlockType(node);
+                if (setting.indexOf(type) !== -1) {
+                    var openingBrace = file.getFirstNodeToken(node);
+                    var prevToken = file.getPrevToken(openingBrace);
+
+                    errors.assert.sameLine({
+                        token: prevToken,
+                        nextToken: openingBrace,
+                        message: 'Newline before curly brace for "' + type + '" block statement is disallowed'
+                    });
+                }
+            });
         }
     }
 };
 
-function checkAll(file, errors) {
-    file.iterateNodesByType('BlockStatement', function(node) {
-        var openingBrace = file.getFirstNodeToken(node);
-        var prevToken = file.getPrevToken(openingBrace);
-
-        errors.assert.sameLine({
-            token: prevToken,
-            nextToken: openingBrace,
-            message: 'Newline before curly brace for block statement is disallowed'
-        });
-    });
-}
-
-function checkSpecificTypes(file, errors, types) {
-    file.iterateNodesByType(['BlockStatement'], function(node) {
-        var type = getBlockType(node);
-        if (types.indexOf(type) !== -1) {
-            var openingBrace = file.getFirstNodeToken(node);
-            var prevToken = file.getPrevToken(openingBrace);
-
-            errors.assert.sameLine({
-                token: prevToken,
-                nextToken: openingBrace,
-                message: 'Newline before curly brace for "' + type + '" block statement is disallowed'
-            });
-        }
-    });
-}
-
 function getBlockType(node) {
-    var parentType = node.parentNode.type;
-    var blockType;
-    switch (parentType) {
+    var parentNode = node.parentNode;
+    switch (parentNode.type) {
         case 'IfStatement':
-            if (node.parentNode.alternate === node) {
-                blockType = 'else';
-            } else {
-                blockType = 'if';
-            }
-            break;
+            return (parentNode.alternate === node) ? 'else' : 'if';
         case 'FunctionDeclaration':
         case 'FunctionExpression':
-            blockType = 'function';
-            break;
+            return 'function';
         case 'ForStatement':
         case 'ForInStatement':
         case 'ForOfStatement':
-            blockType = 'for';
-            break;
+            return 'for';
         case 'WhileStatement':
-            blockType = 'while';
-            break;
+            return 'while';
         case 'DoWhileStatement':
-            blockType = 'do';
-            break;
+            return 'do';
         case 'TryStatement':
-            if (node.parentNode.finalizer === node) {
-                blockType = 'finally';
-            } else {
-                blockType = 'try';
-            }
-            break;
+            return (parentNode.finalizer === node) ? 'finally' : 'try';
         case 'CatchClause':
-            blockType = 'catch';
-            break;
+            return 'catch';
         default:
-            blockType = 'other';
-            break;
+            return false;
     }
-    return blockType;
 }

--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -1,9 +1,12 @@
 /**
  * Disallows newline before opening curly brace of all block statements.
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `Array`
  *
- * Values: `true`
+ * Values:
+ *
+ * - `true` always disallows newline before curly brace of block statements
+ * - `Array` specifies block-type keywords after which newlines are disallowed before curly brace
  *
  * #### Example
  *

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -3,8 +3,10 @@
  *
  * Type: `Boolean` or `Array`
  *
- * Values: `true` always requires newline before curly brace of block statements
- * `Array` specifies block-starting keywords after which newlines are required before curly brace
+ * Values:
+ *
+ * - `true` always requires newline before curly brace of block statements
+ * - `Array` specifies block-starting keywords after which newlines are required before curly brace
  *
  * #### Example
  *

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -6,7 +6,8 @@
  * Values:
  *
  * - `true` always requires newline before curly brace of block statements
- * - `Array` specifies block-starting keywords after which newlines are required before curly brace
+ * - `Array` specifies block-type keywords after which newlines are required before curly brace
+ *     - Valid types include: `['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function']`
  *
  * #### Example
  *
@@ -163,8 +164,6 @@
 
 var assert = require('assert');
 
-var allowedKeywords = ['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function'];
-
 module.exports = function() {};
 
 module.exports.prototype = {
@@ -182,82 +181,57 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        if (this._setting === true) {
-            checkAll(file, errors);
+        var setting = this._setting;
+        if (setting === true) {
+            file.iterateNodesByType('BlockStatement', function(node) {
+                var openingBrace = file.getFirstNodeToken(node);
+                var prevToken = file.getPrevToken(openingBrace);
+
+                errors.assert.differentLine({
+                    token: prevToken,
+                    nextToken: openingBrace,
+                    message: 'Missing newline before curly brace for block statement'
+                });
+            });
         } else {
-            checkSpecificTypes(file, errors, this._setting);
+            file.iterateNodesByType(['BlockStatement'], function(node) {
+                var type = getBlockType(node);
+                if (setting.indexOf(type) !== -1) {
+                    var openingBrace = file.getFirstNodeToken(node);
+                    var prevToken = file.getPrevToken(openingBrace);
+
+                    errors.assert.differentLine({
+                        token: prevToken,
+                        nextToken: openingBrace,
+                        message: 'Missing newline before curly brace for "' + type + '" block statement'
+                    });
+                }
+            });
         }
     }
 };
 
-function checkAll(file, errors) {
-    file.iterateNodesByType('BlockStatement', function(node) {
-        var openingBrace = file.getFirstNodeToken(node);
-        var prevToken = file.getPrevToken(openingBrace);
-
-        errors.assert.differentLine({
-            token: prevToken,
-            nextToken: openingBrace,
-            message: 'Missing newline before curly brace for block statement'
-        });
-    });
-}
-
-function checkSpecificTypes(file, errors, types) {
-    file.iterateNodesByType(['BlockStatement'], function(node) {
-        var type = getBlockType(node);
-        if (types.indexOf(type) !== -1) {
-            var openingBrace = file.getFirstNodeToken(node);
-            var prevToken = file.getPrevToken(openingBrace);
-
-            errors.assert.differentLine({
-                token: prevToken,
-                nextToken: openingBrace,
-                message: 'Missing newline before curly brace for "' + type + '" block statement'
-            });
-        }
-    });
-}
-
 function getBlockType(node) {
-    var parentType = node.parentNode.type;
-    var blockType;
-    switch (parentType) {
+    var parentNode = node.parentNode;
+    switch (parentNode.type) {
         case 'IfStatement':
-            if (node.parentNode.alternate === node) {
-                blockType = 'else';
-            } else {
-                blockType = 'if';
-            }
-            break;
+            return (parentNode.alternate === node) ? 'else' : 'if';
         case 'FunctionDeclaration':
         case 'FunctionExpression':
-            blockType = 'function';
-            break;
+            return 'function';
         case 'ForStatement':
         case 'ForInStatement':
         case 'ForOfStatement':
-            blockType = 'for';
-            break;
+            return 'for';
         case 'WhileStatement':
-            blockType = 'while';
-            break;
+            return 'while';
         case 'DoWhileStatement':
-            blockType = 'do';
-            break;
+            return 'do';
         case 'TryStatement':
-            if (node.parentNode.finalizer === node) {
-                blockType = 'finally';
-            } else {
-                blockType = 'try';
-            }
-            break;
+            return (parentNode.finalizer === node) ? 'finally' : 'try';
         case 'CatchClause':
-            blockType = 'catch';
-            break;
+            return 'catch';
         default:
-            blockType = 'other';
-            break;
+            return false;
     }
-    return blockType;
 }

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -182,8 +182,8 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var setting = this._setting;
-        if (setting === true) {
-            file.iterateNodesByType('BlockStatement', function(node) {
+        file.iterateNodesByType('BlockStatement', function(node) {
+            if (setting === true || setting.indexOf(getBlockType(node)) !== -1) {
                 var openingBrace = file.getFirstNodeToken(node);
                 var prevToken = file.getPrevToken(openingBrace);
 
@@ -192,22 +192,8 @@ module.exports.prototype = {
                     nextToken: openingBrace,
                     message: 'Missing newline before curly brace for block statement'
                 });
-            });
-        } else {
-            file.iterateNodesByType(['BlockStatement'], function(node) {
-                var type = getBlockType(node);
-                if (setting.indexOf(type) !== -1) {
-                    var openingBrace = file.getFirstNodeToken(node);
-                    var prevToken = file.getPrevToken(openingBrace);
-
-                    errors.assert.differentLine({
-                        token: prevToken,
-                        nextToken: openingBrace,
-                        message: 'Missing newline before curly brace for "' + type + '" block statement'
-                    });
-                }
-            });
-        }
+            }
+        });
     }
 };
 

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -1,9 +1,10 @@
 /**
  * Requires newline before opening curly brace of all block statements.
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `Array`
  *
- * Values: `true`
+ * Values: `true` always requires newline before curly brace of block statements
+ * `Array` specifies block-starting keywords after which newlines are required before curly brace
  *
  * #### Example
  *
@@ -67,22 +68,111 @@
  *     foo();
  * }
  * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireNewlineBeforeBlockStatements": ["if", "else", "for"]
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * if (i > 0)
+ * {
+ *     positive = true;
+ * }
+ *
+ * if (i < 0)
+ * {
+ *     negative = true;
+ * }
+ * else
+ * {
+ *     negative = false;
+ * }
+ *
+ * for (var i = 0, len = myList.length; i < len; ++i)
+ * {
+ *     newList.push(myList[i]);
+ * }
+ *
+ * // this is fine, since "function" wasn't configured
+ * function myFunc(x) {
+ *     return x + 1;
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (i < 0) {
+ *     negative = true;
+ * }
+ *
+ * if (i < 0) {
+ *     negative = true;
+ * } else {
+ *     negative = false;
+ * }
+ *
+ * for (var i = 0, len = myList.length; i < len; ++i) {
+ *     newList.push(myList[i]);
+ * }
+ * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireNewlineBeforeBlockStatements": ["function", "while"]
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * function myFunc(x)
+ * {
+ *     return x + 1;
+ * }
+ *
+ * var z = function(x)
+ * {
+ *     return x - 1;
+ * }
+ *
+ * // this is fine, since "for" wasn't configured
+ * for (var i = 0, len = myList.length; i < len; ++i) {
+ *     newList.push(myList[i]);
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function myFunc(x) {
+ *     return x + 1;
+ * }
+ *
+ * var z = function(x) {
+ *     return x - 1;
+ * }
+ * ```
  */
 
 var assert = require('assert');
 
+var allowedKeywords = ['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function'];
+
 module.exports = function() {};
 
 module.exports.prototype = {
-    configure: function(requireNewlineBeforeBlockStatements) {
+    configure: function(settingValue) {
         assert(
-            typeof requireNewlineBeforeBlockStatements === 'boolean',
-            'requireNewlineBeforeBlockStatements option requires boolean value'
+            Array.isArray(settingValue) && settingValue.length || settingValue === true,
+            'requireNewlineBeforeBlockStatements option requires non-empty array value or true value'
         );
-        assert(
-            requireNewlineBeforeBlockStatements === true,
-            'requireNewlineBeforeBlockStatements option requires true value or should be removed'
-        );
+
+        this._setting = settingValue;
     },
 
     getOptionName: function() {
@@ -90,15 +180,82 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateNodesByType('BlockStatement', function(node) {
+        if (this._setting === true) {
+            checkAll(file, errors);
+        } else {
+            checkSpecificTypes(file, errors, this._setting);
+        }
+    }
+};
+
+function checkAll(file, errors) {
+    file.iterateNodesByType('BlockStatement', function(node) {
+        var openingBrace = file.getFirstNodeToken(node);
+        var prevToken = file.getPrevToken(openingBrace);
+
+        errors.assert.differentLine({
+            token: prevToken,
+            nextToken: openingBrace,
+            message: 'Missing newline before curly brace for block statement'
+        });
+    });
+}
+
+function checkSpecificTypes(file, errors, types) {
+    file.iterateNodesByType(['BlockStatement'], function(node) {
+        var type = getBlockType(node);
+        if (types.indexOf(type) !== -1) {
             var openingBrace = file.getFirstNodeToken(node);
             var prevToken = file.getPrevToken(openingBrace);
 
             errors.assert.differentLine({
                 token: prevToken,
                 nextToken: openingBrace,
-                message: 'Missing newline before curly brace for block statement'
+                message: 'Missing newline before curly brace for "' + type + '" block statement'
             });
-        });
+        }
+    });
+}
+
+function getBlockType(node) {
+    var parentType = node.parentNode.type;
+    var blockType;
+    switch (parentType) {
+        case 'IfStatement':
+            if (node.parentNode.alternate === node) {
+                blockType = 'else';
+            } else {
+                blockType = 'if';
+            }
+            break;
+        case 'FunctionDeclaration':
+        case 'FunctionExpression':
+            blockType = 'function';
+            break;
+        case 'ForStatement':
+        case 'ForInStatement':
+        case 'ForOfStatement':
+            blockType = 'for';
+            break;
+        case 'WhileStatement':
+            blockType = 'while';
+            break;
+        case 'DoWhileStatement':
+            blockType = 'do';
+            break;
+        case 'TryStatement':
+            if (node.parentNode.finalizer === node) {
+                blockType = 'finally';
+            } else {
+                blockType = 'try';
+            }
+            break;
+        case 'CatchClause':
+            blockType = 'catch';
+            break;
+        default:
+            blockType = 'other';
+            break;
     }
-};
+    return blockType;
+}

--- a/test/rules/disallow-newline-before-block-statements.js
+++ b/test/rules/disallow-newline-before-block-statements.js
@@ -9,7 +9,7 @@ describe('rules/disallow-newline-before-block-statements', function() {
         checker.registerDefaultRules();
     });
 
-    describe('option value true', function() {
+    describe('with option value true -', function() {
         beforeEach(function() {
             checker.configure({ disallowNewlineBeforeBlockStatements: true });
         });
@@ -54,6 +54,229 @@ describe('rules/disallow-newline-before-block-statements', function() {
 
         it('should not throw error if opening parentheses is first symbol in the file', function() {
             assert(checker.checkString('{ test: 1 }').isEmpty());
+        });
+    });
+
+    describe('with option value array - ', function() {
+
+        describe('"if" blocks', function() {
+            it('should report extra newlines when configured with "if"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "if" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "if"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"else" and "else if" blocks', function() {
+            it('should report extra newlines when configured with "else"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse\n{\n\tx--;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "else" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse {\n\tx--;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "else"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse\n{\n\tx--;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"for" loops', function() {
+            it('should report extra newlines when configured with "for"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i)\n{\n\tx++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "for" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i) {\n\tx++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when note configured with "for"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i)\n{\n\tx++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"for...in" loops', function() {
+            it('should report extra newlines when configured with "for"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i in x)\n{\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "for" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i in x) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "for"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('for (var i in x)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('function declarations', function() {
+            it('should report extra newlines when configured with "function"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('function myFunc(y)\n{\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "function" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('function myFunc(y) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "function"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('function myFunc(y)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('function statements', function() {
+            it('should report extra newlines when configured with "function"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('var z = function(y)\n{\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "function" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('var z = function(y) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "function"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('var z = function(y)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"try" blocks', function() {
+            it('should report extra newlines when configured with "try"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['try'] });
+                assert(checker.checkString('try\n{\n\ty++;\n} catch(e) {\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "try" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['try'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n}\nfinally\n{\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "try"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try\n{\n\ty++;\n} catch(e) {\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"catch" blocks', function() {
+            it('should report extra newlines when configured with "catch"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['catch'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e)\n{\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "catch" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['catch'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "catch"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e)\n{\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"finally" blocks', function() {
+            it('should report extra newlines when configured with "finally"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['finally'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n} finally\n{\n\tq = 5;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "finally" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['finally'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n} finally {\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "finally"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n} finally\n{\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"while" loops', function() {
+            it('should report extra newlines when configured with "while"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['while'] });
+                assert(checker.checkString('while (x < 10)\n{\n\tx++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "while" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['while'] });
+                assert(checker.checkString('while (x < 10) {\n\tx++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "while"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('while (x < 10)\n{\n\tx++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"do...while" loops', function() {
+            it('should report extra newlines when configured with "do"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['do'] });
+                assert(checker.checkString('do\n{\n\tx++;\n} while (x < 10);')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "do" and newline not added', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['do'] });
+                assert(checker.checkString('do {\n\tx++;\n} while (x < 10);')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "do"', function() {
+                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('do\n{\n\tx++;\n} while (x < 10);')
+                    .isEmpty());
+            });
         });
     });
 });

--- a/test/rules/disallow-newline-before-block-statements.js
+++ b/test/rules/disallow-newline-before-block-statements.js
@@ -58,16 +58,17 @@ describe('rules/disallow-newline-before-block-statements', function() {
     });
 
     describe('with option value array - ', function() {
-
         describe('"if" blocks', function() {
-            it('should report extra newlines when configured with "if"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
+            });
+
+            it('should report extra newlines when configured with "if"', function() {
                 assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "if" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['if'] });
                 assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
                     .isEmpty());
             });
@@ -80,14 +81,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"else" and "else if" blocks', function() {
-            it('should report extra newlines when configured with "else"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['else'] });
+            });
+
+            it('should report extra newlines when configured with "else"', function() {
                 assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse\n{\n\tx--;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "else" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['else'] });
                 assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse {\n\tx--;\n}')
                     .isEmpty());
             });
@@ -100,14 +103,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"for" loops', function() {
-            it('should report extra newlines when configured with "for"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+            });
+
+            it('should report extra newlines when configured with "for"', function() {
                 assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i)\n{\n\tx++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "for" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i) {\n\tx++;\n}')
                     .isEmpty());
             });
@@ -120,14 +125,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"for...in" loops', function() {
-            it('should report extra newlines when configured with "for"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
+            });
+
+            it('should report extra newlines when configured with "for"', function() {
                 assert(checker.checkString('for (var i in x)\n{\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "for" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('for (var i in x) {\n\ty++;\n}')
                     .isEmpty());
             });
@@ -140,14 +147,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('function declarations', function() {
-            it('should report extra newlines when configured with "function"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+            });
+
+            it('should report extra newlines when configured with "function"', function() {
                 assert(checker.checkString('function myFunc(y)\n{\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "function" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
                 assert(checker.checkString('function myFunc(y) {\n\ty++;\n}')
                     .isEmpty());
             });
@@ -160,14 +169,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('function statements', function() {
-            it('should report extra newlines when configured with "function"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
+            });
+
+            it('should report extra newlines when configured with "function"', function() {
                 assert(checker.checkString('var z = function(y)\n{\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "function" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['function'] });
                 assert(checker.checkString('var z = function(y) {\n\ty++;\n}')
                     .isEmpty());
             });
@@ -180,14 +191,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"try" blocks', function() {
-            it('should report extra newlines when configured with "try"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['try'] });
+            });
+
+            it('should report extra newlines when configured with "try"', function() {
                 assert(checker.checkString('try\n{\n\ty++;\n} catch(e) {\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "try" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['try'] });
                 assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n}\nfinally\n{\n\tq = 5;\n}')
                     .isEmpty());
             });
@@ -200,14 +213,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"catch" blocks', function() {
-            it('should report extra newlines when configured with "catch"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['catch'] });
+            });
+
+            it('should report extra newlines when configured with "catch"', function() {
                 assert(checker.checkString('try {\n\ty++;\n} catch(e)\n{\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "catch" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['catch'] });
                 assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n}')
                     .isEmpty());
             });
@@ -220,14 +235,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"finally" blocks', function() {
-            it('should report extra newlines when configured with "finally"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['finally'] });
+            });
+
+            it('should report extra newlines when configured with "finally"', function() {
                 assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n} finally\n{\n\tq = 5;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "finally" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['finally'] });
                 assert(checker.checkString('try {\n\ty++;\n} catch(e) {\n} finally {\n\tq = 5;\n}')
                     .isEmpty());
             });
@@ -240,14 +257,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"while" loops', function() {
-            it('should report extra newlines when configured with "while"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['while'] });
+            });
+
+            it('should report extra newlines when configured with "while"', function() {
                 assert(checker.checkString('while (x < 10)\n{\n\tx++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "while" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['while'] });
                 assert(checker.checkString('while (x < 10) {\n\tx++;\n}')
                     .isEmpty());
             });
@@ -260,14 +279,16 @@ describe('rules/disallow-newline-before-block-statements', function() {
         });
 
         describe('"do...while" loops', function() {
-            it('should report extra newlines when configured with "do"', function() {
+            beforeEach(function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['do'] });
+            });
+
+            it('should report extra newlines when configured with "do"', function() {
                 assert(checker.checkString('do\n{\n\tx++;\n} while (x < 10);')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "do" and newline not added', function() {
-                checker.configure({ disallowNewlineBeforeBlockStatements: ['do'] });
                 assert(checker.checkString('do {\n\tx++;\n} while (x < 10);')
                     .isEmpty());
             });
@@ -275,6 +296,29 @@ describe('rules/disallow-newline-before-block-statements', function() {
             it('should not complain when not configured with "do"', function() {
                 checker.configure({ disallowNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('do\n{\n\tx++;\n} while (x < 10);')
+                    .isEmpty());
+            });
+        });
+
+        describe('other block types', function() {
+            beforeEach(function() {
+                checker.configure({
+                    disallowNewlineBeforeBlockStatements: [
+                        'if',
+                        'else',
+                        'try',
+                        'catch',
+                        'finally',
+                        'do',
+                        'while',
+                        'for',
+                        'function'
+                    ]
+                });
+            });
+
+            it('should be ignored', function() {
+                assert(checker.checkString('{\nvar y = { "things": "stuff" };\n}')
                     .isEmpty());
             });
         });

--- a/test/rules/require-newline-before-block-statements.js
+++ b/test/rules/require-newline-before-block-statements.js
@@ -9,7 +9,7 @@ describe('rules/require-newline-before-block-statements', function() {
         checker.registerDefaultRules();
     });
 
-    describe('option value true', function() {
+    describe('with option value true - ', function() {
         beforeEach(function() {
             checker.configure({ requireNewlineBeforeBlockStatements: true });
         });
@@ -52,6 +52,229 @@ describe('rules/require-newline-before-block-statements', function() {
 
         it('should not throw error if opening parentheses is first symbol in the file', function() {
             assert(checker.checkString('{test: 1 }').isEmpty());
+        });
+    });
+
+    describe('with option value array - ', function() {
+
+        describe('"if" blocks', function() {
+            it('should report missing newlines when configured with "if"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "if" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "if"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"else" and "else if" blocks', function() {
+            it('should report missing newlines when configured with "else"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse{\n\tx--;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "else" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['else'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse\n{\n\tx--;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "else"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse{\n\tx--;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"for" loops', function() {
+            it('should report missing newlines when configured with "for"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i) {\n\tx++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "for" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i)\n{\n\tx++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when note configured with "for"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i) {\n\tx++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"for...in" loops', function() {
+            it('should report missing newlines when configured with "for"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i in x) {\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "for" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('for (var i in x)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "for"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('for (var i in x) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('function declarations', function() {
+            it('should report missing newlines when configured with "function"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('function myFunc(y) {\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "function" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('function myFunc(y)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "function"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('function myFunc(y) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('function statements', function() {
+            it('should report missing newlines when configured with "function"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('var z = function(y) {\n\ty++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "function" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+                assert(checker.checkString('var z = function(y)\n{\n\ty++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "function"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+                assert(checker.checkString('var z = function(y) {\n\ty++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"try" blocks', function() {
+            it('should report missing newlines when configured with "try"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['try'] });
+                assert(checker.checkString('try {\n\ty++;\n}\ncatch(e)\n{\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "try" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['try'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally\n{\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "try"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try {\n\ty++;\n}\ncatch(e)\n{\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"catch" blocks', function() {
+            it('should report missing newlines when configured with "catch"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['catch'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e) {\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "catch" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['catch'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "catch"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e) {\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"finally" blocks', function() {
+            it('should report missing newlines when configured with "finally"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['finally'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally {\n\tq = 5;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "finally" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['finally'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally\n{\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "finally"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally {\n\tq = 5;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"while" loops', function() {
+            it('should report missing newlines when configured with "while"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['while'] });
+                assert(checker.checkString('while (x < 10) {\n\tx++;\n}')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "while" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['while'] });
+                assert(checker.checkString('while (x < 10)\n{\n\tx++;\n}')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "while"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('while (x < 10) {\n\tx++;\n}')
+                    .isEmpty());
+            });
+        });
+
+        describe('"do...while" loops', function() {
+            it('should report missing newlines when configured with "do"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['do'] });
+                assert(checker.checkString('do {\n\tx++;\n}\nwhile (x < 10);')
+                    .getErrorCount() === 1);
+            });
+
+            it('should not complain when configured with "do" and newline exists', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['do'] });
+                assert(checker.checkString('do\n{\n\tx++;\n}\nwhile (x < 10);')
+                    .isEmpty());
+            });
+
+            it('should not complain when not configured with "do"', function() {
+                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+                assert(checker.checkString('do {\n\tx++;\n}\nwhile (x < 10);')
+                    .isEmpty());
+            });
         });
     });
 });

--- a/test/rules/require-newline-before-block-statements.js
+++ b/test/rules/require-newline-before-block-statements.js
@@ -56,16 +56,17 @@ describe('rules/require-newline-before-block-statements', function() {
     });
 
     describe('with option value array - ', function() {
-
         describe('"if" blocks', function() {
-            it('should report missing newlines when configured with "if"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
+            });
+
+            it('should report missing newlines when configured with "if"', function() {
                 assert(checker.checkString('if(i == 0) {\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "if" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['if'] });
                 assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}')
                     .isEmpty());
             });
@@ -78,14 +79,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"else" and "else if" blocks', function() {
-            it('should report missing newlines when configured with "else"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['else'] });
+            });
+
+            it('should report missing newlines when configured with "else"', function() {
                 assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse{\n\tx--;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "else" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['else'] });
                 assert(checker.checkString('if(i == 0)\n{\n\tx++;\n\ty = {\n\t\tb: "1"\n\t};\n}\nelse\n{\n\tx--;\n}')
                     .isEmpty());
             });
@@ -98,14 +101,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"for" loops', function() {
-            it('should report missing newlines when configured with "for"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+            });
+
+            it('should report missing newlines when configured with "for"', function() {
                 assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i) {\n\tx++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "for" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('for (var i = 0, len = 10; i < 10; ++i)\n{\n\tx++;\n}')
                     .isEmpty());
             });
@@ -118,14 +123,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"for...in" loops', function() {
-            it('should report missing newlines when configured with "for"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
+            });
+
+            it('should report missing newlines when configured with "for"', function() {
                 assert(checker.checkString('for (var i in x) {\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "for" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('for (var i in x)\n{\n\ty++;\n}')
                     .isEmpty());
             });
@@ -138,14 +145,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('function declarations', function() {
-            it('should report missing newlines when configured with "function"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+            });
+
+            it('should report missing newlines when configured with "function"', function() {
                 assert(checker.checkString('function myFunc(y) {\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "function" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
                 assert(checker.checkString('function myFunc(y)\n{\n\ty++;\n}')
                     .isEmpty());
             });
@@ -158,14 +167,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('function statements', function() {
-            it('should report missing newlines when configured with "function"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
+            });
+
+            it('should report missing newlines when configured with "function"', function() {
                 assert(checker.checkString('var z = function(y) {\n\ty++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "function" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['function'] });
                 assert(checker.checkString('var z = function(y)\n{\n\ty++;\n}')
                     .isEmpty());
             });
@@ -178,14 +189,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"try" blocks', function() {
-            it('should report missing newlines when configured with "try"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['try'] });
+            });
+
+            it('should report missing newlines when configured with "try"', function() {
                 assert(checker.checkString('try {\n\ty++;\n}\ncatch(e)\n{\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "try" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['try'] });
                 assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally\n{\n\tq = 5;\n}')
                     .isEmpty());
             });
@@ -198,14 +211,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"catch" blocks', function() {
-            it('should report missing newlines when configured with "catch"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['catch'] });
+            });
+
+            it('should report missing newlines when configured with "catch"', function() {
                 assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e) {\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "catch" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['catch'] });
                 assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}')
                     .isEmpty());
             });
@@ -218,14 +233,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"finally" blocks', function() {
-            it('should report missing newlines when configured with "finally"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['finally'] });
+            });
+
+            it('should report missing newlines when configured with "finally"', function() {
                 assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally {\n\tq = 5;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "finally" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['finally'] });
                 assert(checker.checkString('try\n{\n\ty++;\n}\ncatch(e)\n{\n}\nfinally\n{\n\tq = 5;\n}')
                     .isEmpty());
             });
@@ -238,14 +255,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"while" loops', function() {
-            it('should report missing newlines when configured with "while"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['while'] });
+            });
+
+            it('should report missing newlines when configured with "while"', function() {
                 assert(checker.checkString('while (x < 10) {\n\tx++;\n}')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "while" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['while'] });
                 assert(checker.checkString('while (x < 10)\n{\n\tx++;\n}')
                     .isEmpty());
             });
@@ -258,14 +277,16 @@ describe('rules/require-newline-before-block-statements', function() {
         });
 
         describe('"do...while" loops', function() {
-            it('should report missing newlines when configured with "do"', function() {
+            beforeEach(function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['do'] });
+            });
+
+            it('should report missing newlines when configured with "do"', function() {
                 assert(checker.checkString('do {\n\tx++;\n}\nwhile (x < 10);')
                     .getErrorCount() === 1);
             });
 
             it('should not complain when configured with "do" and newline exists', function() {
-                checker.configure({ requireNewlineBeforeBlockStatements: ['do'] });
                 assert(checker.checkString('do\n{\n\tx++;\n}\nwhile (x < 10);')
                     .isEmpty());
             });
@@ -273,6 +294,29 @@ describe('rules/require-newline-before-block-statements', function() {
             it('should not complain when not configured with "do"', function() {
                 checker.configure({ requireNewlineBeforeBlockStatements: ['for'] });
                 assert(checker.checkString('do {\n\tx++;\n}\nwhile (x < 10);')
+                    .isEmpty());
+            });
+        });
+
+        describe('other block types', function() {
+            beforeEach(function() {
+                checker.configure({
+                    requireNewlineBeforeBlockStatements: [
+                        'if',
+                        'else',
+                        'try',
+                        'catch',
+                        'finally',
+                        'do',
+                        'while',
+                        'for',
+                        'function'
+                    ]
+                });
+            });
+
+            it('should be ignored', function() {
+                assert(checker.checkString('{ var y = { "things": "stuff" }; }')
                     .isEmpty());
             });
         });


### PR DESCRIPTION
For the `requireNewlineBeforeBlockStatements` and `disallowNewlineBeforeBlockStatements` rules, this adds the ability to specify an array of block statement types that it should enforce, rather than merely having a binary switch via specifying `true` to enforce it for _all_ block statements, or omitting the rule to enforce it for _none_ of them.

The use-case this targets is one where my team's code style conventions dictate that we keep curly braces on the same line for functions, but on a new line for other control statements (`if`, `else`, `for`, `while`, etc).

e.g.,
```js
function getAsyncValue(callback) {     // brace on same line for functions
    setTimeout(function() {            // brace on same line for functions
        callback(Math.Floor(Math.random() * 10000));
    });
}

...

getAsyncValue(function(value) {        // brace on same line for functions
    var result = 0;
    var size;

    if (value > 1024)                  // brace on new line for other control statements
    {
        result = largeNumberAggregator(yValue);
        size = 'large';
    }
    else                               // brace on new line for other control statements
    {
        result = smallNumberAggregator(yValue);
        size = 'small';
    }

    console.log('Crunched a ' + size + ' number (' + value + ') and got ' + result);
});
```

could be style-checked by using the following rules:
```js
{
    ...
    "requireNewlineBeforeBlockStatements": [
        "if",
        "else",
        "for",
        "while",
        "do",
        "try",
        "catch",
        "finally"
    ],
    "disallowNewlineBeforeBlockStatements": ["function"],
    ...
}
```
