### PR TITLE
Disallowing do..while on new line

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -36,7 +36,10 @@ var JsFile = function(filename, source, tree, options) {
     this._tokenRangeEndIndex = tokenIndexes.tokenRangeEndIndex;
     this._tokensByLineIndex = tokenIndexes.tokensByLineIndex;
 
-    this._index = this._buildNodeIndex();
+    var nodeIndexes = this._buildNodeIndex();
+    this._index = nodeIndexes.nodesByType;
+    this._nodesByStartRange = nodeIndexes.nodesByStartRange;
+
     this._fixEsprimaIdentifiers();
 
     this._buildDisabledRuleIndex();
@@ -371,6 +374,23 @@ JsFile.prototype = {
                 return false;
             }
         });
+        return result;
+    },
+
+    /**
+     * Returns nodes by range start index from earlier built index.
+     *
+     * @param {Object} token
+     * @returns {Object[]}
+     */
+    getNodesByFirstToken: function(token) {
+        var result = [];
+        if (token && token.range && token.range[0] >= 0) {
+            var nodes = this._nodesByStartRange[token.range[0]];
+            if (nodes) {
+                result = result.concat(nodes);
+            }
+        }
         return result;
     },
 
@@ -720,21 +740,30 @@ JsFile.prototype = {
     },
 
     /**
-     * Builds node index using node type as the key.
-     *
-     * @returns {Object}
+     * Builds node indexes using
+     *  i. node type as the key
+     *  ii. node start range as the key
+     * @returns {{nodesByType: {}, nodesByStartRange: {}}}
      * @private
      */
     _buildNodeIndex: function() {
-        var index = {};
+        var nodesByType = {};
+        var nodesByStartRange = {};
         this.iterate(function(node, parentNode, parentCollection) {
             var type = node.type;
 
             node.parentNode = parentNode;
             node.parentCollection = parentCollection;
-            (index[type] || (index[type] = [])).push(node);
+            (nodesByType[type] || (nodesByType[type] = [])).push(node);
+
+            // this part builds a node index that uses node start ranges as the key
+            var startRange = node.range[0];
+            (nodesByStartRange[startRange] || (nodesByStartRange[startRange] = [])).push(node);
         });
-        return index;
+        return {
+            nodesByType: nodesByType,
+            nodesByStartRange: nodesByStartRange
+        };
     },
 
     /**

--- a/lib/rules/disallow-keywords-on-new-line.js
+++ b/lib/rules/disallow-keywords-on-new-line.js
@@ -58,6 +58,24 @@ module.exports.prototype = {
                 return;
             }
 
+            // Special cases for #885, using while as the keyword contradicts rule meaning
+            // but it is more efficient and reduces complexity of the code in this rule
+            if (token.value === 'while') {
+                var nodes = file.getNodesByFirstToken(token);
+
+                if (nodes.length === 0) {
+                    // "while" that is part of a do will not return nodes as it is not a start token
+                    if (prevToken.value !== '}') {
+                        // allow "while" that is part of a "do while" with no braces to succeed
+                        return;
+                    }
+                } else {
+                    // it is a "while" statement that is not part of a "do while"
+                    // , allow it to succeed even though it contradicts rule meaning
+                    return;
+                }
+            }
+
             errors.assert.sameLine({
                 token: prevToken,
                 nextToken: token

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -589,6 +589,68 @@ describe('modules/js-file', function() {
         });
     });
 
+    describe('getNodesByFirstToken', function() {
+        describe('invalid arguments', function() {
+            var file;
+            beforeEach(function() {
+                file = createJsFile('x++;y++;');
+            });
+
+            it('should return empty array if the argument is invalid', function() {
+                var nodes = file.getNodesByFirstToken();
+                assert.equal(nodes.length, 0);
+            });
+
+            it('should return empty array if the argument.range is invalid', function() {
+                var nodes = file.getNodesByFirstToken({});
+                assert.equal(nodes.length, 0);
+            });
+
+            it('should return empty array if the argument.range[0] is invalid', function() {
+                var nodes = file.getNodesByFirstToken({
+                    range: {}
+                });
+                assert.equal(nodes.length, 0);
+            });
+        });
+
+        describe('empty progam', function() {
+            var file;
+            beforeEach(function() {
+                file = createJsFile('');
+            });
+
+            it('should return 1 node of type Program when provided the first token', function() {
+                var token = file.getFirstToken();
+                var nodes = file.getNodesByFirstToken(token);
+                assert.equal(nodes.length, 1);
+                assert.equal(nodes[0].type, 'Program');
+            });
+        });
+
+        describe('normal progam', function() {
+            var file;
+            beforeEach(function() {
+                file = createJsFile('var x;\ndo {\n\tx++;\n} while (x < 10);');
+            });
+
+            it('should return nodes when supplied with a token that is the start of a node', function() {
+                var token = file.getFirstToken();
+                var nodes = file.getNodesByFirstToken(token);
+                assert.equal(nodes.length, 2);
+                assert.equal(nodes[0].type, 'Program');
+                assert.equal(nodes[1].type, 'VariableDeclaration');
+            });
+
+            it('should return an empty array when supplied with a token that is not the start of a node', function() {
+                var token = file.getFirstToken();
+                var nextToken = file.findNextToken(token, 'Keyword', 'while');
+                var nodes = file.getNodesByFirstToken(nextToken);
+                assert.equal(nodes.length, 0);
+            });
+        });
+    });
+
     describe('getNodesByType', function() {
         it('should return nodes using specified type', function() {
             var nodes = createJsFile('x++;y++;').getNodesByType('Identifier');

--- a/test/specs/rules/disallow-keywords-on-new-line.js
+++ b/test/specs/rules/disallow-keywords-on-new-line.js
@@ -69,6 +69,31 @@ describe('rules/disallow-keywords-on-new-line', function() {
         });
     });
 
+    describe('illegal keyword placement for "do while" (#885)', function() {
+        beforeEach(function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+
+            input = 'do {\n' +
+                    'x++;\n' +
+                '}\n' +
+                'while(x > 0)';
+
+            output = 'do {\n' +
+                    'x++;\n' +
+                '} while(x > 0)';
+        });
+
+        it('should report', function() {
+            assert(checker.checkString(input).getErrorCount() === 1);
+        });
+
+        it('should fix', function() {
+            var result = checker.fixString(input);
+            assert(result.errors.isEmpty());
+            assert.equal(result.output, output);
+        });
+    });
+
     it('should not report legal keyword placement', function() {
         checker.configure({ disallowKeywordsOnNewLine: ['else'] });
         assert(
@@ -88,6 +113,43 @@ describe('rules/disallow-keywords-on-new-line', function() {
             checker.checkString(
                 'if (block) block[v]["(type)"] = "var";\n' +
                 'else funct[v] = "var";'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report legal keyword placement for "do while" (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do {\n' +
+                    'x++;\n' +
+                '}while(x > 0)'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report special case for "do while" multiple line statement without braces (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'do\n' +
+                    ';\n' +
+                'while(i > 0)'
+            ).isEmpty()
+        );
+    });
+
+    it('should not report legal keyword placement for "while" statement (#885)', function() {
+        checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+        assert(
+            checker.checkString(
+                'var i = 0;\n' +
+                'if (i) {\n' +
+                    'i++;\n' +
+                '}' +
+                'while(i > 0) {\n' +
+                    ';\n' +
+                '}'
             ).isEmpty()
         );
     });


### PR DESCRIPTION
    Make option disallowKeywordsOnNewLine perform special scenarios for the keyword "while" when checking "DoWhileStatements". The behavior contradicts the original idea of keyword "while" but it is done to reuse existing code in a efficient and less complex manner
    1.  Allow "while" that is part of a "do while" with no braces to succeed
    2.  Allow "while" that is not part of a "do while" to succeed even though it contradicts rule meaning

Fixes #885 - issue