### PR TITLE
Presets: Add validate indentation rule for Yandex

### DIFF
--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -95,5 +95,6 @@
     "disallowMultipleLineBreaks": true,
     "disallowMixedSpacesAndTabs": true,
     "disallowTrailingWhitespace": true,
+    "validateIndentation": 4,
     "validateLineBreaks": "LF"
 }

--- a/test/data/options/preset/yandex.js
+++ b/test/data/options/preset/yandex.js
@@ -95,6 +95,7 @@ switch (value) {
     default:
         // ...
         // no break keyword on the last case
+        doSomething();
 }
 
 // Ternary operators.


### PR DESCRIPTION
The Yandex guide specifies 4 spaces for indentation, but the
`validateIndentation` rule isn't listed in the preset.

I had to add a function call to the default switch path in order for
the tests to pass. Not sure if this is caused by a bug in node-jscs
or not.