### PR TITLE
Updating rules to use File Traversal APIs.

### DIFF
--- a/lib/rules/disallow-padding-newlines-before-keywords.js
+++ b/lib/rules/disallow-padding-newlines-before-keywords.js
@@ -91,9 +91,9 @@ module.exports.prototype = {
     check: function(file, errors) {
         var keywordIndex = this._keywordIndex;
 
-        file.iterateTokensByType('Keyword', function(token, i, tokens) {
+        file.iterateTokensByType('Keyword', function(token) {
             if (keywordIndex[token.value]) {
-                var prevToken = tokens[i - 1];
+                var prevToken = file.getPrevToken(token);
 
                 if (prevToken && token.loc.start.line - prevToken.loc.end.line > 1) {
                     errors.add(

--- a/lib/rules/disallow-padding-newlines-in-objects.js
+++ b/lib/rules/disallow-padding-newlines-in-objects.js
@@ -55,7 +55,6 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
-            var tokens = file.getTokens();
             var openingBracket = file.getFirstNodeToken(node);
             var nextToken = file.getNextToken(openingBracket);
 

--- a/lib/rules/disallow-spaces-inside-parentheses.js
+++ b/lib/rules/disallow-spaces-inside-parentheses.js
@@ -78,7 +78,7 @@ module.exports.prototype = {
             });
         }
 
-        file.iterateTokenByValue('(', function(token, index, tokens) {
+        file.iterateTokenByValue('(', function(token) {
             var nextToken = file.getNextToken(token);
             var value = nextToken.value;
             var type = nextToken.type;
@@ -94,7 +94,7 @@ module.exports.prototype = {
             }
         });
 
-        file.iterateTokenByValue(')', function(token, index, tokens) {
+        file.iterateTokenByValue(')', function(token) {
             var prevToken = file.getPrevToken(token);
             var value = prevToken.value;
             var type = prevToken.type;

--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -73,16 +73,20 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateTokensByType('Identifier', function(token, index, tokens) {
+        file.iterateTokensByType('Identifier', function(token) {
             var value = token.value;
             if (value.replace(/^_+|_+$/g, '').indexOf('_') === -1 || value.toUpperCase() === value) {
                 return;
             }
             if (this._ignoreProperties) {
-                if (index + 1 < tokens.length && tokens[index + 1].value === ':') {
+                var nextToken = file.getNextToken(token);
+                var prevToken = file.getPrevToken(token);
+
+                if (nextToken && nextToken.value === ':') {
                     return;
                 }
-                if (index > 0 && tokens[index - 1].value === '.') {
+
+                if (prevToken && prevToken.value === '.') {
                     return;
                 }
             }

--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -90,9 +90,9 @@ module.exports.prototype = {
         var excludedTokens = [':', ',', '(', '='];
         var keywordIndex = this._keywordIndex;
 
-        file.iterateTokensByType('Keyword', function(token, i, tokens) {
+        file.iterateTokensByType('Keyword', function(token) {
             if (keywordIndex[token.value]) {
-                var prevToken = tokens[i - 1];
+                var prevToken = file.getPrevToken(token);
 
                 // Handle special case of 'else if' construct.
                 if (token.value === 'if' && prevToken && prevToken.value === 'else') {


### PR DESCRIPTION
disallowPaddingNewLinesBeforeKeywords: Now using File Traversal APIs
disallowPaddingNewLinesInObjects: Now using File Traversal APIs
disallowSpacesInsideParentheses: Now using File Traversal APIs
requireCamelcaseOrUppercaseIdentifiers: Now using File Traversal APIs
requirePaddingNewLinesBeforeKeywords: Now using File Traversal APIs

Finishes step 1 in auto format steps outlined in #516