### PR TITLE
Add esprimaOptions in BUILTIN_OPTIONS

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -13,6 +13,7 @@ var BUILTIN_OPTIONS = {
     esnext: true,
     es3: true,
     esprima: true,
+    esprimaOptions: true,
     errorFilter: true
 };
 

--- a/test/config/configuration.js
+++ b/test/config/configuration.js
@@ -154,6 +154,11 @@ describe('modules/config/configuration', function() {
             }, /^AssertionError: `esprimaOptions` should be an object$/);
         }
 
+        it('should accept `esprimaOptions` rule', function() {
+            configuration.load({esprimaOptions: { foo: 'bar' }});
+            assert(configuration.getUnsupportedRuleNames().length === 0);
+        });
+
         it('should return the supplied esprima options', function() {
             configuration.load({esprimaOptions: { foo: 'bar' }});
             assert.deepEqual(configuration.getEsprimaOptions(), {foo: 'bar'});


### PR DESCRIPTION
`esprimaOptions` was missing in the `BUILTIN_OPTIONS` object.

This could trigger a `Unsupported rule: esprimaOptions` error if we specify an `esprimaOptions` in the `.jscsrc` file.