### PR TITLE
disallowSpaceBeforeBinaryOperators: comments are allowed

### DIFF
--- a/lib/rules/disallow-space-before-binary-operators.js
+++ b/lib/rules/disallow-space-before-binary-operators.js
@@ -72,7 +72,7 @@ module.exports.prototype = {
         if (operators[',']) {
             file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
                 errors.assert.noWhitespaceBetween({
-                    token: file.getPrevToken(token),
+                    token: file.getPrevToken(token, {includeComments: true}),
                     nextToken: token,
                     message: 'Operator , should stick to previous expression'
                 });
@@ -103,7 +103,7 @@ module.exports.prototype = {
                     operator
                 );
 
-                var prevToken = file.getPrevToken(operatorToken);
+                var prevToken = file.getPrevToken(operatorToken, {includeComments: true});
 
                 if (operators[operator]) {
                     errors.assert.noWhitespaceBetween({

--- a/test/rules/disallow-space-before-binary-operators.js
+++ b/test/rules/disallow-space-before-binary-operators.js
@@ -97,4 +97,14 @@ describe('rules/disallow-space-before-binary-operators', function() {
         checker.configure({ disallowSpaceBeforeBinaryOperators: [','] });
         assert(checker.checkString('var x = [1, 2]\n  , y = 32').isEmpty());
     });
+
+    it('should not report error if a comment is ahead of the comma', function() {
+        checker.configure({ disallowSpaceBeforeBinaryOperators: [','] });
+        assert(checker.checkString('var x = [1, 2] /* test*/, y = 32').isEmpty());
+    });
+
+    it('should report error if a space is between comment and the comma', function() {
+        checker.configure({ disallowSpaceBeforeBinaryOperators: [','] });
+        assert(checker.checkString('var x = [1, 2] /* test*/ , y = 32').getErrorCount() === 1);
+    });
 });


### PR DESCRIPTION
disallowSpaceBeforeBinaryOperators should include comments in the token list. This was found when using the autofixer with the mdcs prset against the three.js library [pull request](https://github.com/mrdoob/three.js/pull/6102). 