### PR TITLE
requireSpacesInsideArrayBrackets: comments should be also taken into account

### DIFF
--- a/lib/rules/require-spaces-inside-array-brackets.js
+++ b/lib/rules/require-spaces-inside-array-brackets.js
@@ -95,9 +95,9 @@ module.exports.prototype = {
 
         file.iterateNodesByType('ArrayExpression', function(node) {
             var openBracket = file.getFirstNodeToken(node);
-            var afterOpen = file.getNextToken(openBracket);
+            var afterOpen = file.getNextToken(openBracket, {includeComments: true});
             var closeBracket = file.getLastNodeToken(node);
-            var beforeClose = file.getPrevToken(closeBracket);
+            var beforeClose = file.getPrevToken(closeBracket, {includeComments: true});
 
             // Skip for empty array brackets
             if (afterOpen.value === ']') {

--- a/test/rules/require-spaces-inside-array-brackets.js
+++ b/test/rules/require-spaces-inside-array-brackets.js
@@ -107,4 +107,35 @@ describe('rules/require-spaces-inside-array-brackets', function() {
             assert(checker.checkString('var x = [(1)];').isEmpty());
         });
     });
+
+    describe('comments', function() {
+        beforeEach(function() {
+            checker.configure({ requireSpacesInsideArrayBrackets: 'all' });
+        });
+
+        it('should report missing space after comment', function() {
+            assert(checker.checkString('var x = [ 1 /*,2*/];').getErrorCount() === 1);
+        });
+
+        it('should not report with space after comment', function() {
+            assert(checker.checkString('var x = [ 1 /*,2*/ ];').isEmpty());
+        });
+
+        it('should report missing space before comment', function() {
+            assert(checker.checkString('var x = [/*0,*/ 1 ];').getErrorCount() === 1);
+        });
+
+        it('should not report with space before comment', function() {
+            assert(checker.checkString('var x = [ /*0,*/ 1 ];').isEmpty());
+        });
+
+        it('should report missing space before and after comments', function() {
+            assert(checker.checkString('var x = [/*0,*/ 1 /*,2*/];').getErrorCount() === 2);
+        });
+
+        it('should not report with space before comment', function() {
+            assert(checker.checkString('var x = [ /*0,*/ 1 /*,2*/ ];;').isEmpty());
+        });
+
+    });
 });


### PR DESCRIPTION
disallowSpaceBeforeBinaryOperators should include comments in the token list. This was found when using the autofixer with the mdcs prset against the three.js library.