### PR TITLE
(require|disallow)SpacesInsideArrayBrackets: use includeComments in toke...

### DIFF
--- a/lib/rules/disallow-spaces-inside-array-brackets.js
+++ b/lib/rules/disallow-spaces-inside-array-brackets.js
@@ -96,9 +96,9 @@ module.exports.prototype = {
 
         file.iterateNodesByType('ArrayExpression', function(node) {
             var openBracket = file.getFirstNodeToken(node);
-            var afterOpen = file.getNextToken(openBracket);
+            var afterOpen = file.getNextToken(openBracket, {includeComments: true});
             var closeBracket = file.getLastNodeToken(node);
-            var beforeClose = file.getPrevToken(closeBracket);
+            var beforeClose = file.getPrevToken(closeBracket, {includeComments: true});
 
             // Skip for empty array brackets
             if (afterOpen.value === ']') {

--- a/lib/rules/require-spaces-inside-array-brackets.js
+++ b/lib/rules/require-spaces-inside-array-brackets.js
@@ -95,9 +95,9 @@ module.exports.prototype = {
 
         file.iterateNodesByType('ArrayExpression', function(node) {
             var openBracket = file.getFirstNodeToken(node);
-            var afterOpen = file.getNextToken(openBracket);
+            var afterOpen = file.getNextToken(openBracket, {includeComments: true});
             var closeBracket = file.getLastNodeToken(node);
-            var beforeClose = file.getPrevToken(closeBracket);
+            var beforeClose = file.getPrevToken(closeBracket, {includeComments: true});
 
             // Skip for empty array brackets
             if (afterOpen.value === ']') {

--- a/test/specs/rules/disallow-spaces-inside-array-brackets.js
+++ b/test/specs/rules/disallow-spaces-inside-array-brackets.js
@@ -64,6 +64,18 @@ describe('rules/disallow-spaces-inside-array-brackets', function() {
                 ).isEmpty());
             });
         });
+
+        it('should not report with comments before the first element', function() {
+            assert(checker.checkString(
+                'var x = [/*A*/ 1, 2]'
+            ).isEmpty());
+        });
+
+        it('should not report with comments after the last element', function() {
+            assert(checker.checkString(
+                'var x = [1, 2, /*Z*/]'
+            ).isEmpty());
+        });
     });
 
     describe('"all"', function() {

--- a/test/specs/rules/require-spaces-inside-array-brackets.js
+++ b/test/specs/rules/require-spaces-inside-array-brackets.js
@@ -41,6 +41,18 @@ describe('rules/require-spaces-inside-array-brackets', function() {
         it('should report anything for empty array', function() {
             assert(checker.checkString('[];').isEmpty());
         });
+
+        it('should not report with comments before the first element', function() {
+            assert(checker.checkString(
+                'var x = [ /*A*/ 1, 2 ]'
+            ).isEmpty());
+        });
+
+        it('should not report with comments after the last element', function() {
+            assert(checker.checkString(
+                'var x = [ 1, 2, /*Z*/ ]'
+            ).isEmpty());
+        });
     });
 
     describe('"allButNested"', function() {


### PR DESCRIPTION
...n

Fixes #1161 

Might need to add to this PR for other rules that may want this as well, like the other requireSpacesInside* rules? (brackets, objects, parens)