### PR TITLE
token-assert:Make sure newlines get fixed

### DIFF
--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -185,18 +185,18 @@ TokenAssert.prototype.linesBetween = function(options) {
     }).bind(this);
 
     if (atLeast !== undefined && linesBetween < atLeast) {
-        whitespaceBefore = new Array(atLeast).join('\n');
-        emitError('at least ' + atLeast);
+        whitespaceBefore = new Array(atLeast + 1).join('\n');
+        emitError('at least ' + atLeast, whitespaceBefore);
     }
 
     if (atMost !== undefined && linesBetween > atMost) {
-        whitespaceBefore = new Array(atMost).join('\n');
-        emitError('at most ' + atMost);
+        whitespaceBefore = new Array(atMost + 1).join('\n');
+        emitError('at most ' + atMost, whitespaceBefore);
     }
 
     if (exactly !== undefined && linesBetween !== exactly) {
         if (exactly > 0) {
-            whitespaceBefore = new Array(exactly).join('\n');
+            whitespaceBefore = new Array(exactly + 1).join('\n');
         }
         emitError('exactly ' + exactly, whitespaceBefore);
     }

--- a/test/rules/require-padding-newlines-in-blocks.js
+++ b/test/rules/require-padding-newlines-in-blocks.js
@@ -90,4 +90,14 @@ describe('rules/require-padding-newlines-in-blocks', function() {
             assert(checker.checkString('var a = function() {abc();};').isEmpty());
         });
     });
+
+    describe('option value 1', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: true });
+        });
+
+        it('should report missing padding newline after opening brace', function() {
+            assert(checker.fixString('if (true) {abc();abc();\n\n}').errors.isEmpty());
+        });
+    });
 });

--- a/test/token-assert.js
+++ b/test/token-assert.js
@@ -564,6 +564,38 @@ describe('modules/token-assert', function() {
 
                 assert(!onError.called);
             });
+
+            it('should edit the whitespaceBefore', function() {
+                var file = createJsFile('x\n=y;');
+
+                var tokenAssert = new TokenAssert(file);
+                tokenAssert.on('error', function() {});
+
+                var tokens = file.getTokens();
+                tokenAssert.linesBetween({
+                    token: tokens[0],
+                    nextToken: tokens[1],
+                    atLeast: 2
+                });
+
+                assert(tokens[1].whitespaceBefore.length = 2);
+            });
+
+            it('should edit the whitespaceBefore', function() {
+                var file = createJsFile('x\n\n\n=y;');
+
+                var tokenAssert = new TokenAssert(file);
+                tokenAssert.on('error', function() {});
+
+                var tokens = file.getTokens();
+                tokenAssert.linesBetween({
+                    token: tokens[0],
+                    nextToken: tokens[1],
+                    atLeast: 2
+                });
+
+                assert(tokens[1].whitespaceBefore.length = 2);
+            });
         });
 
         describe('atLeast', function() {
@@ -619,6 +651,22 @@ describe('modules/token-assert', function() {
 
                 assert(!onError.called);
             });
+
+            it('should edit the whitespaceBefore', function() {
+                var file = createJsFile('x\n=y;');
+
+                var tokenAssert = new TokenAssert(file);
+                tokenAssert.on('error', function() {});
+
+                var tokens = file.getTokens();
+                tokenAssert.linesBetween({
+                    token: tokens[0],
+                    nextToken: tokens[1],
+                    atLeast: 2
+                });
+
+                assert(tokens[1].whitespaceBefore.length >= 2);
+            });
         });
 
         describe('atMost', function() {
@@ -673,6 +721,22 @@ describe('modules/token-assert', function() {
                 assert(onError.calledOnce);
                 var error = onError.getCall(0).args[0];
                 assert.equal(error.message, 'x and = should have at most 1 line(s) between them');
+            });
+
+            it('should edit the whitespaceBefore', function() {
+                var file = createJsFile('x\n\n\n=y;');
+
+                var tokenAssert = new TokenAssert(file);
+                tokenAssert.on('error', function() {});
+
+                var tokens = file.getTokens();
+                tokenAssert.linesBetween({
+                    token: tokens[0],
+                    nextToken: tokens[1],
+                    atMost: 1
+                });
+
+                assert(tokens[1].whitespaceBefore.length <= 1);
             });
         });
 


### PR DESCRIPTION
The new lines rules should now be able to get fixed too.