### PR TITLE
Fixes for requirePaddingNewLinesBeforeLineComments (consecutive and in blocks)

### DIFF
--- a/lib/rules/require-padding-newlines-before-line-comments.js
+++ b/lib/rules/require-padding-newlines-before-line-comments.js
@@ -3,21 +3,42 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Values:
+ * - `true`: always require a newline before line comments
+ * - `Object`:
+ *      - `"allExcept"`: `"firstInBlock"` Comments may be first line of block without extra padding
  *
- * #### Example
- *
+ * #### Examples
  * ```js
  * "requirePaddingNewLinesBeforeLineComments": true
+ * "requirePaddingNewLinesBeforeLineComments": { "allExcept": "firstInBlock" }
  * ```
  *
- * ##### Valid
+ * ##### Valid for `true`
  *
  * ```js
  * var a = 2;
  *
  * // comment
  * return a;
+ *
+ * function() {
+ *
+ *   // comment
+ * }
+ * ```
+ *
+ * ##### Valid for `{ "allExcept": "firstInBlock" }`
+ *
+ * ```js
+ * var a = 2;
+ *
+ * // comment
+ * return a;
+ *
+ * function() {
+ *   // comment
+ * }
  * ```
  *
  * ##### Invalid
@@ -26,6 +47,10 @@
  * var a = 2;
  * //comment
  * return a;
+ *
+ * function() {
+ *   // comment
+ * }
  * ```
  */
 
@@ -36,10 +61,18 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(value) {
-        assert(
-            value === true,
-            'requirePaddingNewLinesBeforeLineComments option requires true value or should be removed'
-        );
+        this._allowFirstInBlock = false;
+
+        if (typeof value === 'object') {
+            assert(typeof value.allExcept === 'string' && value.allExcept === 'firstInBlock',
+                'requirePaddingNewLinesBeforeLineComments option requires the "allExcept" ' +
+                 'property to equal "firstInBlock"');
+            this._allowFirstInBlock = true;
+        } else {
+            assert(value === true,
+                'requirePaddingNewLinesBeforeLineComments option requires true value or object'
+            );
+        }
     },
 
     getOptionName: function() {
@@ -47,13 +80,27 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var allowFirstInBlock = this._allowFirstInBlock;
+
         file.iterateTokensByType('Line', function(comment) {
             if (comment.loc.start.line === 1) {
                 return;
             }
 
+            var prevToken = file.getPrevToken(comment, {
+                includeComments: true
+            });
+
+            if (prevToken.type === 'Line') {
+                return;
+            }
+
+            if (allowFirstInBlock && prevToken.type === 'Punctuator' && prevToken.value === '{') {
+                return;
+            }
+
             errors.assert.linesBetween({
-                token: file.getPrevToken(comment, {includeComments: true}),
+                token: prevToken,
                 nextToken: comment,
                 atLeast: 2,
                 message: 'Line comments must be preceded with a blank line'

--- a/test/rules/require-padding-newlines-before-line-comments.js
+++ b/test/rules/require-padding-newlines-before-line-comments.js
@@ -7,34 +7,97 @@ describe('rules/require-padding-newlines-before-line-comments', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requirePaddingNewLinesBeforeLineComments: true });
     });
 
-    it('should report missing padding before line comment', function() {
-        assert(checker.checkString('var a = 2;\n// comment').getErrorCount() === 1);
+    describe('invalid options', function() {
+        it('should throw if false', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewLinesBeforeLineComments: false });
+            });
+        });
+
+        it('should throw if array', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewLinesBeforeLineComments: [] });
+            });
+        });
+
+        it('should throw if empty object', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewLinesBeforeLineComments: {} });
+            });
+        });
+
+        it('should throw if not allExcept object', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewLinesBeforeLineComments: { allBut: false} });
+            });
+        });
+
+        it('should throw if not allExcept firstInBlock', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewLinesBeforeLineComments: { allExcept: 'firstBlock'} });
+            });
+        });
     });
 
-    it('should report line comment after block comment', function() {
-        assert(checker.checkString('var a = 2;\n/* comment */\n// comment').getErrorCount() === 1);
+    describe('value true', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewLinesBeforeLineComments: true });
+        });
+
+        it('should report missing padding before line comment', function() {
+            assert(checker.checkString('var a = 2;\n// comment').getErrorCount() === 1);
+        });
+
+        it('should report line comment after block comment', function() {
+            assert(checker.checkString('var a = 2;\n/* comment */\n// comment').getErrorCount() === 1);
+        });
+
+        it('should not report multiple line comments', function() {
+            assert(checker.checkString('// comment\n//foo').isEmpty());
+        });
+
+        it('should report one error if multiple comments dont have line space', function() {
+            assert(checker.checkString('var a = 2;\n// comment\n// comment').getErrorCount() === 1);
+        });
+
+        it('should not report missing padding if comment is first line', function() {
+            assert(checker.checkString('// comment\nvar a = 2;').isEmpty());
+        });
+
+        it('should not report padding before line comment', function() {
+            assert(checker.checkString('var a = 2;\n\n// comment').isEmpty());
+        });
+
+        it('should not report additional padding before line comment', function() {
+            assert(checker.checkString('var a = 2;\n\n\n// comment').isEmpty());
+        });
+
+        it('should not report missing padding with block comment', function() {
+            assert(checker.checkString('var a = 2;\n/* comment */').isEmpty());
+        });
+
+        it('should not report line comment after block comment with padding', function() {
+            assert(checker.checkString('var a = 2;\n/* comment */\n\n// comment').isEmpty());
+        });
+
+        it('should report error if first line in block', function() {
+            assert(checker.checkString('if (true) {\n// comment\n}').getErrorCount() === 1);
+        });
     });
 
-    it('should not report missing padding if comment is first line', function() {
-        assert(checker.checkString('// comment\nvar a = 2;').isEmpty());
-    });
+    describe('value allExcept: firstInBlock', function() {
+        beforeEach(function() {
+            checker.configure({
+                requirePaddingNewLinesBeforeLineComments: {
+                    allExcept: 'firstInBlock'
+                }
+            });
+        });
 
-    it('should not report padding before line comment', function() {
-        assert(checker.checkString('var a = 2;\n\n// comment').isEmpty());
-    });
-
-    it('should not report additional padding before line comment', function() {
-        assert(checker.checkString('var a = 2;\n\n\n// comment').isEmpty());
-    });
-
-    it('should not report missing padding with block comment', function() {
-        assert(checker.checkString('var a = 2;\n/* comment */').isEmpty());
-    });
-
-    it('should not report line comment after block comment with padding', function() {
-        assert(checker.checkString('var a = 2;\n/* comment */\n\n// comment').isEmpty());
+        it('should not report error if first line in block', function() {
+            assert(checker.checkString('if (true) {\n// comment\n}').isEmpty());
+        });
     });
 });


### PR DESCRIPTION
requirePaddingNewLinesBeforeLineComments: Allowing multiple line comments together. Allowing no padding if first line in block.