### PR TITLE
requireSpaceAfterKeywords: use token assert

### DIFF
--- a/lib/rules/require-space-after-keywords.js
+++ b/lib/rules/require-space-after-keywords.js
@@ -42,11 +42,6 @@
  */
 
 var assert = require('assert');
-var util = require('util');
-var texts = [
-    'Missing space after "%s" keyword',
-    'Should be one space instead of %d, after "%s" keyword'
-];
 
 var defaultKeywords = require('../utils').spacedKeywords;
 
@@ -79,23 +74,17 @@ module.exports.prototype = {
         file.iterateTokensByType(['Keyword'], function(token) {
             if (keywordIndex[token.value]) {
                 var nextToken = file.getCommentAfterToken(token) || file.getNextToken(token);
-                var diff = nextToken.range[0] - token.range[1];
 
-                if (nextToken.loc.end.line === token.loc.start.line &&
-                    diff !== 1
-                ) {
-                    if (nextToken.type !== 'Punctuator' || nextToken.value !== ';') {
-                        errors.add(
-                            util.format.apply(null,
-                                diff === 0 ?
-                                    [texts[0], token.value] :
-                                    [texts[1], diff, token.value]
-                            ),
-                            nextToken.loc.start.line,
-                            nextToken.loc.start.column
-                        );
-                    }
+                if (nextToken.type === 'Punctuator' && nextToken.value === ';') {
+                    return;
                 }
+
+                errors.assert.whitespaceBetween({
+                    token: token,
+                    nextToken: nextToken,
+                    spaces: 1,
+                    message: 'One space required after "' + token.value + '" keyword'
+                });
             }
         });
     }

--- a/test/checker.js
+++ b/test/checker.js
@@ -144,11 +144,10 @@ describe('modules/checker', function() {
                 });
 
                 return checker.fixFile(tmpDir + '/spaces.js').then(function(errors) {
-                    assert.equal(errors.getErrorCount(), 1);
-                    assert.equal(errors.getErrorList()[0].message, 'Missing space after "if" keyword');
+                    assert.equal(errors.getErrorCount(), 0);
                     assert.equal(
                         fs.readFileSync(tmpDir + '/spaces.js', 'utf8'),
-                        'var y = 2;\nvar x = y + 1;\nif(x);\n'
+                        'var y = 2;\nvar x = y + 1;\nif (x);\n'
                     );
                 });
             });
@@ -175,12 +174,10 @@ describe('modules/checker', function() {
                 });
 
                 return checker.fixPath(tmpDir).then(function(errorsCollection) {
-                    var errors = errorsCollection[0];
-                    assert.equal(errors.getErrorCount(), 1);
-                    assert.equal(errors.getErrorList()[0].message, 'Missing space after "if" keyword');
+                    assert.equal(errorsCollection[0].getErrorCount(), 0);
                     assert.equal(
                         fs.readFileSync(tmpDir + '/spaces.js', 'utf8'),
-                        'var y = 2;\nvar x = y + 1;\nif(x);\n'
+                        'var y = 2;\nvar x = y + 1;\nif (x);\n'
                     );
                 });
             });

--- a/test/rules/require-space-after-keywords.js
+++ b/test/rules/require-space-after-keywords.js
@@ -11,10 +11,7 @@ describe('rules/require-space-after-keywords', function() {
 
     it('should report missing space after keyword', function() {
         checker.configure({ requireSpaceAfterKeywords: ['if'] });
-        var errors = checker.checkString('if(x) { x++; }');
-        var error = errors.getErrorList()[0];
-
-        assert(errors.explainError(error).indexOf('Missing space after "if" keyword') === 0);
+        assert(checker.checkString('if(x) { x++; }').getErrorCount() === 1);
     });
 
     it('should not report space after keyword', function() {
@@ -57,13 +54,9 @@ describe('rules/require-space-after-keywords', function() {
         assert(checker.checkString('function foo() {\r\n\treturn\r\n}').getErrorCount() === 0);
     });
 
-    it('should show different error if there is more than one space (#396)', function() {
+    it('should trigger error if there is more than one space (#396)', function() {
         checker.configure({ requireSpaceAfterKeywords: ['if'] });
-
-        var errors = checker.checkString('if  (x) {}');
-        var error = errors.getErrorList()[0];
-
-        assert(errors.explainError(error).indexOf('Should be one space instead of 2, after "if"') === 0);
+        assert(checker.checkString('if  (x) {}').getErrorCount() === 1);
     });
 
     it('should not trigger error for comments (#397)', function() {
@@ -73,11 +66,7 @@ describe('rules/require-space-after-keywords', function() {
 
     it('should trigger different error for comments with more than one space', function() {
         checker.configure({ requireSpaceAfterKeywords: ['if'] });
-
-        var errors = checker.checkString('if  /**/(x) {}');
-        var error = errors.getErrorList()[0];
-
-        assert(errors.explainError(error).indexOf('Should be one space instead of 2, after "if"') === 0);
+        assert(checker.checkString('if  /**/(x) {}').getErrorCount() === 1);
     });
 
     it('should report on all spaced keywords if a value of true is supplied', function() {


### PR DESCRIPTION
I modified the tests since we don't need multiple error messages anymore? This rule enforces 1 space.
I wasn't sure about the `nextToken.loc.end.line === token.loc.start.line` check - we didn't have any tests for that either.