### PR TITLE
Preset: Idiomatic

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -8,6 +8,7 @@ Note: the easiest way to use a preset is with the [preset](#preset) option descr
  * [Crockford](https://github.com/jscs-dev/node-jscs/blob/master/presets/crockford.json) — http://javascript.crockford.com/code.html
  * [Google](https://github.com/jscs-dev/node-jscs/blob/master/presets/google.json) — https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
  * [Grunt](https://github.com/jscs-dev/node-jscs/blob/master/presets/grunt.json) — http://gruntjs.com/contributing#syntax
+ * [Idiomatic](https://github.com/jscs-dev/node-jscs/blob/master/presets/idiomatic.json) — https://github.com/rwaldron/idiomatic.js#idiomatic-style-manifesto
  * [jQuery](https://github.com/jscs-dev/node-jscs/blob/master/presets/jquery.json) — https://contribute.jquery.org/style-guide/js/
  * [MDCS](https://github.com/jscs-dev/node-jscs/blob/master/presets/mdcs.json) — [https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style™](https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2)
  * [node-style-guide](https://github.com/jscs-dev/node-jscs/blob/master/presets/node-style-guide.json) - https://github.com/felixge/node-style-guide
@@ -221,7 +222,7 @@ Extends defined rules with preset rules.
 
 Type: `String`
 
-Values: You can choose one of the default presets: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"node-style-guide"`, `"wikimedia"`, `"wordpress"`, `"yandex"`.
+Values: You can choose one of the default presets: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"node-style-guide"`, `"wikimedia"`, `"wordpress"`, `"yandex"`, `"idiomatic"`.
 
 Or you can load from it local path or as node module
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -1012,6 +1012,9 @@ Configuration.prototype.registerDefaultPresets = function() {
     // http://gruntjs.com/contributing#syntax
     this.registerPreset('grunt', require('../../presets/grunt.json'));
 
+    // https://github.com/rwaldron/idiomatic.js#idiomatic-style-manifesto
+    this.registerPreset('idiomatic', require('../../presets/idiomatic.json'));
+
     // https://contribute.jquery.org/style-guide/js/
     this.registerPreset('jquery', require('../../presets/jquery.json'));
 

--- a/presets/idiomatic.json
+++ b/presets/idiomatic.json
@@ -1,0 +1,17 @@
+{
+    "preset": "jquery",
+    "requireSpacesInsideParentheses": {
+        "all": true,
+        "ignoreParenthesizedExpression": true,
+        "except": [ "{", "}", "[", "]", "function", "\"" ]
+    },
+    "disallowSpacesInCallExpression": true,
+    "requirePaddingNewLinesBeforeLineComments": null,
+    "requireSpaceAfterLineComment": {
+        "allExcept": ["#", "="]
+    },
+    "disallowMultipleLineBreaks": null,
+    "requireCapitalizedComments": null,
+    "validateIndentation": null,
+    "validateCommentPosition": { "position": "above" }
+}

--- a/test/data/options/preset/idiomatic.js
+++ b/test/data/options/preset/idiomatic.js
@@ -1,0 +1,223 @@
+// A. Parens, Braces, Linebreaks
+
+
+// if/else/for/while/try always have spaces, braces and span multiple lines
+// this encourages readability
+
+// 2.A.1.1
+// Use whitespace to promote readability
+
+if ( condition ) {
+
+}
+
+while ( condition ) {
+
+}
+
+for ( ; i < length; i++ ) {
+
+}
+
+for ( prop in object ) {
+
+}
+
+if ( true ) {
+
+} else {
+
+}
+
+// B. Assignments, Declarations, Functions ( Named, Expression, Constructor )
+
+// 2.B.1.2
+// Using only one `var` per scope (function) promotes readability
+// and keeps your declaration list free of clutter (also saves a few keystrokes)
+
+// or..
+var
+foo = "",
+bar = "",
+quux;
+
+// 2.B.1.3
+// var statements should always be in the beginning of their respective scope (function).
+
+// Good
+function foo() {
+  var bar = "",
+    qux;
+
+  // all statements after the variables declarations.
+}
+
+// 2.B.1.4
+// const and let, from ECMAScript 6, should likewise be at the top of their scope (block).
+
+// Good
+function foo() {
+  let foo;
+  if ( condition ) {
+    let bar = "";
+
+  }
+}
+
+// 2.B.2.1
+// Named Function Declaration
+function foo( arg1, argN ) {
+
+}
+
+// Usage
+foo( arg1, argN );
+
+// 2.B.2.2
+// Named Function Declaration
+function square( number ) {
+  return number * number;
+}
+
+// Usage
+square( 10 );
+
+// Really contrived continuation passing style
+function square( number, callback ) {
+  callback( number * number );
+}
+
+square( 10, function( square ) {
+  // callback statements
+});
+
+// 2.B.2.3
+// Function Expression
+function a() {
+    var square = function( number ) {
+      // Return something valuable and relevant
+      return number * number;
+    };
+}
+
+// Function Expression with Identifier
+// This preferred form has the added value of being
+// able to call itself and have an identity in stack traces:
+function b() {
+    var factorial = function factorial( number ) {
+      if ( number < 2 ) {
+        return 1;
+      }
+
+      return number * factorial( number - 1 );
+    };
+}
+
+// 2.B.2.4
+// Constructor Declaration
+function FooBar( options ) {
+  this.options = options;
+}
+
+// Usage
+function c() {
+    var fooBar = new FooBar({ a: "alpha" });
+    fooBar.options;
+    // { a: "alpha" }
+}
+
+// 2.C.1.1
+// Functions with callbacks
+foo(function() {
+  // Note there is no extra space between the first paren
+  // of the executing function call and the word "function"
+});
+
+// Function accepting an array, no space
+foo([ "alpha", "beta" ]);
+
+// 2.C.1.2
+// Function accepting an object, no space
+foo({
+  a: "alpha",
+  b: "beta"
+});
+
+// ** new rule **
+// Single argument string literal, no space
+foo("bar");
+
+// ** new rule **
+// Inner grouping parens, no space
+if ( !("foo" in obj) ) {
+
+}
+
+// 5.1.1
+// A Practical Module
+
+(function( global ) {
+  var Module = (function() {
+
+    var data = "secret";
+
+    return {
+      // This is some boolean property
+      bool: true,
+      // Some string value
+      string: "a string",
+      // An array property
+      array: [ 1, 2, 3, 4 ],
+      // An object property
+      object: {
+        lang: "en-Us"
+      },
+      getData: function() {
+        // get the current value of `data`
+        return data;
+      },
+      setData: function( value ) {
+        // set the value of `data` and return it
+        return ( data = value );
+      }
+    };
+  })();
+
+  // Other things might happen here
+
+  // expose our module to the global object
+  global.Module = Module;
+
+})( this );
+
+// 5.2.1
+// A Practical Constructor
+
+(function( global ) {
+
+  function Ctor( foo ) {
+
+    this.foo = foo;
+
+    return this;
+  }
+
+  Ctor.prototype.getFoo = function() {
+    return this.foo;
+  };
+
+  Ctor.prototype.setFoo = function( val ) {
+    return ( this.foo = val );
+  };
+
+
+  // To call constructor's without `new`, you might do this:
+  var ctor = function( foo ) {
+    return new Ctor( foo );
+  };
+
+
+  // expose our constructor to the global object
+  global.ctor = ctor;
+
+})( this );

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -269,6 +269,7 @@ describe('config/configuration', function() {
             assert(configuration.hasPreset('grunt'));
             assert(configuration.hasPreset('node-style-guide'));
             assert(configuration.hasPreset('wordpress'));
+            assert(configuration.hasPreset('idiomatic'));
         });
     });
 

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -522,6 +522,7 @@ describe('string-checker', function() {
         testPreset('crockford');
         testPreset('google');
         testPreset('grunt');
+        testPreset('idiomatic');
         testPreset('jquery');
         testPreset('mdcs');
         testPreset('node-style-guide');


### PR DESCRIPTION
#1065. WIP

Idiomatic | JSCS
-------------|---------
`indentation` | no preference but be consistent!
`quotes?` | use jquery preset: `"validateQuoteMarks": { "mark": "\"", "escape": true }`,
`foo("bar")`| **new rule option**: `requireSpacesInsideParentheses`: Single argument string literal, no space
`if ( !("foo" in obj) ) {` | **new rule option**: `requireSpacesInsideParentheses`: Inner grouping parens, no space
`foo([ "alpha", "beta" ]);` | `"requireSpacesInsideParentheses": { "except": [ "[", "]" ] }`
`(function( global ) {})()` | `"requireSpacesInsideParentheses": { "except": ["function"] }`
`foo({ a: "alpha" });` | `"requireSpacesInsideParentheses": { "except": [ "{", "}" ] }`
`square( 10 );` | `"disallowSpacesInCallExpression": true`
`// statements` | `"requireSpaceAfterLineComment": { "allExcept": ["#", "="] }`
 | `"disallowMultipleLineBreaks": null`
`var, const, let statements should always be in the beginning of their respective scope` | #99 **new rule** `requireVarDeclFirst`
`name of regex: rDesc` | **new rule**?
`End of line comments are prohibited!` | **new rule** `validateCommentPosition`
`var factorial = function factorial( number ) {` | similar to #850
`avoid switch if possible` | `disallowNodeTypes: ["SwitchStatement"]`
`early returns` | new rule https://github.com/jscs-dev/node-jscs/issues/1223 `requireEarlyReturn`