### PR TITLE
Don't trim whitespace in markdown-files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 4
 
 [package.json]
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Trailing whitespace is a linebreaks in MD, so shouldn't be stripped by accident