### PR TITLE
(disallow/require)PaddingNewLinesAfterBlocks: Ignoring the end of files

### DIFF
--- a/lib/rules/disallow-padding-newlines-after-blocks.js
+++ b/lib/rules/disallow-padding-newlines-after-blocks.js
@@ -83,7 +83,7 @@ module.exports.prototype = {
             var closingBracket = file.getLastNodeToken(node);
             var nextToken = file.getNextToken(closingBracket);
 
-            while (nextToken !== undefined) {
+            while (nextToken.type !== 'EOF') {
                 if (closingBracket.loc.end.line === nextToken.loc.start.line) {
                     nextToken = file.getNextToken(nextToken);
                     continue;

--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -94,7 +94,7 @@ module.exports.prototype = {
 
             var nextToken = file.getNextToken(closingBracket);
 
-            while (nextToken !== undefined) {
+            while (nextToken.type !== 'EOF') {
                 var excludeValues = excludes[parentNode.type];
                 if (excludeValues && excludeValues.indexOf(nextToken.value) !== -1) {
                     return;

--- a/test/rules/disallow-padding-newlines-after-blocks.js
+++ b/test/rules/disallow-padding-newlines-after-blocks.js
@@ -30,6 +30,10 @@ describe('rules/disallow-padding-newlines-after-blocks', function() {
         assert(checker.checkString('if(true){}').isEmpty());
     });
 
+    it('should not report end of file with extra line', function() {
+        assert(checker.checkString('if(true){}\n').isEmpty());
+    });
+
     it('should not report missing padding after block', function() {
         assert(checker.checkString('if(true){}\nvar a = 2;').isEmpty());
     });

--- a/test/rules/require-padding-newlines-after-blocks.js
+++ b/test/rules/require-padding-newlines-after-blocks.js
@@ -30,6 +30,10 @@ describe('rules/require-padding-newlines-after-blocks', function() {
         assert(checker.checkString('if(true){}').isEmpty());
     });
 
+    it('should not report end of file with empty line', function() {
+        assert(checker.checkString('if(true){}\n').isEmpty());
+    });
+
     it('should not report padding after block', function() {
         assert(checker.checkString('if(true){}\n\nvar a = 2;').isEmpty());
     });


### PR DESCRIPTION
Fixing an error since we are now adding the EOF token into the mix.