### PR TITLE
Preset: JSCS

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,18 +1,6 @@
 {
-    "preset": "google",
+    "preset": "jscs",
     "fileExtensions": [ ".js", "jscs" ],
-
-    "requireParenthesesAroundIIFE": true,
-    "maximumLineLength": 120,
-    "validateLineBreaks": "LF",
-    "validateIndentation": 4,
-
-    "disallowKeywords": ["with"],
-    "disallowSpacesInsideObjectBrackets": null,
-    "disallowImplicitTypeConversion": ["string"],
-
-    "safeContextKeyword": "_this",
-
     "excludeFiles": [
         "test/data/**"
     ]

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -10,6 +10,7 @@
  * [MDCS](https://github.com/jscs-dev/node-jscs/blob/master/presets/mdcs.json) — [https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style™](https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2)
  * [Wikimedia](https://github.com/jscs-dev/node-jscs/blob/master/presets/wikimedia.json) — https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
  * [Yandex](https://github.com/jscs-dev/node-jscs/blob/master/presets/yandex.json) — https://github.com/yandex/codestyle/blob/master/javascript.md
+ * [JSCS](https://github.com/jscs-dev/node-jscs/blob/master/presets/jscs.json)
 
 ## Friendly packages
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -678,6 +678,8 @@ Configuration.prototype.registerDefaultPresets = function() {
 
     // https://github.com/yandex/codestyle/blob/master/javascript.md
     this.registerPreset('yandex', require('../../presets/yandex.json'));
+
+    this.registerPreset('jscs', require('../../presets/jscs.json'));
 };
 
 module.exports = Configuration;

--- a/presets/jscs.json
+++ b/presets/jscs.json
@@ -1,0 +1,14 @@
+{
+    "preset": "google",
+
+    "requireParenthesesAroundIIFE": true,
+    "maximumLineLength": 120,
+    "validateLineBreaks": "LF",
+    "validateIndentation": 4,
+
+    "disallowKeywords": ["with"],
+    "disallowSpacesInsideObjectBrackets": null,
+    "disallowImplicitTypeConversion": ["string"],
+
+    "safeContextKeyword": "_this"
+}

--- a/test/config/configuration.js
+++ b/test/config/configuration.js
@@ -211,6 +211,7 @@ describe('modules/config/configuration', function() {
             assert(configuration.hasPreset('wikimedia'));
             assert(configuration.hasPreset('yandex'));
             assert(configuration.hasPreset('grunt'));
+            assert(configuration.hasPreset('jscs'));
         });
     });
 

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -331,6 +331,7 @@ describe('modules/string-checker', function() {
         testPreset('mdcs');
         testPreset('wikimedia');
         testPreset('yandex');
+        testPreset('jscs', __filename);
 
         /**
          * Helper to test a given preset's configuration against its test file
@@ -340,17 +341,19 @@ describe('modules/string-checker', function() {
          *
          * @example testPreset('google')
          * @param  {String} presetName
+         * @param  {String} [fixturePath]
          */
-        function testPreset(presetName) {
+        function testPreset(presetName, fixturePath) {
             it('preset ' + presetName + ' should not report any errors from the sample file', function() {
-                var checker = new Checker();
+                fixturePath = fixturePath || './test/data/options/preset/' + presetName + '.js';
 
+                var checker = new Checker();
                 checker.registerDefaultRules();
                 checker.configure({
                     preset: presetName
                 });
 
-                return checker.checkFile('./test/data/options/preset/' + presetName + '.js').then(function(errors) {
+                return checker.checkFile(fixturePath).then(function(errors) {
                     assert(errors.isEmpty());
                 });
             });


### PR DESCRIPTION
Useful for standardizing styles across all JSCS org projects.

Also useful if we want to eventually support the JSCS preset as the default.