### PR TITLE
New Rule: (disallow|require)PaddingNewLinesAfterUseStrict

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -675,6 +675,9 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/require-line-break-after-variable-assignment'));
     this.registerRule(require('../rules/require-padding-newline-after-variable-declaration'));
 
+    this.registerRule(require('../rules/disallow-padding-newlines-after-use-strict'));
+    this.registerRule(require('../rules/require-padding-newlines-after-use-strict'));
+
     this.registerRule(require('../rules/require-semicolons'));
     this.registerRule(require('../rules/disallow-semicolons'));
 

--- a/lib/rules/disallow-padding-newlines-after-use-strict.js
+++ b/lib/rules/disallow-padding-newlines-after-use-strict.js
@@ -1,0 +1,65 @@
+/**
+ * Disallow a blank line after `'use strict';` statements
+ *
+ * Values: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowPaddingNewLinesAfterUseStrict": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * 'use strict';
+ * // code
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * 'use strict';
+ *
+ * // code
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(disallowPaddingNewLinesAfterUseStrict) {
+        assert(
+            disallowPaddingNewLinesAfterUseStrict === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowPaddingNewLinesAfterUseStrict';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ExpressionStatement', function(node) {
+            var expression = node.expression;
+
+            if (expression.type !== 'Literal' || expression.value !== 'use strict') {
+                return;
+            }
+
+            var endOfNode = file.getLastNodeToken(node);
+            var nextToken = file.getNextToken(endOfNode, {
+                includeComments: true
+            });
+
+            errors.assert.linesBetween({
+                atMost: 1,
+                token: endOfNode,
+                nextToken: nextToken
+            });
+        });
+    }
+};

--- a/lib/rules/require-padding-newlines-after-use-strict.js
+++ b/lib/rules/require-padding-newlines-after-use-strict.js
@@ -1,0 +1,65 @@
+/**
+ * Requires a blank line after `'use strict';` statements
+ *
+ * Values: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requirePaddingNewLinesAfterUseStrict": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * 'use strict';
+ *
+ * // code
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * 'use strict';
+ * // code
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(requirePaddingNewLinesAfterUseStrict) {
+        assert(
+            requirePaddingNewLinesAfterUseStrict === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requirePaddingNewLinesAfterUseStrict';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ExpressionStatement', function(node) {
+            var expression = node.expression;
+
+            if (expression.type !== 'Literal' || expression.value !== 'use strict') {
+                return;
+            }
+
+            var endOfNode = file.getLastNodeToken(node);
+            var nextToken = file.getNextToken(endOfNode, {
+                includeComments: true
+            });
+
+            errors.assert.linesBetween({
+                atLeast: 2,
+                token: endOfNode,
+                nextToken: nextToken
+            });
+        });
+    }
+};

--- a/test/specs/rules/disallow-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/disallow-padding-newlines-after-use-strict.js
@@ -1,0 +1,57 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-padding-newlines-after-use-strict', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ disallowPaddingNewLinesAfterUseStrict: true });
+    });
+
+    it('should not report if use strict is not present', function() {
+        assert(checker.checkString('var a = 2;').isEmpty());
+    });
+
+    describe('with blank line', function() {
+        var input;
+        var output;
+
+        beforeEach(function() {
+            input = '"use strict";\n\nvar a = 2;';
+            output = '"use strict";\nvar a = 2;';
+        });
+
+        it('should report', function() {
+            assert(checker.checkString(input).getErrorCount() === 1);
+        });
+
+        it('should fix', function() {
+            var result = checker.fixString(input);
+            assert(result.errors.isEmpty());
+            assert.equal(result.output, output);
+        });
+    });
+
+    it('should not report when followed by comment without blank line', function() {
+        assert(checker.checkString('"use strict";\n// comment\nvar a = 2;').isEmpty());
+    });
+
+    it('should report when followed by comment with blank line', function() {
+        assert(checker.checkString('"use strict";\n\n// comment\nvar a = 2;').getErrorCount() === 1);
+    });
+
+    it('should not report with no blank line', function() {
+        assert(checker.checkString('"use strict";\nvar a = 2;').isEmpty());
+    });
+
+    it('should not report on same line', function() {
+        assert(checker.checkString('"use strict"; var a = 2;').isEmpty());
+    });
+
+    it('should not report other statements', function() {
+        assert(checker.checkString('"use stricts";\n\nvar a = 2;').isEmpty());
+        assert(checker.checkString('2 + 2;\n\nvar a = 2;').isEmpty());
+    });
+});

--- a/test/specs/rules/require-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/require-padding-newlines-after-use-strict.js
@@ -1,0 +1,57 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-padding-newlines-after-use-strict', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requirePaddingNewLinesAfterUseStrict: true });
+    });
+
+    it('should not report if use strict is not present', function() {
+        assert(checker.checkString('var a = 2;').isEmpty());
+    });
+
+    describe('with no blank line', function() {
+        var input;
+        var output;
+
+        beforeEach(function() {
+            input = '"use strict";\nvar a = 2;';
+            output = '"use strict";\n\nvar a = 2;';
+        });
+
+        it('should report', function() {
+            assert(checker.checkString(input).getErrorCount() === 1);
+        });
+
+        it('should fix', function() {
+            var result = checker.fixString(input);
+            assert(result.errors.isEmpty());
+            assert.equal(result.output, output);
+        });
+    });
+
+    it('should report when followed by comment without blank line', function() {
+        assert(checker.checkString('"use strict";\n// comment\nvar a = 2;').getErrorCount() === 1);
+    });
+
+    it('should not report when followed by comment with blank line', function() {
+        assert(checker.checkString('"use strict";\n\n// comment\nvar a = 2;').isEmpty());
+    });
+
+    it('should not report with blank line', function() {
+        assert(checker.checkString('"use strict";\n\nvar a = 2;').isEmpty());
+    });
+
+    it('should not report with extra blank lines', function() {
+        assert(checker.checkString('"use strict";\n\n\nvar a = 2;').isEmpty());
+    });
+
+    it('should not report other statements', function() {
+        assert(checker.checkString('"use stricts";\nvar a = 2;').isEmpty());
+        assert(checker.checkString('2 + 2;\nvar a = 2;').isEmpty());
+    });
+});


### PR DESCRIPTION
Implementing the `use strict` part of #1220