### PR TITLE
New rule: requireEmptyLineAfterVariableDeclaration

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -670,6 +670,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-capitalized-comments'));
 
     this.registerRule(require('../rules/require-line-break-after-variable-assignment'));
+    this.registerRule(require('../rules/require-empty-line-after-variable-declaration'));
 
     this.registerRule(require('../rules/disallow-semicolons'));
 

--- a/lib/rules/require-empty-line-after-variable-declaration.js
+++ b/lib/rules/require-empty-line-after-variable-declaration.js
@@ -1,0 +1,73 @@
+/**
+ * Requires an extra blank newline after var declarations, as long
+ * as it is not the last expression in the current block.
+ *
+ * Type: `Boolean`
+ *
+ * Values: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireEmptyLineAfterVariableDeclaration": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var x = {
+ *     a: 1
+ * };
+ *
+ * foo({
+ *     a: {
+ *         b: 1
+ *     }
+ * });
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var x = { a: 1 };
+ * foo({a:{b:1}});
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(requireEmptyLineAfterVariableDeclaration) {
+        assert(
+            requireEmptyLineAfterVariableDeclaration === true,
+            'requireEmptyLineAfterVariableDeclaration option requires true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireEmptyLineAfterVariableDeclaration';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('VariableDeclaration', function(node) {
+            var endOfDeclaration = file.findNextToken(file.getFirstNodeToken(node), 'Punctuator', ';');
+            var nextToken = file.getNextToken(endOfDeclaration);
+
+            if ((nextToken.type === 'Keyword' && nextToken.value === 'var') ||
+                (nextToken.type === 'Punctuator' && nextToken.value === '}') ||
+                nextToken.type === 'EOF') {
+                return;
+            }
+
+            errors.assert.linesBetween({
+                atLeast: 2,
+                token: endOfDeclaration,
+                nextToken: nextToken
+            });
+        });
+    }
+
+};

--- a/test/rules/require-empty-line-after-variable-declaration.js
+++ b/test/rules/require-empty-line-after-variable-declaration.js
@@ -1,0 +1,35 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-empty-line-after-variable-declaration', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requireEmptyLineAfterVariableDeclaration: true });
+    });
+
+    it('should not report if an extra newline is present after var declaration', function() {
+        assert(checker.checkString('var a = 1;\n\nconsole.log(a);').isEmpty());
+        assert(checker.checkString('function a() { var a = 1;\n\nconsole.log(a); }').isEmpty());
+        assert(checker.checkString('var b = 2;\n\nfunction a() { var a = 1;\n\nconsole.log(a); }').isEmpty());
+        assert(checker.checkString(
+            'var b = 2;\n\nfunction a() { var a = 1;\n\nconsole.log(a); } var c = 3;'
+        ).isEmpty());
+    });
+
+    it('should not report for consecutive var declarations', function() {
+        assert(checker.checkString('var a = 1; var b = 2; var c = 3;').isEmpty());
+    });
+
+    it('should not report if var is the last expression in the block', function() {
+        assert(checker.checkString('function a() { var x; }').isEmpty());
+    });
+
+    it('should report if no extra newline is present after var declaration', function() {
+        assert(checker.checkString('var x; console.log(x);').getErrorCount() === 1);
+        assert(checker.checkString('function a() { var x; console.log(x); }').getErrorCount() === 1);
+        assert(checker.checkString('var y; function a() { var x; console.log(x); }').getErrorCount() === 2);
+    });
+});


### PR DESCRIPTION
This check enforces a blank line of breathing room between `var` declarations
and any non-`var` following content in the same block. This is conceptually
similar to `requireLineBreakAfterVariableAssignment`, but enforces
more aggressive minimum whitespace.

Closes gh-1107
Fixes #1107