### PR TITLE
Repaired `node.parentCollection` for switch statements

### DIFF
--- a/lib/tree-iterator.js
+++ b/lib/tree-iterator.js
@@ -18,6 +18,7 @@ function iterate(node, cb) {
                         var pathElement = path.pop();
                         if (typeof pathElement === 'string') {
                             collectionKey = pathElement;
+                            break;
                         }
                     }
 

--- a/test/specs/rules/require-multiple-var-decl.js
+++ b/test/specs/rules/require-multiple-var-decl.js
@@ -26,6 +26,12 @@ describe('rules/require-multiple-var-decl', function() {
         it('should not report separated var decl', function() {
             assert(checker.checkString('var x; x++; var y;').isEmpty());
         });
+        it('supports var decl not contained by a parent with a `body` property (#916, #1163)', function() {
+            assert(checker.checkString('switch (1) { case 1: var x; }').isEmpty());
+        });
+        it('should report consecutive var decl not contained by a parent with a `body` property', function() {
+            assert(checker.checkString('switch (1) { case 1: var x; var y; }').getErrorCount() === 1);
+        });
     });
 
     describe('onevar', function() {


### PR DESCRIPTION
# Explanation
After moving to `estraverse` for `tree-iterator` in #817, we introduced a regression when resolving `node.parentCollection`. We want to resolve the sibling nodes for a node by looking at the property its parent is referring to.

For example, in the script `function a() {} function b() {}`, the `Program` node would have a `body` of an array of 2 `FunctionDeclaration` nodes. If we wanted to find this array from the perspective of `a`, then we would look at its parent node and the key it used to access it (e.g. `body`).

In most cases for `VariableDeclaration's`, the containing node has this declaration inside of a `body` key (e.g. `Program`, `FunctionDeclaration`, `BlockStatement`).

https://github.com/estree/estree/blob/9a35a3d091af6ff9cf7fadfe27c49e22533b2bce/spec.md#programs

https://github.com/estree/estree/blob/9a35a3d091af6ff9cf7fadfe27c49e22533b2bce/spec.md#functions

https://github.com/estree/estree/blob/9a35a3d091af6ff9cf7fadfe27c49e22533b2bce/spec.md#blockstatement

> Fwiw `IfStatement`/`CatchClause`/etc all have a `BlockStatement` as the children which is the proper container for these `VariableDeclaration's`.

However in the case of a `SwitchCase`, we use `consquent` as the key:

https://github.com/estree/estree/blob/9a35a3d091af6ff9cf7fadfe27c49e22533b2bce/spec.md#switchcase

# Problem/solution
The problem we had was that `tree-iterator` wasn't stopping once it found the key. It continued traversing up to the root node (`Program`). As a result, the key was always `body` and this worked great for most cases (e.g. `Program`, `FunctionDeclaration`, `BlockStatement`). However, in the case of `SwitchStatement`, it would yield `undefined`.

In the case of our test failures, the `parentCollection` would be `[undefined]` which means a bad `indexOf` lookup, leading to an error thrown when accessing a property of `undefined`.

To remedy this, we stop looping at the first parent's key via a `break`.

In this PR:

- Added regression tests
- Added patch to `tree-iterator`

Fixes #916. Fixes #1163.

**Notes:**

It should be noted that `parentCollection` is only used by `require-multiple-var-decl`. Additionally, this touches `_buildNodeIndex` which may lead to performance speed up (yey).

https://github.com/jscs-dev/node-jscs/blob/v1.12.0/lib/js-file.js#L728-L738