### PR TITLE
Docs: add reporter

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -74,7 +74,7 @@ jscs path[ path[...]] --preset=jquery
 ```
 
 ### `--reporter`
-`jscs` itself provides six reporters: `checkstyle`, `console`, `inline`, `junit` and `text`.
+`jscs` itself provides six reporters: `checkstyle`, `console`, `inline`, `inlinesingle`, `junit` and `text`.
 ```
 jscs path[ path[...]] --reporter=console
 ```


### PR DESCRIPTION
document says "six reporters", but shown only five.

$ ls lib/reporters/
checkstyle.js console.js inline.js inlinesingle.js junit.js
text.js