### PR TITLE
requireCapitalizedComments: Add `allExcept` option [#1045]

### DIFF
--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -1,9 +1,12 @@
 /**
  * Requires the first alphabetical character of a comment to be uppercase, unless it is part of a multi-line textblock.
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `Object`
  *
- * Value: `true`
+ * Values:
+ *  - `true`
+ *  - `Object`:
+ *     - `allExcept`: array of quoted exceptions
  *
  * #### Example
  *
@@ -45,6 +48,44 @@
  *  * invalid
  *  *\/
  * ```
+ *
+ * ```js
+ * "requireCapitalizedComments": { allExcept: ["jshint"] }
+ * ```
+ *
+ * Valid:
+ *
+ * ```
+ * function sayHello() {
+ *     \/* jshint: -W071 *\/
+ *
+ *     // I can now say hello in lots of statements, if I like.
+ *     return "Hello";
+ * }
+ * ```
+ *
+ * * Invalid:
+ *
+ * ```
+ * function sayHello() {
+ *     \/* jshint: -W071 *\/
+ *
+ *     // i can now say hello in lots of statements, if I like.
+ *     return "Hello";
+ * }
+ * ```
+ *
+ * * Invalid:
+ *
+ * ```
+ * function sayHello() {
+ *     \/* istanbul ignore next *\/
+ *
+ *     // I'd like to ignore this statement in coverage reports.
+ *     return "Hello";
+ * }
+ * ```
+ *
  */
 
 var assert = require('assert');
@@ -52,11 +93,38 @@ var assert = require('assert');
 module.exports = function() {};
 
 module.exports.prototype = {
-    configure: function(requireCapitalizedComments) {
+    configure: function(options) {
+        this._exceptions = {};
+
+        var optionName = this.getOptionName();
+
+        var isObject = typeof options === 'object';
+
         assert(
-            requireCapitalizedComments === true,
-            'requireCapitalizedComments option requires a value of true or should be removed'
+            options === true ||
+            isObject,
+            optionName + ' option requires the value `true` ' +
+            'or an object with String[] `allExcept` property'
         );
+
+        if (isObject) {
+            var exceptions = options.allExcept;
+
+            // verify items in `allExcept` property in object are string values
+            assert(
+                Array.isArray(exceptions) &&
+                exceptions.every(function(el) { return typeof el === 'string'; }),
+                'Property `allExcept` in ' + optionName + ' should be an array of strings'
+            );
+
+            this._hasExceptions = true;
+
+            for (var i = 0, l = exceptions.length; i < l; i++) {
+                this._exceptions[exceptions[i]] = true;
+            }
+        } else {
+            this._hasExceptions = false;
+        }
     },
 
     getOptionName: function() {
@@ -66,10 +134,23 @@ module.exports.prototype = {
     check: function(file, errors) {
         var inTextBlock = null;
 
+        var exceptions = this._exceptions;
+        var hasExceptions = this._hasExceptions;
+
         var letterPattern = require('../../patterns/L');
         var upperCasePattern = require('../../patterns/Lu');
 
         file.getComments().forEach(function(comment) {
+            if (hasExceptions) {
+                // strip leading whitespace and any asterisks
+                // split on whitespace and colons
+                var splitComment = comment.value.replace(/(^\s+|[\*])/g, '').split(/[\s\:]/g);
+
+                if (exceptions[splitComment[0]]) {
+                    return;
+                }
+            }
+
             var stripped = comment.value.replace(/[\n\s\*]/g, '');
             var firstChar = stripped[0];
             var isLetter = firstChar && letterPattern.test(firstChar);

--- a/test/rules/require-capitalized-comments.js
+++ b/test/rules/require-capitalized-comments.js
@@ -11,91 +11,119 @@ describe('rules/require-capitalized-comments', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requireCapitalizedComments: true });
     });
 
-    it('should report on a lowercase start of a comment', function() {
-        assert(checker.checkString('//invalid').getErrorCount() === 1);
-        assert(checker.checkString('// invalid').getErrorCount() === 1);
-        assert(checker.checkString('/** invalid */').getErrorCount() === 1);
-        assert(checker.checkString('/* invalid */').getErrorCount() === 1);
-        assert(checker.checkString('/**\n * invalid\n*/').getErrorCount() === 1);
-        assert(checker.checkString('//\n// invalid\n//').getErrorCount() === 1);
-        assert(checker.checkString('/*\ninvalid\n*/').getErrorCount() === 1);
-        assert(checker.checkString('//\xFCber').getErrorCount() === 1);
-        assert(checker.checkString('//\u03C0').getErrorCount() === 1);
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedComments: true });
+        });
+
+        it('should report on a lowercase start of a comment', function() {
+            assert(checker.checkString('//invalid').getErrorCount() === 1);
+            assert(checker.checkString('// invalid').getErrorCount() === 1);
+            assert(checker.checkString('/** invalid */').getErrorCount() === 1);
+            assert(checker.checkString('/* invalid */').getErrorCount() === 1);
+            assert(checker.checkString('/**\n * invalid\n*/').getErrorCount() === 1);
+            assert(checker.checkString('//\n// invalid\n//').getErrorCount() === 1);
+            assert(checker.checkString('/*\ninvalid\n*/').getErrorCount() === 1);
+            assert(checker.checkString('//\xFCber').getErrorCount() === 1);
+            assert(checker.checkString('//\u03C0').getErrorCount() === 1);
+        });
+
+        it('should not report an uppercase start of a comment', function() {
+            assertEmpty('//Valid');
+            assertEmpty('// Valid');
+            assertEmpty('/** Valid */');
+            assertEmpty('//\n// Valid\n//');
+            assertEmpty('/*\nValid\n*/');
+            assertEmpty('//\xDCber');
+            assertEmpty('//\u03A0');
+        });
+
+        it('should not report on comments that start with a non-alphabetical character', function() {
+            assert(checker.checkString('//123').isEmpty());
+            assert(checker.checkString('// 123').isEmpty());
+            assert(checker.checkString('/**123*/').isEmpty());
+            assert(checker.checkString('/**\n @todo: foobar\n */').isEmpty());
+            assert(checker.checkString('/** 123*/').isEmpty());
+            assert(checker.checkString([
+                '// \xDCber',
+                '// diese Funktion'
+            ].join('\n')).isEmpty());
+        });
+
+        it('should not report on multiple uppercase lines in a "textblock"', function() {
+            assertEmpty([
+                '// This is a textblock.',
+                '// That has two uppercase lines'
+            ].join('\n'));
+
+            assertEmpty([
+                '// A textblock may also have multiple lines.',
+                '// Those lines can be uppercase as well to support',
+                '// sentense breaks in textblocks'
+            ].join('\n'));
+        });
+
+        it('should not report on multiple uppercase lines in multiple "textblocks"', function() {
+            assertEmpty([
+                '// This is a textblock',
+                '//',
+                '// That has two uppercase lines'
+            ].join('\n'));
+        });
+
+        it('should not report on multiple lines that start with non-letters', function() {
+            assertEmpty([
+                '// 123 or any non-alphabetical starting character',
+                '// @are also valid anywhere'
+            ].join('\n'));
+        });
+
+        it('should not report on a lowercase start of a comment in a "textblock"', function() {
+            assertEmpty([
+                '// This is a comment',
+                '// that is part of a textblock'
+            ].join('\n'));
+
+            assertEmpty([
+                '// This is a comment',
+                '// that is part of a textblock',
+                '//',
+                '// So is this the beginning',
+                '// of a textblock that can be',
+                '// entered in and out of'
+            ].join('\n'));
+
+            assertEmpty([
+                '// A textblock is a set of lines',
+                '// that starts with a capitalized letter',
+                '// and has one or more non-capitalized lines',
+                '// afterwards'
+            ].join('\n'));
+        });
+
     });
 
-    it('should not report an uppercase start of a comment', function() {
-        assertEmpty('//Valid');
-        assertEmpty('// Valid');
-        assertEmpty('/** Valid */');
-        assertEmpty('//\n// Valid\n//');
-        assertEmpty('/*\nValid\n*/');
-        assertEmpty('//\xDCber');
-        assertEmpty('//\u03A0');
-    });
+    describe('option value allExcept', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedComments: { allExcept: ['istanbul', 'zombiecheckjs'] } });
+        });
 
-    it('should not report on comments that start with a non-alphabetical character', function() {
-        assert(checker.checkString('//123').isEmpty());
-        assert(checker.checkString('// 123').isEmpty());
-        assert(checker.checkString('/**123*/').isEmpty());
-        assert(checker.checkString('/**\n @todo: foobar\n */').isEmpty());
-        assert(checker.checkString('/** 123*/').isEmpty());
-        assert(checker.checkString([
-            '// \xDCber',
-            '// diese Funktion'
-        ].join('\n')).isEmpty());
-    });
+        it('should report for anything else', function() {
+            assert(checker.checkString('/* my comment: this is cool */').getErrorCount() === 1);
+        });
 
-    it('should not report on multiple uppercase lines in a "textblock"', function() {
-        assertEmpty([
-            '// This is a textblock.',
-            '// That has two uppercase lines'
-        ].join('\n'));
+        it('should report for other comment directives', function() {
+            assert(checker.checkString('/* jshint: -W071 */').getErrorCount() === 1);
 
-        assertEmpty([
-            '// A textblock may also have multiple lines.',
-            '// Those lines can be uppercase as well to support',
-            '// sentense breaks in textblocks'
-        ].join('\n'));
-    });
+            assert(checker.checkString('/* jscs:disable requireCurlyBraces */').getErrorCount() === 1);
+        });
 
-    it('should not report on multiple uppercase lines in multiple "textblocks"', function() {
-        assertEmpty([
-            '// This is a textblock',
-            '//',
-            '// That has two uppercase lines'
-        ].join('\n'));
-    });
+        it('should not report for custom exceptions', function() {
+            assertEmpty('/* istanbul ignore next */');
 
-    it('should not report on multiple lines that start with non-letters', function() {
-        assertEmpty([
-            '// 123 or any non-alphabetical starting character',
-            '// @are also valid anywhere'
-        ].join('\n'));
-    });
-
-    it('should not report on a lowercase start of a comment in a "textblock"', function() {
-        assertEmpty([
-            '// This is a comment',
-            '// that is part of a textblock'
-        ].join('\n'));
-
-        assertEmpty([
-            '// This is a comment',
-            '// that is part of a textblock',
-            '//',
-            '// So is this the beginning',
-            '// of a textblock that can be',
-            '// entered in and out of'
-        ].join('\n'));
-
-        assertEmpty([
-            '// A textblock is a set of lines',
-            '// that starts with a capitalized letter',
-            '// and has one or more non-capitalized lines',
-            '// afterwards'
-        ].join('\n'));
+            assertEmpty('/* zombiecheckjs: ensurebrains */');
+        });
     });
 });


### PR DESCRIPTION
Should I change the title to say `Closes #1045` instead or `[#1045]`?