### PR TITLE
Added `disallow-multiple-spaces` rule. Fixes #435

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -564,6 +564,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-keywords'));
     this.registerRule(require('../rules/disallow-multiple-line-breaks'));
     this.registerRule(require('../rules/disallow-multiple-line-strings'));
+    this.registerRule(require('../rules/disallow-multiple-spaces'));
     this.registerRule(require('../rules/validate-line-breaks'));
     this.registerRule(require('../rules/validate-quote-marks'));
     this.registerRule(require('../rules/validate-indentation'));

--- a/lib/rules/disallow-multiple-spaces.js
+++ b/lib/rules/disallow-multiple-spaces.js
@@ -1,0 +1,74 @@
+/**
+ * Disallows multiple spaces between identifiers, keywords, and any other token
+ *
+ * Type: `Boolean`
+ *
+ * Values: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowMultipleSpaces": true
+ * ```
+ *
+ * ##### Valid
+ * ```js
+ * var x = "hello";
+ * function y() {}
+ * ```
+ *
+ * ##### Invalid
+ * ```js
+ * var x  = "hello";
+ * function y() {}
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true ||
+            typeof options === 'object' &&
+            options.allowEOLComments === true,
+            'options option requires true value ' +
+            'or an object with `allowEOLComments` property'
+        );
+
+        this.allowEOLComments = options.allowEOLComments;
+    },
+
+    getOptionName: function() {
+        return 'disallowMultipleSpaces';
+    },
+
+    check: function(file, errors) {
+        // Iterate over all tokens (including comments)
+        var _this = this;
+        file.getTokens().forEach(function(token, index, tokens) {
+            // If there are no trailing tokens, exit early
+            var nextToken = tokens[index + 1];
+            if (!nextToken) {
+                return;
+            }
+
+            // If we are allowing EOL comments and the next token is an EOL comment skip it
+            // We don't need to check the current token since EOL comments must be on separate lines from the next one
+            if (_this.allowEOLComments && nextToken.type === 'Line') {
+                return;
+            }
+
+            // Verify we have at most 1 space between this token and the next (won't fail for different lines)
+            errors.assert.whitespaceBetween({
+                token: token,
+                nextToken: nextToken,
+                atMost: 1,
+            });
+        });
+    }
+
+};

--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -40,6 +40,21 @@ TokenAssert.prototype.whitespaceBetween = function(options) {
                 fixed: true
             });
         }
+    } else if (options.hasOwnProperty('atMost')) {
+        var atMost = options.atMost;
+        if (nextToken.loc.start.line === token.loc.end.line &&
+            (nextToken.loc.start.column - token.loc.end.column) > atMost
+        ) {
+            this.emit('error', {
+                message: options.message ||
+                    (atMost === 1 ?
+                        'At most 1 space is allowed between ' + token.value + ' and ' + nextToken.value :
+                        'At most ' + atMost + ' spaces are allowed between ' +
+                            token.value + ' and ' + nextToken.value),
+                line: token.loc.end.line,
+                column: token.loc.end.column
+            });
+        }
     } else {
         if (nextToken.range[0] === token.range[1]) {
             nextToken.whitespaceBefore = ' ';

--- a/test/specs/rules/disallow-multiple-spaces.js
+++ b/test/specs/rules/disallow-multiple-spaces.js
@@ -1,0 +1,111 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-multiple-spaces', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('option value true', function() {
+        beforeEach(function() {
+            checker.configure({
+                disallowMultipleSpaces: true
+            });
+        });
+
+        it('should report multiple spaces', function() {
+            assert(checker.checkString('var x  = "oops";').getErrorCount() === 1);
+            assert(checker.checkString('function x  () {}').getErrorCount() === 1);
+            assert(checker.checkString('function x()  {}').getErrorCount() === 1);
+            assert(checker.checkString('1  + 2').getErrorCount() === 1);
+            assert(checker.checkString('1 +  2').getErrorCount() === 1);
+        });
+
+        it('should report multiple spaces between comments', function() {
+            assert(checker.checkString('var X = {  /** @type {String} */ name: "some" };').getErrorCount() === 1);
+            assert(checker.checkString('var x = "oops";  // Multiple spaces before comment').getErrorCount() === 1);
+        });
+
+        it('should not report single spaces between comments', function() {
+            assert(checker.checkString('var X = { /** @type {String} */ name: "some" };').isEmpty());
+            assert(checker.checkString('var x = "oops"; // Multiple spaces before comment').isEmpty());
+        });
+
+        it('should not report single spaces', function() {
+            assert(checker.checkString('var x = "oops";').isEmpty());
+            assert(checker.checkString('function x() {}').isEmpty());
+            assert(checker.checkString('function x () {}').isEmpty());
+            assert(checker.checkString('1 + 2').isEmpty());
+        });
+
+        it('should not report no spaces', function() {
+            assert(checker.checkString('var x="oops";').isEmpty());
+            assert(checker.checkString('function x(){}').isEmpty());
+            assert(checker.checkString('1+2').isEmpty());
+        });
+
+        it('should not report multiple spaces in strings/regular expressions', function() {
+            assert(checker.checkString('"hello  world";').isEmpty());
+            assert(checker.checkString('/hello  world/').isEmpty());
+        });
+
+        it('should not report multiple lines', function() {
+            assert(checker.checkString('var x = "oops";\nvar y = "hello";').isEmpty());
+        });
+
+        it('should not report indentation', function() {
+            assert(checker.checkString('    var x = "oops";').isEmpty());
+        });
+    });
+
+    describe('option value allowEOLComments', function() {
+        beforeEach(function() {
+            checker.configure({
+                disallowMultipleSpaces: {
+                    allowEOLComments: true
+                }
+            });
+        });
+
+        it('should report multiple spaces', function() {
+            assert(checker.checkString('var x  = "oops";').getErrorCount() === 1);
+        });
+
+        it('should report multiple spaces between inline comments', function() {
+            assert(checker.checkString('var X = {  /** @type {String} */ name: "some" };').getErrorCount() === 1);
+        });
+
+        it('should not report multiple spaces between EOL comments', function() {
+            assert(checker.checkString('var x = "oops";  // Multiple spaces before comment').isEmpty());
+        });
+
+        it('should not report single spaces between comments', function() {
+            assert(checker.checkString('var X = { /** @type {String} */ name: "some" };').isEmpty());
+            assert(checker.checkString('var x = "oops"; // Multiple spaces before comment').isEmpty());
+        });
+
+        it('should not report single spaces', function() {
+            assert(checker.checkString('var x = "oops";').isEmpty());
+        });
+
+        it('should not report no spaces', function() {
+            assert(checker.checkString('1+2').isEmpty());
+        });
+    });
+
+    describe('option value bad value', function() {
+        it('raises an assertion error', function() {
+            try {
+                checker.configure({
+                    disallowMultipleSpaces: 'apple'
+                });
+            } catch (err) {
+                return;
+            }
+            assert.fail('`checker.configure` should have raised an error for an invalid value');
+        });
+    });
+});

--- a/test/specs/token-assert.js
+++ b/test/specs/token-assert.js
@@ -142,6 +142,102 @@ describe('modules/token-assert', function() {
 
             assert.equal(onError.getCall(0).args[0].message, 'Custom message');
         });
+
+        it('should trigger error on invalid maximum space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                atMost: 1
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'At most 1 space is allowed between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should trigger plural error on invalid maximum space count between tokens', function() {
+            var file = createJsFile('x    =    y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                atMost: 2
+            });
+
+            assert(onError.calledOnce);
+
+            var error = onError.getCall(0).args[0];
+            assert.equal(error.message, 'At most 2 spaces are allowed between x and =');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 1);
+        });
+
+        it('should not trigger error on newline between tokens for maximum spaces', function() {
+            var file = createJsFile('x\n=y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                atMost: 1
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should not trigger error on valid maximum space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                atMost: 3
+            });
+
+            assert(!onError.calledOnce);
+        });
+
+        it('should accept message for invalid maximum space count between tokens', function() {
+            var file = createJsFile('x   =   y;');
+
+            var tokenAssert = new TokenAssert(file);
+            var onError = sinon.spy();
+            tokenAssert.on('error', onError);
+
+            var tokens = file.getTokens();
+            tokenAssert.whitespaceBetween({
+                token: tokens[0],
+                nextToken: tokens[1],
+                atMost: 1,
+                message: 'Custom message'
+            });
+
+            assert.equal(onError.getCall(0).args[0].message, 'Custom message');
+        });
     });
 
     describe('noWhitespaceBetween', function() {


### PR DESCRIPTION
This PR adds a rule for disallowing multiple spaces between any tokens (e.g. `var` and `x`). I decided to add to `token-assert` for reusability purposes. In this PR:

- Added tests for `disallow-multiple-spaces`
- Added rule for `disallow-multiple-spaces`
- Added `maximumSpaces` option for `TokenAssert.whitespaceBetween`

**Missing:**

- Negation rule for `disallow-multiple-spaces` (e.g. `require-multiple-spaces`)
    - I started building this but realized that it was unlikely to be used and none of the other whitespace `disallow` rules had negations
        - https://github.com/twolfson/node-jscs/compare/496c8911bb1f6d9ccadd98e201558e4b6c344ae4