### PR TITLE
requireLineBreakAfterVariableAssignment: allow exception for init part o...

### DIFF
--- a/lib/rules/require-line-break-after-variable-assignment.js
+++ b/lib/rules/require-line-break-after-variable-assignment.js
@@ -61,6 +61,12 @@ module.exports.prototype = {
     check: function(file, errors) {
         var lastDeclaration;
         file.iterateNodesByType('VariableDeclaration', function(node) {
+            if (node.parentNode.type === 'ForStatement' ||
+                node.parentNode.type === 'ForInStatement' ||
+                node.parentNode.type === 'ForOfStatement') {
+                return;
+            }
+
             for (var i = 0; i < node.declarations.length; i++) {
                 var thisDeclaration = node.declarations[i];
                 if (thisDeclaration.parentNode.kind === 'var') {

--- a/test/specs/rules/require-line-break-after-variable-assignment.js
+++ b/test/specs/rules/require-line-break-after-variable-assignment.js
@@ -40,5 +40,26 @@ describe('rules/require-line-break-after-variable-assignment', function() {
         it('should report when multiple var statements on single line.', function() {
             assert(checker.checkString('var bad = {\n\tkey : value\n}; var heckWhyNot = 5;').getErrorCount() === 1);
         });
+
+        it('should not report when variables are defined in the init part of a for loop', function() {
+            assert(checker.checkString('for (var i = 0, length = myArray.length; i < length; i++) {}').isEmpty());
+        });
+
+        it('should not report when variables are defined in the init part of a for in loop', function() {
+            assert(checker.checkString('for (var i in arr) {}').isEmpty());
+        });
+
+        it('should not report when variables are defined in the init part of a for of loop', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('for (var i of arr) {}').isEmpty());
+        });
+
+        it('should report for variables defined in the body of a for loop', function() {
+            assert(checker.checkString(
+                'for (var i = 0, length = myArray.length; i < length; i++) {' +
+                    'var x = 1, y = 2;' +
+                '}'
+            ).getErrorCount() === 1);
+        });
     });
 });


### PR DESCRIPTION
...f for loop

Fixes #1157.

Returns if `node.parentNode.type === 'ForStatement'`