### PR TITLE
crockford.json: Enable requireSpaceBeforeObjectValues

### DIFF
--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -62,5 +62,6 @@
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
     "disallowNewlineBeforeBlockStatements": true,
-    "disallowMultipleLineStrings": true
+    "disallowMultipleLineStrings": true,
+    "requireSpaceBeforeObjectValues": true
 }

--- a/test/data/options/preset/crockford.js
+++ b/test/data/options/preset/crockford.js
@@ -48,7 +48,7 @@ div.onclick = function (e) {
 };
 
 obj = {
-    method: function () {
+    method: function () { // requireSpaceBeforeObjectValues
         return this.datum; // requireDotNotation
     },
     datum: 0


### PR DESCRIPTION
Hey there,

I believe this rule is missing. Pretty sure Crockford always puts at least one space between the colon and the value.