### PR TITLE
Website: Added link to the preset option from the list of presets

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -2,6 +2,8 @@
 
 ## Presets
 
+Note: the easiest way to use a preset is with the [preset](#preset) option described below. This will use the correct version of the preset for the JSCS version being used. Not all presets may be available.
+
  * [Airbnb](https://github.com/jscs-dev/node-jscs/blob/master/presets/airbnb.json) — https://github.com/airbnb/javascript
  * [Crockford](https://github.com/jscs-dev/node-jscs/blob/master/presets/crockford.json) — http://javascript.crockford.com/code.html
  * [Google](https://github.com/jscs-dev/node-jscs/blob/master/presets/google.json) — https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml


### PR DESCRIPTION
I could not test the internal link as the heading id seems to be mangled for being in the preview and also I do not know if the HTML converter will process correctly.

Closes gh-issues/1185
Fixes #1185