### PR TITLE
Config: Add "ignore-missing-config" option

### DIFF
--- a/bin/jscs
+++ b/bin/jscs
@@ -16,6 +16,7 @@ program
     .description('A code style linter for programmatically enforcing your style guide.')
     .option('-c, --config [path]', 'configuration file path')
     .option('--auto-configure [path]', 'auto-generate a JSCS configuration file')
+    .option('-i, --ignore-missing-config', 'if configuration file is not found, don\'t complain')
     .option('-e, --esnext', 'attempts to parse esnext code (currently es6)')
     .option('--es3', 'validates code as es3')
     .option('-s, --esprima <path>', 'attempts to use a custom version of Esprima')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -47,7 +47,7 @@ module.exports = function(program) {
      * Trying to load config.
      * Custom config path can be specified using '-c' option.
      */
-    if (!config && !program.preset && !program.autoConfigure) {
+    if (!config && !program.preset && !program.autoConfigure && !program.ignoreMissingConfig) {
         if (program.config) {
             console.error('Configuration source', program.config, 'was not found.');
         } else {

--- a/test/cli.js
+++ b/test/cli.js
@@ -121,6 +121,18 @@ describe('modules/cli', function() {
         console.error.restore();
     });
 
+    it('should not exit if missing custom configs are ignored', function() {
+        var result = cli({
+            args: ['test/data/cli/success.js'],
+            config: 'config.js',
+            ignoreMissingConfig: true
+        });
+
+        assert(typeof result === 'object');
+
+        return assertNoCliErrors(result);
+    });
+
     it('should set presets', function() {
         var Checker = require('../lib/checker');
         var originalCheckPath = Checker.prototype.checkPath;

--- a/test/cli.js
+++ b/test/cli.js
@@ -121,7 +121,7 @@ describe('modules/cli', function() {
         console.error.restore();
     });
 
-    it('should not exit if missing custom configs are ignored', function() {
+    it('should not exit with error status if missing config is ignored', function() {
         var result = cli({
             args: ['test/data/cli/success.js'],
             config: 'config.js',


### PR DESCRIPTION
Currently, `jscs` exits with a non-zero status code when it can't find a config file.

This is great for certain use cases, e.g. as a reminder for when you have forgotten to add a `.jscsrc` file to a project directory.

But for other situations, e.g. when you have configured your editor to send any opened "*.js" file to `jscs`, and your editor warns you when the program exits with a non-zero status code, then it can be quite annoying to try and edit files from projects which do not use JSCS, as you will be bombarded with "No configuration found." messages.

Trivially, this is the particular case for a [GNU Emacs](http://www.gnu.org/software/emacs/) + [Flycheck](https://github.com/flycheck/flycheck) setup defined as follows in a user's `~/.emacs` file:

```lisp
(flycheck-define-checker javascript-jscs
  "JSCS - JavaScript Code Style"
  :command ("jscs" "--reporter=checkstyle" source-inplace)
  :error-parser flycheck-parse-checkstyle
  :modes (js-mode js2-mode js3-mode))

(add-to-list 'flycheck-checkers 'javascript-jscs)
```

One workaround is to `echo '{}' >> ~/.jscsrc`, but it's not a very good solution, especially if a user doesn't know to do that. This option allows you to no-op your way through the program if a config file is not found.