### PR TITLE
Disallowing do..while on new line

### DIFF
--- a/lib/rules/disallow-keywords-on-new-line.js
+++ b/lib/rules/disallow-keywords-on-new-line.js
@@ -53,8 +53,14 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var keywordIndex = this._keywordIndex;
+        // do counter to handle #885
+        var openDoLoop = 0;
 
         file.iterateTokensByType('Keyword', function(token) {
+            if (token.value === 'do') {
+                openDoLoop++;
+            }
+
             if (keywordIndex[token.value]) {
                 var prevToken = file.getPrevToken(token);
 
@@ -62,6 +68,22 @@ module.exports.prototype = {
                 // it makes more sense that way.
                 if (token.value === 'else' && prevToken.value !== '}') {
                     return;
+                }
+
+                // Special cases for #885
+                if (token.value === 'while') {
+                    // Allow while that is not part of a do to succeed even though it contradicts rule meaning
+                    if (openDoLoop === 0) {
+                        return;
+                    }
+
+                    // If code reaches here we have a while token that closes the last do token
+                    openDoLoop--;
+
+                    // Allow while that is part of a do to succeed for do whiles with no braces
+                    if (prevToken.value !== '}') {
+                        return;
+                    }
                 }
 
                 errors.assert.sameLine({

--- a/test/rules/disallow-keywords-on-new-line.js
+++ b/test/rules/disallow-keywords-on-new-line.js
@@ -23,6 +23,18 @@ describe('rules/disallow-keywords-on-new-line', function() {
         );
     });
 
+    it('should report illegal keyword placement for do while', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do {\n' +
+                    'x++;\n' +
+                '}\n' +
+                'while(x > 0)'
+            ).getErrorCount() === 1
+        );
+    });
+
     it('should report illegal keyword placement', function() {
         checker.configure({ disallowKeywordsOnNewLine: ['else'] });
         assert(
@@ -56,6 +68,52 @@ describe('rules/disallow-keywords-on-new-line', function() {
             checker.checkString(
                 'if (block) block[v]["(type)"] = "var";\n' +
                 'else funct[v] = "var";'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report special case for "while" statement without is not part of do (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'var i = 0\n' +
+                'while(i > 0) {\n' +
+                    ';\n' +
+                '}'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report special case for "do while" multiple line statement without braces (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do\n' +
+                    ';\n' +
+                'while(i > 0)'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report special case for "do while" single line statement without braces (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do ; while(i > 0)'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report special case for "do while" enclosing an inner while loop (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do {\n' +
+                    'while(i > 0) {\n' +
+                        ';\n' +
+                    '}' +
+                    'x++;\n' +
+                '} while(x > 0)'
             ).isEmpty()
         );
     });


### PR DESCRIPTION
1.	Allow while that is not part of a do to succeed even though it contradicts rule meaning
2.	Allow while that is part of a do to succeed for do whiles with no braces

Fixes #885 - issue