### PR TITLE
Change 'Value' to 'Values' to be consistent

### DIFF
--- a/lib/rules/disallow-anonymous-functions.js
+++ b/lib/rules/disallow-anonymous-functions.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`laxcomma`](http://www.jshint.com/docs/options/#laxcomma)
  *

--- a/lib/rules/disallow-curly-braces.js
+++ b/lib/rules/disallow-curly-braces.js
@@ -1,7 +1,7 @@
 /**
  * Disallows curly braces after statements.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to disallow curly braces after the following keywords:
  *

--- a/lib/rules/disallow-dangling-underscores.js
+++ b/lib/rules/disallow-dangling-underscores.js
@@ -8,7 +8,7 @@
  *  - `super_` (node.js, used by
  *    [`util.inherits`](http://nodejs.org/docs/latest/api/util.html#util_util_inherits_constructor_superconstructor))
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values:
  *  - `true`

--- a/lib/rules/disallow-empty-blocks.js
+++ b/lib/rules/disallow-empty-blocks.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`noempty`](http://jshint.com/docs/options/#noempty)
  *

--- a/lib/rules/disallow-function-declarations.js
+++ b/lib/rules/disallow-function-declarations.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-keywords-in-comments.js
+++ b/lib/rules/disallow-keywords-in-comments.js
@@ -1,7 +1,7 @@
 /**
  * Disallows keywords in your comments, such as TODO or FIXME
  *
- * Type: `Boolean` or `String` or `Array`
+ * Types: `Boolean`, `String` or `Array`
  *
  * Values:
  * - `true`

--- a/lib/rules/disallow-mixed-spaces-and-tabs.js
+++ b/lib/rules/disallow-mixed-spaces-and-tabs.js
@@ -2,7 +2,7 @@
  * Requires lines to not contain both spaces and tabs consecutively,
  * or spaces after tabs only for alignment if "smart"
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values: `true` or `"smart"`
  *

--- a/lib/rules/disallow-multiple-line-breaks.js
+++ b/lib/rules/disallow-multiple-line-breaks.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-multiple-line-strings.js
+++ b/lib/rules/disallow-multiple-line-strings.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`multistr`](http://www.jshint.com/docs/options/#multistr)
  *

--- a/lib/rules/disallow-multiple-spaces.js
+++ b/lib/rules/disallow-multiple-spaces.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -1,7 +1,7 @@
 /**
  * Disallows multiple `var` declaration (except for-loop).
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values:
  *

--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-operator-before-line-break.js
+++ b/lib/rules/disallow-operator-before-line-break.js
@@ -1,7 +1,7 @@
 /**
  * Requires putting certain operators on the next line rather than on the current line before a line break.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of operators to apply to or `true`
  *

--- a/lib/rules/disallow-padding-newlines-after-blocks.js
+++ b/lib/rules/disallow-padding-newlines-after-blocks.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-padding-newlines-before-keywords.js
+++ b/lib/rules/disallow-padding-newlines-before-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Disallow an empty line above the specified keywords.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted types or `true` to disallow padding new lines after all of the keywords below.
  *

--- a/lib/rules/disallow-padding-newlines-before-line-comments.js
+++ b/lib/rules/disallow-padding-newlines-before-line-comments.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-padding-newlines-in-blocks.js
+++ b/lib/rules/disallow-padding-newlines-in-blocks.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true` validates all non-empty blocks.
+ * Value: `true` validates all non-empty blocks.
  *
  * #### Example
  *

--- a/lib/rules/disallow-padding-newlines-in-objects.js
+++ b/lib/rules/disallow-padding-newlines-in-objects.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-quoted-keys-in-objects.js
+++ b/lib/rules/disallow-quoted-keys-in-objects.js
@@ -1,7 +1,7 @@
 /**
  * Disallows quoted keys in object if possible.
  *
- * Type: `String` or `Boolean`
+ * Types: `String` or `Boolean`
  *
  * Values:
  *

--- a/lib/rules/disallow-space-after-binary-operators.js
+++ b/lib/rules/disallow-space-after-binary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Requires sticking binary operators to the right.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to disallow space after all possible binary operators
  *

--- a/lib/rules/disallow-space-after-keywords.js
+++ b/lib/rules/disallow-space-after-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after keyword.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to disallow spaces after all possible keywords.
  *

--- a/lib/rules/disallow-space-after-line-comment.js
+++ b/lib/rules/disallow-space-after-line-comment.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after object keys.
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values:
  *  - `true`

--- a/lib/rules/disallow-space-after-prefix-unary-operators.js
+++ b/lib/rules/disallow-space-after-prefix-unary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Requires sticking unary operators to the right.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to disallow space after prefix for all unary operators
  *

--- a/lib/rules/disallow-space-before-binary-operators.js
+++ b/lib/rules/disallow-space-before-binary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Requires sticking binary operators to the left.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to disallow space before all possible binary operators
  *

--- a/lib/rules/disallow-space-before-block-statements.js
+++ b/lib/rules/disallow-space-before-block-statements.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-space-before-keywords.js
+++ b/lib/rules/disallow-space-before-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space before keyword.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to disallow spaces before all possible keywords.
  *

--- a/lib/rules/disallow-space-before-object-values.js
+++ b/lib/rules/disallow-space-before-object-values.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-space-before-postfix-unary-operators.js
+++ b/lib/rules/disallow-space-before-postfix-unary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Requires sticking unary operators to the left.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to disallow space before postfix for all unary operators
  * (i.e. increment/decrement operators)

--- a/lib/rules/disallow-spaces-in-call-expression.js
+++ b/lib/rules/disallow-spaces-in-call-expression.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/disallow-spaces-in-conditional-expression.js
+++ b/lib/rules/disallow-spaces-in-conditional-expression.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space before and/or after `?` or `:` in conditional expressions.
  *
- * Type: `Object` or `Boolean`
+ * Types: `Object` or `Boolean`
  *
  * Values: `"afterTest"`, `"beforeConsequent"`, `"afterConsequent"`, `"beforeAlternate"` as child properties,
  * or `true` to set all properties to true. Child properties must be set to `true`. These token names correspond to:

--- a/lib/rules/disallow-spaces-in-for-statement.js
+++ b/lib/rules/disallow-spaces-in-for-statement.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true` to disallow spaces in between for statement.
+ * Value: `true` to disallow spaces in between for statement.
  *
  * #### Example
  *

--- a/lib/rules/disallow-spaces-inside-array-brackets.js
+++ b/lib/rules/disallow-spaces-inside-array-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after opening array square bracket and before closing.
  *
- * Type: `Boolean` or `String` or `Object`
+ * Types: `Boolean`, `String` or `Object`
  *
  * Values: `"all"` or `true` for strict mode, `"nested"` (*deprecated* use `"allExcept": [ "[", "]" ]`)
  * ignores closing brackets in a row.

--- a/lib/rules/disallow-spaces-inside-brackets.js
+++ b/lib/rules/disallow-spaces-inside-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after opening square bracket and before closing.
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values: `true` for strict mode, or `"allExcept": [ "[", "]" ]`
  * ignores closing brackets in a row.

--- a/lib/rules/disallow-spaces-inside-object-brackets.js
+++ b/lib/rules/disallow-spaces-inside-object-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after opening object curly brace and before closing.
  *
- * Type: `Object`, `Boolean` or `String`
+ * Types: `Object`, `Boolean` or `String`
  *
  * Values: `"all"` or `true` for strict mode, `"nested"` (*deprecated* use `"allExcept": ['}']`)
  * ignores closing brackets in a row.

--- a/lib/rules/disallow-spaces-inside-parentheses.js
+++ b/lib/rules/disallow-spaces-inside-parentheses.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after opening round bracket and before closing.
  *
- * Type: `Object` or `Boolean`
+ * Types: `Object` or `Boolean`
  *
  * Values: Either `true` or Object with `"only"` property as an array of tokens
  *

--- a/lib/rules/disallow-trailing-comma.js
+++ b/lib/rules/disallow-trailing-comma.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`es3`](http://jshint.com/docs/options/#es3)
  *

--- a/lib/rules/disallow-trailing-whitespace.js
+++ b/lib/rules/disallow-trailing-whitespace.js
@@ -1,7 +1,7 @@
 /**
  * Requires all lines to end on a non-whitespace character
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values:
  *  - `true`

--- a/lib/rules/disallow-yoda-conditions.js
+++ b/lib/rules/disallow-yoda-conditions.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -1,7 +1,7 @@
 /**
  * Requires all lines to be at most the number of characters specified
  *
- * Type: `Integer` or `Object`
+ * Types: `Integer` or `Object`
  *
  * Values:
  *  - `Integer`: lines should be at most the number of characters specified

--- a/lib/rules/require-anonymous-functions.js
+++ b/lib/rules/require-anonymous-functions.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-blocks-on-newline.js
+++ b/lib/rules/require-blocks-on-newline.js
@@ -1,7 +1,7 @@
 /**
  * Requires blocks to begin and end with a newline
  *
- * Type: `Boolean` or `Integer`
+ * Types: `Boolean` or `Integer`
  *
  * Values: `true` validates all non-empty blocks,
  * `Integer` specifies a minimum number of statements in the block before validating.

--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -1,7 +1,7 @@
 /**
  * Requires identifiers to be camelCased or UPPERCASE_WITH_UNDERSCORES
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values: `true` or `"ignoreProperties"`
  *

--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -3,7 +3,7 @@
  *
  * By default, the prefix for inline comments `jscs` is ignored.
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values:
  *  - `true`

--- a/lib/rules/require-capitalized-constructors.js
+++ b/lib/rules/require-capitalized-constructors.js
@@ -1,7 +1,7 @@
 /**
  * Requires constructors to be capitalized (except for `this`)
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values: `true` or Object with `allExcept` Array of quoted identifiers which are exempted
  *

--- a/lib/rules/require-comma-before-line-break.js
+++ b/lib/rules/require-comma-before-line-break.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`laxcomma`](http://www.jshint.com/docs/options/#laxcomma)
  *

--- a/lib/rules/require-curly-braces.js
+++ b/lib/rules/require-curly-braces.js
@@ -1,7 +1,7 @@
 /**
  * Requires curly braces after statements.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to require curly braces after the following keywords:
  *

--- a/lib/rules/require-dollar-before-jquery-assignment.js
+++ b/lib/rules/require-dollar-before-jquery-assignment.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  *
  * #### Example

--- a/lib/rules/require-dot-notation.js
+++ b/lib/rules/require-dot-notation.js
@@ -1,7 +1,7 @@
 /**
  * Requires member expressions to use dot notation when possible
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values:
  *  - `true`

--- a/lib/rules/require-function-declarations.js
+++ b/lib/rules/require-function-declarations.js
@@ -8,7 +8,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-line-break-after-variable-assignment.js
+++ b/lib/rules/require-line-break-after-variable-assignment.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-line-feed-at-file-end.js
+++ b/lib/rules/require-line-feed-at-file-end.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-multiple-var-decl.js
+++ b/lib/rules/require-multiple-var-decl.js
@@ -1,7 +1,7 @@
 /**
  * Requires multiple `var` declaration.
  *
- * Type: `Boolean` or `String`
+ * Types: `Boolean` or `String`
  *
  * Values: `true` or `"onevar"`
  *

--- a/lib/rules/require-newline-before-block-statements.js
+++ b/lib/rules/require-newline-before-block-statements.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-operator-before-line-break.js
+++ b/lib/rules/require-operator-before-line-break.js
@@ -1,7 +1,7 @@
 /**
  * Requires operators to appear before line breaks and not after.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to require all possible binary operators to appear before line breaks
  *

--- a/lib/rules/require-padding-newline-after-variable-declaration.js
+++ b/lib/rules/require-padding-newline-after-variable-declaration.js
@@ -4,7 +4,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Requires an empty line above the specified keywords unless the keyword is the first expression in a block.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted types or `true` to require padding new lines before all of the keywords below.
  *

--- a/lib/rules/require-padding-newlines-before-line-comments.js
+++ b/lib/rules/require-padding-newlines-before-line-comments.js
@@ -1,7 +1,7 @@
 /**
  * Requires newline before line comments
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values:
  * - `true`: always require a newline before line comments

--- a/lib/rules/require-padding-newlines-in-blocks.js
+++ b/lib/rules/require-padding-newlines-in-blocks.js
@@ -1,7 +1,7 @@
 /**
  * Requires blocks to begin and end with 2 newlines
  *
- * Type: `Boolean` or `Integer`
+ * Types: `Boolean` or `Integer`
  *
  * Values: `true` validates all non-empty blocks,
  * `Integer` specifies a minimum number of statements in the block before validating.

--- a/lib/rules/require-padding-newlines-in-objects.js
+++ b/lib/rules/require-padding-newlines-in-objects.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-parentheses-around-iife.js
+++ b/lib/rules/require-parentheses-around-iife.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * JSHint: [`immed`](http://www.jshint.com/docs/options/#immed)
  *

--- a/lib/rules/require-quoted-keys-in-objects.js
+++ b/lib/rules/require-quoted-keys-in-objects.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-semicolons.js
+++ b/lib/rules/require-semicolons.js
@@ -11,7 +11,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-space-after-binary-operators.js
+++ b/lib/rules/require-space-after-binary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Disallows sticking binary operators to the right.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to require space after all possible binary operators
  *

--- a/lib/rules/require-space-after-keywords.js
+++ b/lib/rules/require-space-after-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Requires space after keyword.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to require all of the keywords below to have a space afterward.
  *

--- a/lib/rules/require-space-after-line-comment.js
+++ b/lib/rules/require-space-after-line-comment.js
@@ -1,7 +1,7 @@
 /**
  * Requires that a line comment (`//`) be followed by a space.
  *
- * Type: `Boolean` or `Object` or `String`
+ * Types: `Boolean`, `Object` or `String`
  *
  * Values:
  *  - `true`

--- a/lib/rules/require-space-after-object-keys.js
+++ b/lib/rules/require-space-after-object-keys.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-space-after-prefix-unary-operators.js
+++ b/lib/rules/require-space-after-prefix-unary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Disallows sticking unary operators to the right.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to require space after prefix for all unary operators
  *

--- a/lib/rules/require-space-before-binary-operators.js
+++ b/lib/rules/require-space-before-binary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Disallows sticking binary operators to the left.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to require space before all possible binary operators
  * without comma operator, since it's rarely used with this rule

--- a/lib/rules/require-space-before-block-statements.js
+++ b/lib/rules/require-space-before-block-statements.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-space-before-keywords.js
+++ b/lib/rules/require-space-before-keywords.js
@@ -1,7 +1,7 @@
 /**
  * Requires space before keyword.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted keywords or `true` to require all possible keywords to have a preceding space.
  *

--- a/lib/rules/require-space-before-object-values.js
+++ b/lib/rules/require-space-before-object-values.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-space-before-postfix-unary-operators.js
+++ b/lib/rules/require-space-before-postfix-unary-operators.js
@@ -1,7 +1,7 @@
 /**
  * Disallows sticking unary operators to the left.
  *
- * Type: `Array` or `Boolean`
+ * Types: `Array` or `Boolean`
  *
  * Values: Array of quoted operators or `true` to require space before postfix for all unary operators
  * (i.e. increment/decrement operators).

--- a/lib/rules/require-spaces-in-call-expression.js
+++ b/lib/rules/require-spaces-in-call-expression.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/require-spaces-in-conditional-expression.js
+++ b/lib/rules/require-spaces-in-conditional-expression.js
@@ -1,7 +1,7 @@
 /**
  * Requires space before and/or after `?` or `:` in conditional expressions.
  *
- * Type: `Object` or `Boolean`
+ * Types: `Object` or `Boolean`
  *
  * Values: `"afterTest"`, `"beforeConsequent"`, `"afterConsequent"`, `"beforeAlternate"` as child properties,
  * or `true` to set all properties to `true`. Child properties must be set to `true`.

--- a/lib/rules/require-spaces-in-for-statement.js
+++ b/lib/rules/require-spaces-in-for-statement.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true` to requires spaces inbetween for statement.
+ * Value: `true` to requires spaces inbetween for statement.
  *
  * #### Example
  *

--- a/lib/rules/require-spaces-inside-array-brackets.js
+++ b/lib/rules/require-spaces-inside-array-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Requires space after opening array square bracket and before closing.
  *
- * Type: `String` or `Object`
+ * Types: `String` or `Object`
  *
  * Values: `"all"` for strict mode, `"allButNested"` (*deprecated* use `"allExcept": [ "[", "]"]`)
  * ignores closing brackets in a row.

--- a/lib/rules/require-spaces-inside-brackets.js
+++ b/lib/rules/require-spaces-inside-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Requires space after opening square bracket and before closing.
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values: `true` for strict mode, or `"allExcept": [ "[", "]"]`
  * ignores closing brackets in a row.

--- a/lib/rules/require-spaces-inside-object-brackets.js
+++ b/lib/rules/require-spaces-inside-object-brackets.js
@@ -1,7 +1,7 @@
 /**
  * Requires space after opening object curly brace and before closing.
  *
- * Type: `Object` or `String`
+ * Types: `Object` or `String`
  *
  * Values: `"all"` for strict mode, `"allButNested"` (*deprecated* use `"allExcept": ['}']`)
  * ignores closing brackets in a row.

--- a/lib/rules/require-spaces-inside-parentheses.js
+++ b/lib/rules/require-spaces-inside-parentheses.js
@@ -1,7 +1,7 @@
 /**
  * Requires space after opening round bracket and before closing.
  *
- * Type: `Object` or `String`
+ * Types: `Object` or `String`
  *
  * Values: `"all"` for strict mode, `"allButNested"`
  * (*deprecated* use `"except": ['(', ')']`) ignores nested brackets in a row, you could also specify token exceptions.

--- a/lib/rules/require-trailing-comma.js
+++ b/lib/rules/require-trailing-comma.js
@@ -1,7 +1,7 @@
 /**
  * Requires an extra comma following the final element of an array or object literal.
  *
- * Type: `Boolean` or `Object`
+ * Types: `Boolean` or `Object`
  *
  * Values:
  *

--- a/lib/rules/require-yoda-conditions.js
+++ b/lib/rules/require-yoda-conditions.js
@@ -3,7 +3,7 @@
  *
  * Type: `Boolean`
  *
- * Values: `true`
+ * Value: `true`
  *
  * #### Example
  *

--- a/lib/rules/safe-context-keyword.js
+++ b/lib/rules/safe-context-keyword.js
@@ -1,7 +1,7 @@
 /**
  * Option to check `var that = this` expressions
  *
- * Type: `Array` or `String`
+ * Types: `Array` or `String`
  *
  * Values: String value used for context local declaration
  *

--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -1,7 +1,7 @@
 /**
  * Validates indentation for switch statements and block statements
  *
- * Type: `Integer` or `String` or `Object`
+ * Types: `Integer`, `String` or `Object`
  *
  * Values:
  *  - `Integer`: A positive number of spaces

--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -1,7 +1,7 @@
 /**
  * Requires all quote marks to be either the supplied value, or consistent if `true`
  *
- * Type: `Boolean`, `String` or `Object`
+ * Types: `Boolean`, `String` or `Object`
  *
  * Values:
  *  - `"\""`: all strings require double quotes


### PR DESCRIPTION
Not as important, so moved these changes into separate PR. Just to be consistent – seems like most of the rules have "Values" instead of "Value".