### PR TITLE
Extract JavaScript to validate from HTML files (fixes #764)

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -149,6 +149,19 @@ jscs path[ path[...]] --preset=jquery
 
 In order to add/remove preset rules you will need to create a `.jscsrc` config file.
 
+### `--extract`
+With this option you can set glob pattern for files which embeded JavaScript should be checked.
+```
+jscs path[ path[...]] --extract *.html 
+```
+
+You can set several patterns if necessary.
+```
+jscs path[ path[...]] --extract *.html --extract *.htm
+```
+
+Currently, only the `html` format is supported (JavaScript inside `<script>` will be checked) and extracted code cannot be auto fixed.
+
 ### `--reporter` (`-r`)
 `jscs` itself provides eight reporters: `checkstyle`, `console`, `inline`, `inlinesingle`, `junit`, `text`, `unix` and `json`.
 ```
@@ -281,6 +294,26 @@ Values: A single file extension or an Array of file extensions, beginning with a
 #### Default
 
 `.js` files are processed by default
+
+### extract
+
+Set list of glob patterns for files which embeded JavaScript should be checked.
+
+Type: `Array` or `false`
+
+Values: Array of file matching patterns
+
+JavaScript extracting from files that doesn't match to [fileExtensions](#fileExtensions) or [excludeFiles](#excludefiles), but match to patterns in this list. Currenly, only `html` format is supported.
+
+#### Example
+
+```js
+"extract": ["*.htm", "*.html"]
+```
+
+#### Default
+
+Default value is `["**/*.+(htm|html|xhtml)"]`. So JavaScript is extracted from files with `.htm`, `.html` or `.xhtml` extension.
 
 ### maxErrors
 Set the maximum number of errors to report (pass -1 or null to report all errors).

--- a/bin/jscs
+++ b/bin/jscs
@@ -17,6 +17,9 @@ program
     .option('-c, --config [path]', 'configuration file path')
     .option('--auto-configure [path]', 'auto-generate a JSCS configuration file')
     .option('-x, --fix', 'fix code style violations (applies to fixable violations)')
+    .option('--extract <mask>', 'set file masks from which to extract JavaScript', function(value, memo) {
+        return memo ? memo.concat(value) : [value];
+    })
     .option('-e, --esnext', 'attempts to parse esnext code (currently es6)')
     .option('--es3', 'validates code as es3')
     .option('-s, --esprima <path>', 'attempts to use a custom version of Esprima')

--- a/lib/checker.js
+++ b/lib/checker.js
@@ -1,6 +1,7 @@
 var vowFs = require('vow-fs');
 var Vow = require('vow');
 var StringChecker = require('./string-checker');
+var extractJs = require('./extract-js');
 var utils = require('util');
 var path = require('path');
 
@@ -65,6 +66,36 @@ Checker.prototype.fixFile = function(path) {
 };
 
 /**
+ * Extract JavaScript from file.
+ *
+ * @param {String} path
+ * @returns {Promise.<Errors>}
+ */
+Checker.prototype.extractFile = function(path) {
+    if (this._configuration.isFileExcluded(path)) {
+        return Vow.resolve(null);
+    }
+
+    if (!this._configuration.shouldExtractFile(path)) {
+        return Vow.resolve(null);
+    }
+
+    return vowFs.read(path, 'utf8').then(function(data) {
+        var result = extractJs(path, data);
+
+        result.sources.forEach(function(script) {
+            this.checkString(script.source, path).getErrorList().forEach(function(error) {
+                error.line += script.line;
+                error.column += script.offset;
+                result.addError(error);
+            });
+        }, this);
+
+        return result.errors;
+    }, this);
+};
+
+/**
  * Checks directory recursively.
  *
  * @param {String} path
@@ -116,12 +147,14 @@ Checker.prototype._processDirectory = function(path, fileHandler) {
                 }
 
                 if (!this._hasCorrectExtension(fullname)) {
-                    return [];
+                    if (!this._configuration.shouldExtractFile(fullname)) {
+                        return [];
+                    }
+
+                    return this.extractFile(fullname);
                 }
 
-                return Vow.when(fileHandler(fullname)).then(function(errors) {
-                    return errors;
-                });
+                return fileHandler(fullname);
             }, this);
         }, this)).then(function(results) {
             return [].concat.apply([], results);
@@ -138,7 +171,6 @@ Checker.prototype._processDirectory = function(path, fileHandler) {
  */
 Checker.prototype._processPath = function(path, fileHandler) {
     path = path.replace(/\/$/, '');
-    var _this = this;
 
     return vowFs.exists(path).then(function(exists) {
         if (!exists) {
@@ -147,14 +179,14 @@ Checker.prototype._processPath = function(path, fileHandler) {
 
         return vowFs.stat(path).then(function(stat) {
             if (stat.isDirectory()) {
-                return _this._processDirectory(path, fileHandler);
+                return this._processDirectory(path, fileHandler);
             }
 
             return fileHandler(path).then(function(errors) {
                 return [errors];
             });
-        });
-    });
+        }, this);
+    }, this);
 };
 
 /**

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -10,6 +10,7 @@ var BUILTIN_OPTIONS = {
     excludeFiles: true,
     additionalRules: true,
     fileExtensions: true,
+    extract: true,
     maxErrors: true,
     configPath: true,
     esnext: true,
@@ -124,6 +125,30 @@ function Configuration() {
     this._excludedFileMatchers = [];
 
     /**
+     * Extraction masks.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._extractFileMasks = [];
+
+    /**
+     * Default extractions masks.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._defaultExtractFileMasks = ['**/*.+(htm|html|xhtml)'];
+
+    /**
+     * List of file matchers from which to extract JavaScript.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._extractFileMatchers = [];
+
+    /**
      * Maxixum amount of error that would be reportered.
      *
      * @protected
@@ -222,6 +247,7 @@ Configuration.prototype.getProcessedConfig = function() {
     }, this);
     result.excludeFiles = this._excludedFileMasks;
     result.fileExtensions = this._fileExtensions;
+    result.extract = this._extractFileMasks;
     result.maxErrors = this._maxErrors;
     result.preset = this._presetName;
     result.esnext = this._esnextEnabled;
@@ -290,6 +316,27 @@ Configuration.prototype.isFileExcluded = function(filePath) {
  */
 Configuration.prototype.getFileExtensions = function() {
     return this._fileExtensions;
+};
+
+/**
+ * Returns extract file masks.
+ *
+ * @returns {String[]}
+ */
+Configuration.prototype.getExtractFileMasks = function() {
+    return this._extractFileMasks;
+};
+
+/**
+ * Should filePath to be extracted?
+ *
+ * @returns {Boolean}
+ */
+Configuration.prototype.shouldExtractFile = function(filePath) {
+    filePath = path.resolve(filePath);
+    return this._extractFileMatchers.some(function(matcher) {
+        return matcher.match(filePath);
+    });
 };
 
 /**
@@ -439,6 +486,14 @@ Configuration.prototype._processConfig = function(config) {
         options.additionalRules.forEach(function(rule) {
             this._loadAdditionalRule(rule, options.configPath);
         }, this);
+    }
+
+    if (options.hasOwnProperty('extract')) {
+        this._loadExtract(options.extract);
+
+    // Set default masks if there is no presets that could define their own
+    } else if (!options.hasOwnProperty('preset')) {
+        this._loadExtract(this._defaultExtractFileMasks);
     }
 
     if (options.hasOwnProperty('fileExtensions')) {
@@ -677,6 +732,27 @@ Configuration.prototype._loadExcludedFiles = function(masks) {
 
     this._excludedFileMasks = this._excludedFileMasks.concat(masks);
     this._excludedFileMatchers = this._excludedFileMasks.map(function(fileMask) {
+        return new minimatch.Minimatch(path.resolve(this._basePath, fileMask), {
+            dot: true
+        });
+    }, this);
+};
+
+/**
+ * Load paths for extract.
+ *
+ * @param {Array} masks
+ * @protected
+ */
+Configuration.prototype._loadExtract = function(masks) {
+    if (masks === false) {
+        masks = [];
+    }
+
+    assert(Array.isArray(masks), '`extract` option should be array of strings or false');
+
+    this._extractFileMasks = masks.slice();
+    this._extractFileMatchers = this._extractFileMasks.map(function(fileMask) {
         return new minimatch.Minimatch(path.resolve(this._basePath, fileMask), {
             dot: true
         });

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -14,7 +14,8 @@ var OVERRIDE_OPTIONS = [
     'esprima',
     'es3',
     'verbose',
-    'esnext'
+    'esnext',
+    'extract'
 ];
 
 function req(entity, dir) {

--- a/lib/extract-js.js
+++ b/lib/extract-js.js
@@ -1,0 +1,230 @@
+var htmlparser = require('htmlparser2');
+var Errors = require('./errors');
+var rLineSplit = /\r\n|\r|\n/;
+var rHasNonWhitespace = /\S/;
+
+/**
+ * Html file representation (needed for errors output).
+ *
+ * @name HtmlFile
+ * @param {Object} params
+ * @param {String} params.filename
+ * @param {String} params.source
+ */
+var HtmlFile = function(params) {
+    this._filename = params.filename;
+    this._lines = params.source.split(rLineSplit);
+};
+
+HtmlFile.prototype = {
+    /**
+     * Returns source filename for this object representation.
+     *
+     * @returns {String}
+     */
+    getFilename: function() {
+        return this._filename;
+    },
+
+    /**
+     * Returns array of source lines for the file.
+     *
+     * @returns {String[]}
+     */
+    getLines: function() {
+        return this._lines;
+    }
+};
+
+/**
+ * Parse html and retrieve script sources.
+ *
+ * @param {String} html
+ * @returns {Object[]}
+ */
+function getScripts(html) {
+    function onopen(name, attrs) {
+        // tag should be a <script>
+        if (name !== 'script' ||
+            // ignore scripts with src attribute
+            attrs.src ||
+            // script tag should has no type attribute or attribute should be equal to text/javascript
+            (attrs.type && attrs.type.toLowerCase() !== 'text/javascript')) {
+            return;
+        }
+
+        // store script content start pos
+        scriptStartPos = parser.endIndex + 1;
+    }
+
+    function onclose() {
+        if (!scriptStartPos) {
+            return;
+        }
+
+        // get script content
+        var scriptEndPos = parser.startIndex;
+        var source = html.substring(scriptStartPos, scriptEndPos);
+
+        // store script content only if it contains non-whitespace characters
+        if (rHasNonWhitespace.test(source)) {
+            scripts.push({
+                source: source,
+                start: scriptStartPos,
+                end: scriptEndPos
+            });
+        }
+
+        // reset script start position
+        scriptStartPos = 0;
+    }
+
+    var scriptStartPos = 0;
+    var scripts = [];
+    var parser = new htmlparser.Parser({
+        onopentag: onopen,
+        onclosetag: onclose
+    });
+
+    parser.parseComplete(html);
+
+    return scripts;
+}
+
+/**
+ * JavaScript in HTML usually shifted based on first JS line. For example
+ * if first line of fragment is offset by 4 spaces, each line in this
+ * fragment will have offset 4 to restore the original column.
+ * This function trim script source and normalize lines offset.
+ *
+ * @param {String} source
+ * @returns {Object[]}
+ */
+function normalizeSource(source) {
+    var lines = source.split(rLineSplit);
+    var lineCount = lines.length;
+    var tabOnlyOffset = false;
+    var spaceOnlyOffset = false;
+    var offset;
+
+    // remove first list if it's an empty string
+    // usually <script> starts with new line
+    if (!rHasNonWhitespace.test(lines[0])) {
+        lines.shift();
+    }
+
+    // replace last line by empty string if it contains only whitespaces
+    // it helps avoid disallowTrailingWhitespace errors on last line
+    if (!rHasNonWhitespace.test(lines[lines.length - 1])) {
+        lines[lines.length - 1] = '';
+    }
+
+    // calculate min line offset
+    offset = Math.min.apply(null, lines.map(function(line) {
+        // skip empty lines
+        if (!line) {
+            return Infinity;
+        }
+
+        // fetch whitespaces at the line beginning
+        var offsetStr = line.match(/^\s*/)[0];
+        var tabCount = offsetStr.match(/\t*/)[0].length;
+
+        if (offsetStr.length === line.length) {
+            return 0;
+        }
+
+        // mixed spaces and tabs in one offset -> don't remove offsets
+        if (tabCount && tabCount !== offsetStr.length) {
+            return 0;
+        }
+
+        if (tabCount) {
+            if (spaceOnlyOffset) {
+                // no spaces, but previous offset has ony spaces -> mixed spaces and tabs
+                return 0;
+            } else {
+                // remember offset contains only tabs
+                tabOnlyOffset = true;
+            }
+        } else {
+            if (tabOnlyOffset) {
+                // no tabs, but previous offset has only tabs -> mixed spaces and tabs
+                return 0;
+            } else {
+                // remember offset contains only spaces
+                spaceOnlyOffset = true;
+            }
+        }
+
+        return offsetStr.length;
+    }));
+
+    // remove common offsets if possible
+    if (offset) {
+        lines = lines.map(function(line) {
+            return line.substr(offset);
+        });
+    }
+
+    return {
+        source: lines.join('\n'),
+        offset: offset,
+        lineCount: lineCount
+    };
+}
+
+/**
+ * Parse HTML and search for <script> sources. Each script source also normalize
+ * by line offset. Result contains script sources with information about line
+ * offset (that was removed for each line) and lines count before script source.
+ * This information helps restore absolute positions in html file for errors.
+ *
+ * @param {String} filename
+ * @param {String} data
+ * @returns {Object[]}
+ */
+function extractJs(filename, data) {
+    var errors = new Errors(new HtmlFile({
+        filename: filename,
+        source: data
+    }));
+    var scripts = getScripts(data);
+    var sources = [];
+    var line = 1;
+    var lastHtmlPos = 0;
+
+    scripts.forEach(function(scriptInfo) {
+        // fetch script source and normalize it
+        var normalized = normalizeSource(scriptInfo.source);
+
+        // add line offset before script
+        line += data.substring(lastHtmlPos, scriptInfo.start).split(rLineSplit).length - 1;
+
+        sources.push({
+            source: normalized.source,
+            offset: normalized.offset,
+            line: line
+        });
+
+        // save offsets for next fragment
+        line += normalized.lineCount - 1;
+        lastHtmlPos = scriptInfo.end;
+    });
+
+    return {
+        sources: sources,
+        errors: errors,
+        addError: function(error) {
+            errors._errorList.push({
+                filename: filename,
+                rule: error.rule,
+                message: error.message,
+                line: error.line,
+                column: error.column
+            });
+        }
+    };
+}
+
+module.exports = extractJs;

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "to-single-quotes": "^1.0.2",
     "vow": "~0.4.8",
     "vow-fs": "~0.3.4",
-    "xmlbuilder": "^2.6.1"
+    "xmlbuilder": "^2.6.1",
+    "htmlparser2": "3.8.3"
   },
   "devDependencies": {
     "browserify": "^11.0.0",

--- a/test/data/extract/always.htm
+++ b/test/data/extract/always.htm
@@ -1,0 +1,18 @@
+should be ignored when not always
+<!doctype html>
+
+<html>
+<head>
+  <title>Test file</title>
+  <script type="ignore/me"></script>
+  <script>
+    with (x) { y++; }
+  </script>
+</head>
+<body>
+  <script type="text/javascript">
+    with (x) { y++; }
+    if (true) {}
+  </script>
+</body>
+</html>

--- a/test/data/extract/index.html
+++ b/test/data/extract/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+
+<html>
+<head>
+  <title>Test file</title>
+  <script type="ignore/me">
+    with (x) { y++; }
+  </script>
+  <script type="text/javascript" alt="should be ignored as empty">
+  </script>
+  <script>/* edge cases */</script>
+  <script>  
+  /* edge cases */</script>
+  <script src="some/script.js">
+    // should be ignored too
+    with (x) { y++; }
+  </script>
+  <script>
+    with (x) { y++; }
+  </script>
+</head>
+<body>
+  <script type="text/javascript">
+		with (x) { y++; }
+  </script>
+  <script>
+    // mixed offset #1
+		// tabs
+  </script>
+  <script>
+    // mixed offset #2
+	  // one tabs
+  </script>
+  <script>
+		// mixed offset #3
+    // tabs
+  </script>
+</body>
+</html>

--- a/test/data/extract/plain.txt
+++ b/test/data/extract/plain.txt
@@ -1,0 +1,4 @@
+should be ignored usually
+<script>
+  with (x) {}
+</script>

--- a/test/data/extract/valid.xhtml
+++ b/test/data/extract/valid.xhtml
@@ -1,0 +1,6 @@
+<script>
+    if (valid) {}
+  
+    // line above should contains 2 spaces
+    // check whitespate only lines ignoring
+</script>

--- a/test/specs/checker.js
+++ b/test/specs/checker.js
@@ -64,6 +64,14 @@ describe('checker', function() {
                 assert.equal(errors[0].getErrorList().length, 0);
             });
         });
+
+        it('should throw an exception when path doesn\'t exists', function() {
+            return checker.checkPath('./test/non-exists').then(function() {
+                assert(false);
+            }, function() {
+                assert(true);
+            });
+        });
     });
 
     describe('checkStdin', function() {
@@ -93,6 +101,92 @@ describe('checker', function() {
 
             process.stdin.emit('data', 'foo');
             process.stdin.emit('end');
+        });
+    });
+
+    describe('extract', function() {
+        it('should extract from *.htm, *.html and *.xhtml by default', function() {
+            return checker.checkPath('./test/data/extract').then(function(errors) {
+                assert.equal(errors.length, 3);
+                assert.equal(errors[0].getErrorList().length, 2);
+                assert.equal(errors[1].getErrorList().length, 2);
+                assert.equal(errors[2].getErrorList().length, 0);
+            });
+        });
+
+        it('should not extract js when set to false', function() {
+            checker.configure({
+                extract: false
+            });
+
+            return checker.checkPath('./test/data/extract').then(function(errors) {
+                assert.equal(errors.length, 0);
+            });
+        });
+
+        it('should try extract js from any file', function() {
+            checker.configure({
+                extract: ['**']
+            });
+
+            return checker.checkPath('./test/data/extract').then(function(errors) {
+                assert.equal(errors.length, 4);
+                assert.equal(errors[0].getErrorList().length, 2);
+                assert.equal(errors[1].getErrorList().length, 2);
+                assert.equal(errors[2].getErrorList().length, 1);
+                assert.equal(errors[3].getErrorList().length, 0);
+            });
+        });
+
+        it('extractFile should return empty error list if no errors', function() {
+            var checker = new Checker();
+
+            // no check rules no any errors
+            checker.configure({
+                extract: ['**']
+            });
+
+            return checker.extractFile('./test/data/extract/always.htm').then(function(errors) {
+                assert.equal(errors.getErrorList().length, 0);
+            });
+        });
+
+        it('extractFile should return null if file doesn\'t check', function() {
+            checker.configure({
+                extract: false
+            });
+
+            return checker.extractFile('./test/data/extract/always.htm').then(function(errors) {
+                assert.equal(errors, null);
+            });
+        });
+
+        describe('should take in account excludeFiles', function() {
+            it('on checkPath', function() {
+                checker.configure({
+                    extract: ['**'],
+                    excludeFiles: [
+                        './test/**'
+                    ]
+                });
+
+                return checker.checkPath('./test/data/extract').then(function(errors) {
+                    assert.equal(errors.length, 0);
+                });
+            });
+
+            it('on extractFile', function() {
+                checker.configure({
+                    extract: ['**'],
+                    excludeFiles: [
+                        './test/**'
+                    ]
+                });
+
+                return checker.extractFile('./test/data/extract/always.htm').then(function(errors) {
+                    assert.equal(errors, null);
+                });
+            });
         });
     });
 

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -326,6 +326,71 @@ describe('config/configuration', function() {
         });
     });
 
+    describe('extract', function() {
+        it('should be check html files by default', function() {
+            configuration.load({});
+            assert.deepEqual(configuration.getExtractFileMasks(), ['**/*.+(htm|html|xhtml)']);
+        });
+
+        it('should set array of masks', function() {
+            configuration.load({
+                extract: ['foo', 'bar']
+            });
+            assert.deepEqual(configuration.getExtractFileMasks(), ['foo', 'bar']);
+        });
+
+        it('should set `never`', function() {
+            configuration.load({
+                extract: false
+            });
+            assert.deepEqual(configuration.getExtractFileMasks(), []);
+        });
+
+        it('should throw an exception when set wrong string value', function() {
+            assert.throws(function() {
+                configuration.load({
+                    extract: 'foo'
+                });
+            });
+        });
+    });
+
+    describe('shouldExtractFile', function() {
+        it('should be check *.htm, *.html, *.xhtml by default', function() {
+            configuration.load({});
+            assert(configuration.shouldExtractFile('file.htm'));
+            assert(configuration.shouldExtractFile('file.html'));
+            assert(configuration.shouldExtractFile('file.xhtml'));
+            assert(configuration.shouldExtractFile('foo/file.htm'));
+            assert(configuration.shouldExtractFile('foo/file.html'));
+            assert(configuration.shouldExtractFile('foo/file.xhtml'));
+            assert(!configuration.shouldExtractFile('file.txt'));
+            assert(!configuration.shouldExtractFile('file.ht'));
+            assert(!configuration.shouldExtractFile('file.html.tmp'));
+            assert(!configuration.shouldExtractFile('smth.html/file.txt'));
+        });
+
+        it('should set array of masks', function() {
+            configuration.load({
+                extract: ['foo', 'bar']
+            });
+            assert(configuration.shouldExtractFile('foo'));
+            assert(configuration.shouldExtractFile('bar'));
+            assert(!configuration.shouldExtractFile('baz/foo'));
+            assert(!configuration.shouldExtractFile('foo/bar'));
+        });
+
+        it('should set `never`', function() {
+            configuration.load({
+                extract: false
+            });
+            assert(!configuration.shouldExtractFile('file.html'));
+            assert(!configuration.shouldExtractFile('foo/file.html'));
+            assert(!configuration.shouldExtractFile('file.html.tmp'));
+            assert(!configuration.shouldExtractFile('smth.html/file.txt'));
+        });
+    });
+
     describe('usePlugin', function() {
         it('should run plugin with configuration specified', function() {
             var plugin = function() {};

--- a/test/specs/extract-js.js
+++ b/test/specs/extract-js.js
@@ -1,0 +1,72 @@
+var assert = require('assert');
+var Checker = require('../../lib/checker');
+
+describe('extract-js', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('common', function() {
+        it('should not throw an exceptions on error explain (console reporter)', function() {
+            checker.configure({
+                disallowKeywords: ['with'],
+                extract: ['**']
+            });
+
+            return checker.checkPath('./test/data/extract').then(function(errorsCollection) {
+                var errorCount = 0;
+
+                assert.doesNotThrow(function() {
+                    errorsCollection.forEach(function(errors) {
+                        if (!errors.isEmpty()) {
+                            errors.getErrorList().forEach(function(error) {
+                                errors.explainError(error, true);
+                                errorCount++;
+                            });
+                        }
+                    });
+                });
+
+                assert.equal(errorCount, 5);
+            });
+        });
+    });
+
+    describe('whitespaces', function() {
+        it('should be no errors on disallowTrailingWhitespace', function() {
+            checker.configure({
+                disallowTrailingWhitespace: true
+            });
+
+            return checker.extractFile('./test/data/extract/index.html').then(function(errors) {
+                assert(errors.isEmpty());
+            });
+        });
+
+        it('should be errors on disallowMixedSpacesAndTabs', function() {
+            checker.configure({
+                disallowMixedSpacesAndTabs: true
+            });
+
+            return checker.extractFile('./test/data/extract/index.html').then(function(errors) {
+                // disallowMixedSpacesAndTabs doesn't warn when some line contains only tabs
+                // and some only spaces (i.e. '\s\svar foo;\t\tvar bar;'). If this behavior
+                // will change here will be three errors.
+                assert(errors.getErrorList().length === 1);
+            });
+        });
+
+        it('should be no errors on validateIndentation', function() {
+            checker.configure({
+                validateIndentation: 2
+            });
+
+            return checker.extractFile('./test/data/extract/always.htm').then(function(errors) {
+                assert(errors.isEmpty());
+            });
+        });
+    });
+});


### PR DESCRIPTION
Implementation of `extract` option, that behave similar to jshint `extract` option (see #764 for details).
Solution tries avoid undesirable errors by `disallowTrailingWhitespace`, `disallowMixedSpacesAndTabs ` and `validateIndentation` rules.