### PR TITLE
ValidateIndentation: Adding a broken test for functions as an argument

### DIFF
--- a/test/specs/rules/validate-indentation.js
+++ b/test/specs/rules/validate-indentation.js
@@ -233,6 +233,13 @@ describe('rules/validate-indentation', function() {
             '});';
             assert(!checker.checkString(source).isEmpty());
         });
+
+        it('should report function in argument with invalid indentation', function() {
+            var source = '    fn("foo", function() {\n' +
+                        '    a();\n' +
+                        '});';
+            assert(!checker.checkString(source).isEmpty());
+        });
     });
 
     describe('fixing', function() {


### PR DESCRIPTION
@mikesherov While running my autoformatting plugin, this is the main issue I ran into.

This passes:
```javascript
    fn("foo", function() {
    a();
});
```

But should fail and require:

```javascript
    fn("foo", function() {
        a();
    });
```

This is also an issue with arrays. This shouldn't be valid:
```javascript
        var files = [
    'foo',
    'bar',
    'baz'
];
```

I guessed as to where to put the test, let me know if it should be somewhere else. It's also possible that this is supposed to be covered by some rule other than validateIndentation.