### PR TITLE
requireCapitalizedComments: automatically except `jscs` comments

### DIFF
--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -94,7 +94,11 @@ module.exports = function() {};
 
 module.exports.prototype = {
     configure: function(options) {
-        this._exceptions = {};
+        // except comments that begin with `jscs`, since these are used to
+        // selectively enable/disable rules within a file
+        this._exceptions = {
+            'jscs': true
+        };
 
         var optionName = this.getOptionName();
 
@@ -117,13 +121,9 @@ module.exports.prototype = {
                 'Property `allExcept` in ' + optionName + ' should be an array of strings'
             );
 
-            this._hasExceptions = true;
-
             for (var i = 0, l = exceptions.length; i < l; i++) {
                 this._exceptions[exceptions[i]] = true;
             }
-        } else {
-            this._hasExceptions = false;
         }
     },
 
@@ -133,22 +133,18 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var inTextBlock = null;
-
         var exceptions = this._exceptions;
-        var hasExceptions = this._hasExceptions;
 
         var letterPattern = require('../../patterns/L');
         var upperCasePattern = require('../../patterns/Lu');
 
         file.iterateTokensByType(['Line', 'Block'], function(comment) {
-            if (hasExceptions) {
-                // strip leading whitespace and any asterisks
-                // split on whitespace and colons
-                var splitComment = comment.value.replace(/(^\s+|[\*])/g, '').split(/[\s\:]/g);
+            // strip leading whitespace and any asterisks
+            // split on whitespace and colons
+            var splitComment = comment.value.replace(/(^\s+|[\*])/g, '').split(/[\s\:]/g);
 
-                if (exceptions[splitComment[0]]) {
-                    return;
-                }
+            if (exceptions[splitComment[0]]) {
+                return;
             }
 
             var stripped = comment.value.replace(/[\n\s\*]/g, '');

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -52,6 +52,13 @@ describe('rules/require-capitalized-comments', function() {
             ].join('\n')).isEmpty());
         });
 
+        it('should not report on comments that disable or enable JSCS rules', function() {
+            assert(checker.checkString('//jscs:enable').isEmpty());
+            assert(checker.checkString('// jscs:disable').isEmpty());
+            assert(checker.checkString('/*jscs:enable rule*/').isEmpty());
+            assert(checker.checkString('/* jscs:disable rule*/').isEmpty());
+        });
+
         it('should not report on multiple uppercase lines in a "textblock"', function() {
             assertEmpty([
                 '// This is a textblock.',
@@ -116,8 +123,6 @@ describe('rules/require-capitalized-comments', function() {
 
         it('should report for other comment directives', function() {
             assert(checker.checkString('/* jshint: -W071 */').getErrorCount() === 1);
-
-            assert(checker.checkString('/* jscs:disable requireCurlyBraces */').getErrorCount() === 1);
         });
 
         it('should not report for custom exceptions', function() {


### PR DESCRIPTION
Comments beginning with `jscs` are used to selectively disable and enable rules within a file. This directive is case-sensitive and lowercase, so we except it from this rule.

Fixes #1168