### PR TITLE
Preset: node-style-guide

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -8,6 +8,7 @@
  * [Grunt](https://github.com/jscs-dev/node-jscs/blob/master/presets/grunt.json) — http://gruntjs.com/contributing#syntax
  * [jQuery](https://github.com/jscs-dev/node-jscs/blob/master/presets/jquery.json) — https://contribute.jquery.org/style-guide/js/
  * [MDCS](https://github.com/jscs-dev/node-jscs/blob/master/presets/mdcs.json) — [https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style™](https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2)
+ * [node-style-guide](https://github.com/jscs-dev/node-jscs/blob/master/presets/node-style-guide.json) - https://github.com/felixge/node-style-guide
  * [Wikimedia](https://github.com/jscs-dev/node-jscs/blob/master/presets/wikimedia.json) — https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
  * [Yandex](https://github.com/jscs-dev/node-jscs/blob/master/presets/yandex.json) — https://github.com/yandex/codestyle/blob/master/javascript.md
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -700,6 +700,9 @@ Configuration.prototype.registerDefaultPresets = function() {
     // https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2
     this.registerPreset('mdcs', require('../../presets/mdcs.json'));
 
+    // https://github.com/felixge/node-style-guide#nodejs-style-guide
+    this.registerPreset('node-style-guide', require('../../presets/node-style-guide.json'));
+
     // https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
     this.registerPreset('wikimedia', require('../../presets/wikimedia.json'));
 

--- a/presets/node-style-guide.json
+++ b/presets/node-style-guide.json
@@ -1,0 +1,47 @@
+{
+    "disallowKeywords": ["with"],
+    "disallowKeywordsOnNewLine": ["else"],
+    "disallowMixedSpacesAndTabs": true,
+    "disallowMultipleVarDecl": "exceptUndefined",
+    "disallowNewlineBeforeBlockStatements": true,
+    "disallowQuotedKeysInObjects": true,
+    "disallowSpaceAfterObjectKeys": true,
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpacesInFunction": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInsideParentheses": true,
+    "disallowTrailingWhitespace": true,
+    "maximumLineLength": 80,
+    "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireCapitalizedComments": true,
+    "requireCapitalizedConstructors": true,
+    "requireCurlyBraces": true,
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "return",
+        "try",
+        "catch",
+        "typeof"
+    ],
+    "requireSpaceAfterLineComment": true,
+    "requireSpaceAfterBinaryOperators": true,
+    "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireSpaceBeforeObjectValues": true,
+    "requireSpacesInFunction": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "requireTrailingComma": {
+        "ignoreSingleLine": true
+    },
+    "validateIndentation": 2,
+    "validateLineBreaks": "LF",
+    "validateQuoteMarks": "'"
+}

--- a/test/data/options/preset/node-style-guide.js
+++ b/test/data/options/preset/node-style-guide.js
@@ -1,0 +1,135 @@
+// Use single quotes, unless you are writing JSON.
+var foo = 'bar';
+
+// Your opening braces go on the same line as the statement.
+// Also, notice the use of whitespace
+// before and after the condition statement.
+if (true) {
+  console.log('winning');
+}
+
+// One method per line should be used if you want to chain methods.
+// You should also indent these methods so it's easier to tell
+// they are part of the same chain.
+User
+  .findOne({ name: 'foo' })
+  .populate('bar')
+  .exec(function(err, user) {
+    return true;
+  });
+
+// Declare one variable per var statement,
+// it makes it easier to re-order the lines.
+var keys   = ['foo', 'bar'];
+var values = [23, 42];
+
+var object = {};
+while (keys.length) {
+  var key = keys.pop();
+  object[key] = values.pop();
+}
+
+// Use lowerCamelCase for variables, properties and function names
+// Single character variables and uncommon abbreviations should
+// generally be avoided.
+var adminUser = db.query('SELECT * FROM users ...');
+
+// Use UpperCamelCase for class names
+function BankAccount() {
+}
+
+// Use UPPERCASE for Constants
+var SECOND = 1 * 1000;
+
+function File() {
+}
+File.FULL_PERMISSIONS = 0777;
+
+// Use trailing commas and put short declarations on a single line.
+// Only quote keys when your interpreter complains:
+var a = ['hello', 'world'];
+var b = {
+  good: 'code',
+  'is generally': 'pretty',
+};
+
+// Use the === operator
+var a = 0;
+if (a !== '') {
+  console.log('winning');
+}
+
+// Use multi-line ternary operator
+var foo = (a === b)
+  ? 1
+  : 2;
+
+// Do not extend built-in prototypes
+var a = [];
+if (!a.length) {
+  console.log('winning');
+}
+
+// Use descriptive conditions
+var isValidPassword = password.length >= 4 && /^(?=.*\d).{4,}$/.test(password);
+
+if (isValidPassword) {
+  console.log('winning');
+}
+
+// Write small functions
+
+// Return early from functions
+function isPercentage(val) {
+  if (val < 0) {
+    return false;
+  }
+
+  if (val > 100) {
+    return false;
+  }
+
+  return true;
+}
+
+// shows else statement being used
+if (val < 100) {
+  return true;
+} else {
+  return false;
+}
+
+function isPercentage(val) {
+  var isInRange = (val >= 0 && val <= 100);
+  return isInRange;
+}
+
+// Name your closures
+req.on('end', function onEnd() {
+  console.log('winning');
+});
+
+// No nested closures
+setTimeout(function() {
+  client.connect(afterConnect);
+}, 1000);
+
+function afterConnect() {
+  console.log('winning');
+}
+
+// Use slashes for comments
+// 'ID_SOMETHING=VALUE' -> ['ID_SOMETHING=VALUE', 'SOMETHING', 'VALUE']
+var matches = item.match(/ID_([^\n]+)=([^\n]+)/);
+
+// This function has a nasty side effect where a failure to increment a
+// redis counter used for statistics will cause an exception. This needs
+// to be fixed in a later iteration.
+function loadUser(id, cb) {
+  // ...
+}
+
+var isSessionValid = (session.expires < Date.now());
+if (isSessionValid) {
+  // ...
+}

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -216,6 +216,7 @@ describe('modules/config/configuration', function() {
             assert(configuration.hasPreset('wikimedia'));
             assert(configuration.hasPreset('yandex'));
             assert(configuration.hasPreset('grunt'));
+            assert(configuration.hasPreset('node-style-guide'));
         });
     });
 

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -364,6 +364,7 @@ describe('modules/string-checker', function() {
         testPreset('grunt');
         testPreset('jquery');
         testPreset('mdcs');
+        testPreset('node-style-guide');
         testPreset('wikimedia');
         testPreset('yandex');
 


### PR DESCRIPTION
Fixes #1071 

Initial preset config.

Not sure if the preset should only include rules based on the explicit statements or also include rules based on the code in the examples that is implied.

An example is function spacing.

```js
function BankAccount() {
}
setTimeout(function() {
  client.connect(afterConnect);
}, 1000);
```
the rules could be inferred to be 
```js
"disallowSpacesInFunction": {
    "beforeOpeningRoundBrace": true
},
"requireSpacesInFunction": {
    "beforeOpeningCurlyBrace": true
},
```

I can move that huge table of possible rules here as well?