### PR TITLE
Moves from the 'colors' package to 'chalk'.

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var path = require('path');
 
 var stripJSONComments = require('strip-json-comments');
-var supportsColor = require('supports-color');
+var supportsColor = require('chalk').supportsColor;
 var glob = require('glob');
 
 // Configuration sources in priority order.

--- a/lib/config/generator.js
+++ b/lib/config/generator.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var Vow = require('vow');
 var Table = require('cli-table');
 var prompt = require('prompt');
-var colors = require('colors');
+var chalk = require('chalk');
 var assign = require('lodash.assign');
 
 var Checker = require('../checker');
@@ -21,7 +21,7 @@ prompt.start();
  */
 var prompts = [
     {
-        name: colors.green('Please choose a preset number:'),
+        name: chalk.green('Please choose a preset number:'),
         require: true,
         pattern: /\d+/
     },
@@ -209,7 +209,7 @@ function getChecker() {
 function generateRuleHandlingPrompts(violatedRuleNames) {
     return violatedRuleNames.map(function(ruleName) {
         var prompt = assign({}, prompts[1]);
-        prompt.name = colors.green(ruleName) + ': ' + prompt.name;
+        prompt.name = chalk.green(ruleName) + ': ' + prompt.name;
         return prompt;
     });
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var colors = require('colors');
+var chalk = require('chalk');
 var TokenAssert = require('./token-assert');
 
 /**
@@ -175,9 +175,9 @@ Errors.prototype = {
  * @returns {String}
  */
 function formatErrorMessage(message, filename, colorize) {
-    return (colorize ? colors.bold(message) : message) +
+    return (colorize ? chalk.bold(message) : message) +
         ' at ' +
-        (colorize ? colors.green(filename) : filename) + ' :';
+        (colorize ? chalk.green(filename) : filename) + ' :';
 }
 
 /**
@@ -209,7 +209,7 @@ function renderLine(n, line, colorize) {
 
     // "n + 1" to print lines in human way (counted from 1)
     var lineNumber = prependSpaces((n + 1).toString(), 5) + ' |';
-    return ' ' + (colorize ? colors.grey(lineNumber) : lineNumber) + line;
+    return ' ' + (colorize ? chalk.grey(lineNumber) : lineNumber) + line;
 }
 
 /**
@@ -222,7 +222,7 @@ function renderLine(n, line, colorize) {
  */
 function renderPointer(column, colorize) {
     var res = (new Array(column + 9)).join('-') + '^';
-    return colorize ? colors.grey(res) : res;
+    return colorize ? chalk.grey(res) : res;
 }
 
 module.exports = Errors;

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "minimatch": "~2.0.1",
     "prompt": "~0.2.14",
     "strip-json-comments": "~1.0.2",
-    "supports-color": "~1.2.0",
     "vow": "~0.4.8",
     "vow-fs": "~0.3.4",
     "xmlbuilder": "~2.5.0"

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "chalk": "~1.0.0",
     "cli-table": "~0.3.1",
-    "colors": "~1.0.3",
     "commander": "~2.6.0",
     "esprima": "~1.2.4",
     "esprima-harmony-jscs": "1.1.0-tolerate-import",


### PR DESCRIPTION
See discussion in: #275

Contains:
- b50244f Removes dependency on 'supports-color', now covered by 'chalk'.
- 9c7c8c2 Replaces the 'colors' package with 'chalk'.