### PR TITLE
Tests for Fixing Newlines

### DIFF
--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -143,7 +143,7 @@ TokenAssert.prototype.differentLine = function(options) {
 TokenAssert.prototype.linesBetween = function(options) {
     var token = options.token;
     var nextToken = options.nextToken;
-    var whitespaceBefore = '';
+    var whitespaceBefore = ' ';
 
     if (!token || !nextToken) {
         return;

--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -143,7 +143,7 @@ TokenAssert.prototype.differentLine = function(options) {
 TokenAssert.prototype.linesBetween = function(options) {
     var token = options.token;
     var nextToken = options.nextToken;
-    var whitespaceBefore = ' ';
+    var whitespaceBefore = '';
 
     if (!token || !nextToken) {
         return;
@@ -198,6 +198,7 @@ TokenAssert.prototype.linesBetween = function(options) {
         if (exactly > 0) {
             whitespaceBefore = new Array(exactly).join('\n');
         }
+
         emitError('exactly ' + exactly, whitespaceBefore);
     }
 };

--- a/test/rules/disallow-keywords-on-new-line.js
+++ b/test/rules/disallow-keywords-on-new-line.js
@@ -76,7 +76,7 @@ describe('rules/disallow-keywords-on-new-line', function() {
             assert.equal(result.output,
                 'try {\n' +
                     'x++;\n' +
-                '}catch(e) {\n' +
+                '} catch(e) {\n' +
                     'x--;\n' +
                 '}'
                 );

--- a/test/rules/disallow-keywords-on-new-line.js
+++ b/test/rules/disallow-keywords-on-new-line.js
@@ -59,4 +59,41 @@ describe('rules/disallow-keywords-on-new-line', function() {
             ).isEmpty()
         );
     });
+
+    describe('fix', function() {
+        it ('should fix try catch', function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['catch'] });
+            var result = checker.fixString(
+                'try {\n' +
+                    'x++;\n' +
+                '}\n' +
+                'catch(e) {\n' +
+                    'x--;\n' +
+                '}'
+            );
+
+            assert(result.errors.isEmpty());
+            assert.equal(result.output,
+                'try {\n' +
+                    'x++;\n' +
+                '}catch(e) {\n' +
+                    'x--;\n' +
+                '}'
+                );
+        });
+
+        it('should not fix special case for "else" statement without braces (#905)', function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['else'] });
+            var result = checker.fixString(
+                'if (block) block[v]["(type)"] = "var";\n' +
+                'else funct[v] = "var";'
+            );
+
+            assert(result.errors.isEmpty());
+            assert.equal(result.output,
+                'if (block) block[v]["(type)"] = "var";\n' +
+                'else funct[v] = "var";'
+            );
+        });
+    });
 });

--- a/test/rules/disallow-newline-before-block-statements.js
+++ b/test/rules/disallow-newline-before-block-statements.js
@@ -55,5 +55,19 @@ describe('rules/disallow-newline-before-block-statements', function() {
         it('should not throw error if opening parentheses is first symbol in the file', function() {
             assert(checker.checkString('{ test: 1 }').isEmpty());
         });
+
+        describe('fix', function() {
+            it ('should fix disallowed newline before opening brace', function() {
+                var result = checker.fixString('function test()\n{abc();}');
+                assert(result.errors.isEmpty());
+                assert.equal(result.output, 'function test(){abc();}');
+            });
+
+            it('should fix all three statements', function() {
+                var result = checker.fixString('function test()\n{\nif(true)\n{\nreturn 1;\n}\nfor(var i in [1,2,3])\n{\n}\n}');
+                assert(result.errors.isEmpty());
+                assert.equal(result.output, 'function test(){\nif(true){\nreturn 1;\n}\nfor(var i in [1,2,3]){\n}\n}');
+            });
+        });
     });
 });

--- a/test/rules/disallow-newline-before-block-statements.js
+++ b/test/rules/disallow-newline-before-block-statements.js
@@ -60,13 +60,32 @@ describe('rules/disallow-newline-before-block-statements', function() {
             it ('should fix disallowed newline before opening brace', function() {
                 var result = checker.fixString('function test()\n{abc();}');
                 assert(result.errors.isEmpty());
-                assert.equal(result.output, 'function test(){abc();}');
+                assert.equal(result.output, 'function test() {abc();}');
             });
 
             it('should fix all three statements', function() {
-                var result = checker.fixString('function test()\n{\nif(true)\n{\nreturn 1;\n}\nfor(var i in [1,2,3])\n{\n}\n}');
+                var result = checker.fixString(
+                    'function test()\n' +
+                    '{\n' +
+                        'if(true)\n' +
+                        '{\n' +
+                            'return 1;\n' +
+                        '}\n' +
+                        'for(var i in [1,2,3])\n' +
+                        '{\n' +
+                        '}\n' +
+                    '}'
+                );
                 assert(result.errors.isEmpty());
-                assert.equal(result.output, 'function test(){\nif(true){\nreturn 1;\n}\nfor(var i in [1,2,3]){\n}\n}');
+                assert.equal(result.output,
+                    'function test() {\n' +
+                        'if(true) {\n' +
+                            'return 1;\n' +
+                        '}\n' +
+                        'for(var i in [1,2,3]) {\n' +
+                        '}\n' +
+                    '}'
+                );
             });
         });
     });

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -147,39 +147,41 @@ describe('modules/string-checker', function() {
     });
 
     describe('fixString', function() {
-        it('should apply fixes to the specified string', function() {
-            checker.configure({ requireSpaceBeforeBinaryOperators: true });
-            var result = checker.fixString('x=1+2;');
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, 'x =1 +2;');
-        });
+        describe('space rules', function() {
+            it('should apply fixes to the specified string', function() {
+                checker.configure({ requireSpaceBeforeBinaryOperators: true });
+                var result = checker.fixString('x=1+2;');
+                assert(result.errors.isEmpty());
+                assert.equal(result.output, 'x =1 +2;');
+            });
 
-        it('should apply multiple fixes to the specified string', function() {
-            checker.configure({ requireSpaceBeforeBinaryOperators: true, requireSpaceAfterBinaryOperators: true });
-            var result = checker.fixString('x=1+2;');
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, 'x = 1 + 2;');
-        });
+            it('should apply multiple fixes to the specified string', function() {
+                checker.configure({ requireSpaceBeforeBinaryOperators: true, requireSpaceAfterBinaryOperators: true });
+                var result = checker.fixString('x=1+2;');
+                assert(result.errors.isEmpty());
+                assert.equal(result.output, 'x = 1 + 2;');
+            });
 
-        it('should return unfixable errors', function() {
-            checker.configure({ disallowImplicitTypeConversion: ['boolean'] });
-            var result = checker.fixString('x = !!x;');
-            assert.equal(result.errors.getErrorCount(), 1);
-            assert.equal(result.errors.getErrorList()[0].message, 'Implicit boolean conversion');
-        });
+            it('should return unfixable errors', function() {
+                checker.configure({ disallowImplicitTypeConversion: ['boolean'] });
+                var result = checker.fixString('x = !!x;');
+                assert.equal(result.errors.getErrorCount(), 1);
+                assert.equal(result.errors.getErrorList()[0].message, 'Implicit boolean conversion');
+            });
 
-        it('should process parse error', function() {
-            checker.configure({});
-            var result = checker.fixString('x =');
-            assert.equal(result.errors.getErrorCount(), 1);
-            assert.equal(result.errors.getErrorList()[0].message, 'Unexpected end of input');
-            assert.equal(result.output, 'x =');
-        });
+            it('should process parse error', function() {
+                checker.configure({});
+                var result = checker.fixString('x =');
+                assert.equal(result.errors.getErrorCount(), 1);
+                assert.equal(result.errors.getErrorList()[0].message, 'Unexpected end of input');
+                assert.equal(result.output, 'x =');
+            });
 
-        it('should accept file name', function() {
-            checker.configure({});
-            var result = checker.fixString('x = 1;', '1.js');
-            assert.equal(result.errors.getFilename(), '1.js');
+            it('should accept file name', function() {
+                checker.configure({});
+                var result = checker.fixString('x = 1;', '1.js');
+                assert.equal(result.errors.getFilename(), '1.js');
+            });
         });
     });
 

--- a/test/string-checker.js
+++ b/test/string-checker.js
@@ -147,6 +147,27 @@ describe('modules/string-checker', function() {
     });
 
     describe('fixString', function() {
+        it('should return unfixable errors', function() {
+            checker.configure({ disallowImplicitTypeConversion: ['boolean'] });
+            var result = checker.fixString('x = !!x;');
+            assert.equal(result.errors.getErrorCount(), 1);
+            assert.equal(result.errors.getErrorList()[0].message, 'Implicit boolean conversion');
+        });
+
+        it('should process parse error', function() {
+            checker.configure({});
+            var result = checker.fixString('x =');
+            assert.equal(result.errors.getErrorCount(), 1);
+            assert.equal(result.errors.getErrorList()[0].message, 'Unexpected end of input');
+            assert.equal(result.output, 'x =');
+        });
+
+        it('should accept file name', function() {
+            checker.configure({});
+            var result = checker.fixString('x = 1;', '1.js');
+            assert.equal(result.errors.getFilename(), '1.js');
+        });
+
         describe('space rules', function() {
             it('should apply fixes to the specified string', function() {
                 checker.configure({ requireSpaceBeforeBinaryOperators: true });
@@ -160,27 +181,6 @@ describe('modules/string-checker', function() {
                 var result = checker.fixString('x=1+2;');
                 assert(result.errors.isEmpty());
                 assert.equal(result.output, 'x = 1 + 2;');
-            });
-
-            it('should return unfixable errors', function() {
-                checker.configure({ disallowImplicitTypeConversion: ['boolean'] });
-                var result = checker.fixString('x = !!x;');
-                assert.equal(result.errors.getErrorCount(), 1);
-                assert.equal(result.errors.getErrorList()[0].message, 'Implicit boolean conversion');
-            });
-
-            it('should process parse error', function() {
-                checker.configure({});
-                var result = checker.fixString('x =');
-                assert.equal(result.errors.getErrorCount(), 1);
-                assert.equal(result.errors.getErrorList()[0].message, 'Unexpected end of input');
-                assert.equal(result.output, 'x =');
-            });
-
-            it('should accept file name', function() {
-                checker.configure({});
-                var result = checker.fixString('x = 1;', '1.js');
-                assert.equal(result.errors.getFilename(), '1.js');
             });
         });
     });


### PR DESCRIPTION
Adding some tests to two rules that check that they are fixed properly.

I'm not super happy with these test being here. I originally thought these tests should exist in the rules, but now I believe I have a better idea.

Instead of testing all of the rules that they get fixed properly (which has too much overlap with testing `checker.fixString`) we should:

 - [ ] test that the line assertions state `fixed` and have the correct amount of `whitespaceBefore`
 - [ ] test ton `checker.fixString` when given a set of tokens with errors and `whitespaceBefore` outputs the right string

But we shouldn't be making all of the tests to `checker.fixString` use actual rules. We should only use rules with `checker.fixString` as a final integration test of sorts.