### PR TITLE
New rule: disallowSwitchCaseIndentation

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -529,7 +529,7 @@ Configuration.prototype.hasPreset = function(presetName) {
 };
 
 /**
- * Registers built-in Code Style cheking rules.
+ * Registers built-in Code Style checking rules.
  */
 Configuration.prototype.registerDefaultRules = function() {
 
@@ -676,6 +676,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/require-spaces-in-for-statement'));
     this.registerRule(require('../rules/disallow-spaces-in-for-statement'));
     this.registerRule(require('../rules/disallow-keywords-in-comments'));
+
+    this.registerRule(require('../rules/disallow-switch-case-indentation'));
 };
 
 /**

--- a/lib/rules/disallow-switch-case-indentation.js
+++ b/lib/rules/disallow-switch-case-indentation.js
@@ -1,0 +1,94 @@
+/**
+ * Requires `case` statements to begin at the same "column" as their
+ * corresponding `switch` block.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowSwitchCaseIndentation": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * switch (x) {
+ * case "a":
+ *     break;
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * switch (x) {
+ *     case "a":
+ *         break;
+ * }
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(disallowSwitchCaseIndentation) {
+        assert(
+            disallowSwitchCaseIndentation === true,
+            'disallowSwitchCaseIndentation should be `true` or not set'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowSwitchCaseIndentation';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('SwitchStatement', function(currentNode, index, nodes) {
+            var startSwitch = file.getFirstNodeToken(currentNode);
+            var endSwitch = file.getLastNodeToken(currentNode);
+
+            var tokens = file.getTokens().slice(0);
+
+            // We only care about the case tokens at the current switch level, since the user
+            // could potentially have nested switches and the next loop iteration(s) will deal
+            // with them separately
+
+            nodes
+                .filter(function(otherNodes) {
+                    return otherNodes !== currentNode;
+                })
+                .forEach(function(other) {
+                    // To accomplish this, we splice out the token ranges of
+                    // all other switch nodes
+                    var startOther = file.getFirstNodeToken(other);
+                    var endOther = file.getLastNodeToken(other);
+
+                    tokens.splice(tokens.indexOf(startOther), tokens.indexOf(endOther));
+                });
+
+            // Now that the token array is pared down, we grab only the range of the current switch
+            // and get to steppin'
+            tokens
+                .slice(tokens.indexOf(startSwitch), tokens.indexOf(endSwitch))
+                .filter(function(token) {
+                    return token.type === 'Keyword' && token.value === 'case';
+                })
+                .forEach(function(token) {
+                    // ignores the *unlikely* single line edge case
+                    if (token.loc.start.line !== startSwitch.loc.start.line) {
+                        errors.assert.indentation({
+                            lineNumber: token.loc.start.line,
+                            actual: token.loc.start.column,
+                            expected: startSwitch.loc.start.column
+                        });
+                    }
+                });
+        });
+    }
+};

--- a/presets/crockford.json
+++ b/presets/crockford.json
@@ -63,5 +63,6 @@
     "requireDotNotation": true,
     "disallowNewlineBeforeBlockStatements": true,
     "disallowMultipleLineStrings": true,
-    "requireSpaceBeforeObjectValues": true
+    "requireSpaceBeforeObjectValues": true,
+    "disallowSwitchCaseIndentation": true
 }

--- a/test/rules/disallow-switch-case-indentation.js
+++ b/test/rules/disallow-switch-case-indentation.js
@@ -1,0 +1,45 @@
+var Checker = require('../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-switch-case-indentation', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowSwitchCaseIndentation: true });
+    });
+
+    it('should report if the `case` indentation does not match `switch`', function() {
+        assert(checker.checkString('switch (x) {\n case "1": break;\n}').getErrorCount() === 1);
+        assert(checker.checkString('switch (x) {\n case "1": break; case "2": break;\n}').getErrorCount() === 2);
+    });
+
+    it('should report for a nested switch with incorrect indentation', function() {
+        assert(checker.checkString(
+            'switch (x) {\ncase "1":\n switch (y) {\ncase "1": break;\n }\nbreak;\n}'
+        ).isEmpty());
+    });
+
+    it('should not report if the `case` indentation matches `switch`', function() {
+        assert(checker.checkString('switch (x) {\ncase "1": break;\n}').isEmpty());
+        assert(checker.checkString('switch (x) {\ncase "1": break;\ncase "2": break;\n}').isEmpty());
+    });
+
+    it('should not report if the `case` is on the same line as `switch`', function() {
+        assert(checker.checkString('switch (x) { case "1": break; }').isEmpty());
+        assert(checker.checkString('switch (x) {case "1": break; case "2": break;}').isEmpty());
+    });
+
+    it('should not report for multiple switches at different indentation levels', function() {
+        assert(checker.checkString(
+            'switch (x) {\ncase "1": break;\n}\n switch (y) {\n case "1": break;\n }'
+        ).isEmpty());
+    });
+
+    it('should not report for a nested switch with correct indentation', function() {
+        assert(checker.checkString(
+            'switch (x) {\ncase "1":\n switch (y) {\n case "1": break;\n }\nbreak;\n}'
+        ).isEmpty());
+    });
+});


### PR DESCRIPTION
As is the requirement in Crockford style, this rule enforces that direct-child
case statements within a switch block must not be indented or have a different
starting column than their parent switch. This is enforced on a per-switch basis,
so a switch nested inside another could itself be indented with the former's cases
having to be at the same indentation level.

Closes gh-1111
Fixes #1111