### PR TITLE
Extend estraverse rules to support XJS and JSX

### DIFF
--- a/lib/tree-iterator.js
+++ b/lib/tree-iterator.js
@@ -32,6 +32,17 @@ function iterate(node, cb) {
                 }
             },
             keys: {
+                JSXIdentifier: [],
+                JSXNamespacedName: ['namespace', 'name'],
+                JSXMemberExpression: ['object', 'property'],
+                JSXEmptyExpression: [],
+                JSXExpressionContainer: ['expression'],
+                JSXElement: ['openingElement', 'closingElement', 'children'],
+                JSXClosingElement: ['name'],
+                JSXOpeningElement: ['name', 'attributes'],
+                JSXAttribute: ['name', 'value'],
+                JSXSpreadAttribute: ['argument'],
+                JSXText: null,
                 XJSIdentifier: [],
                 XJSNamespacedName: ['namespace', 'name'],
                 XJSMemberExpression: ['object', 'property'],

--- a/test/data/tree-iterator/xjs-ast.js
+++ b/test/data/tree-iterator/xjs-ast.js
@@ -10,19 +10,19 @@ module.exports = {
     {
       "type":"ExpressionStatement",
       "expression":{
-        "type":"JSXElement",
+        "type":"XJSElement",
         "openingElement":{
-          "type":"JSXOpeningElement",
+          "type":"XJSOpeningElement",
           "name":{
-            "type":"JSXIdentifier",
+            "type":"XJSIdentifier",
             "name":"div"
           },
           "selfClosing":false,
           "attributes":[
             {
-              "type":"JSXAttribute",
+              "type":"XJSAttribute",
               "name":{
-                "type":"JSXIdentifier",
+                "type":"XJSIdentifier",
                 "name":"id"
               },
               "value":{
@@ -32,9 +32,9 @@ module.exports = {
               }
             },
             {
-              "type":"JSXAttribute",
+              "type":"XJSAttribute",
               "name":{
-                "type":"JSXIdentifier",
+                "type":"XJSIdentifier",
                 "name":"disabled"
               },
               "value":null
@@ -42,9 +42,9 @@ module.exports = {
           ]
         },
         "closingElement":{
-          "type":"JSXClosingElement",
+          "type":"XJSClosingElement",
           "name":{
-            "type":"JSXIdentifier",
+            "type":"XJSIdentifier",
             "name":"div"
           }
         },
@@ -55,24 +55,24 @@ module.exports = {
             "raw":"\n"
           },
           {
-            "type":"JSXElement",
+            "type":"XJSElement",
             "openingElement":{
-              "type":"JSXOpeningElement",
+              "type":"XJSOpeningElement",
               "name":{
-                "type":"JSXNamespacedName",
+                "type":"XJSNamespacedName",
                 "namespace":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Component"
                 },
                 "name":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Test"
                 }
               },
               "selfClosing":false,
               "attributes":[
                 {
-                  "type":"JSXSpreadAttribute",
+                  "type":"XJSSpreadAttribute",
                   "argument":{
                     "type":"Identifier",
                     "name":"x"
@@ -81,22 +81,22 @@ module.exports = {
               ]
             },
             "closingElement":{
-              "type":"JSXClosingElement",
+              "type":"XJSClosingElement",
               "name":{
-                "type":"JSXNamespacedName",
+                "type":"XJSNamespacedName",
                 "namespace":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Component"
                 },
                 "name":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Test"
                 }
               }
             },
             "children":[
               {
-                "type":"JSXExpressionContainer",
+                "type":"XJSExpressionContainer",
                 "expression":{
                   "type":"MemberExpression",
                   "computed":false,
@@ -120,17 +120,17 @@ module.exports = {
             ]
           },
           {
-            "type":"JSXElement",
+            "type":"XJSElement",
             "openingElement":{
-              "type":"JSXOpeningElement",
+              "type":"XJSOpeningElement",
               "name":{
-                "type":"JSXMemberExpression",
+                "type":"XJSMemberExpression",
                 "object":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Component"
                 },
                 "property":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Test"
                 }
               },
@@ -140,24 +140,24 @@ module.exports = {
               ]
             },
             "closingElement":{
-              "type":"JSXClosingElement",
+              "type":"XJSClosingElement",
               "name":{
-                "type":"JSXMemberExpression",
+                "type":"XJSMemberExpression",
                 "object":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Component"
                 },
                 "property":{
-                  "type":"JSXIdentifier",
+                  "type":"XJSIdentifier",
                   "name":"Test"
                 }
               }
             },
             "children":[
               {
-                "type":"JSXExpressionContainer",
+                "type":"XJSExpressionContainer",
                 "expression":{
-                  "type":"JSXEmptyExpression"
+                  "type":"XJSEmptyExpression"
                 }
               }
             ]

--- a/test/tree-iterator.js
+++ b/test/tree-iterator.js
@@ -21,12 +21,15 @@ describe('modules/tree-iterator', function() {
         assert.equal(spy.callCount, 0);
     });
 
-    it('should not fail for XJS nodes', function() {
+    it('should not fail for JSX/XJS nodes', function() {
         var spy = sinon.spy();
         assert.doesNotThrow(function() {
             iterate(require('./data/tree-iterator/jsx-ast'), spy);
         });
-        assert.equal(spy.callCount, 42);
+        assert.doesNotThrow(function() {
+            iterate(require('./data/tree-iterator/xjs-ast'), spy);
+        });
+        assert.equal(spy.callCount, 84);
     });
 
     it('should exit thread on false result', function() {


### PR DESCRIPTION
Fixes #1131
Closes gh-1132

Appends the new keys in `lib/tree-iterator.js`.
Not sure if we want to do it this way - I just added another data file and am testing both files - XJS and JSX.