### PR TITLE
New Rule: (disallow|require)PaddingNewLinesBeforeExport

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -680,6 +680,9 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-padding-newlines-after-use-strict'));
     this.registerRule(require('../rules/require-padding-newlines-after-use-strict'));
 
+    this.registerRule(require('../rules/disallow-padding-newlines-before-export'));
+    this.registerRule(require('../rules/require-padding-newlines-before-export'));
+
     this.registerRule(require('../rules/require-semicolons'));
     this.registerRule(require('../rules/disallow-semicolons'));
 

--- a/lib/rules/disallow-padding-newlines-before-export.js
+++ b/lib/rules/disallow-padding-newlines-before-export.js
@@ -1,0 +1,70 @@
+/**
+ * Disallows newline before module.exports
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requirePaddingNewLinesBeforeExport": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = 2;
+ * module.exports = a;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = 2;
+ *
+ * module.exports = a;
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(value) {
+        assert(
+            value === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowPaddingNewLinesBeforeExport';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('AssignmentExpression', function(node) {
+            var left = node.left;
+            if (!(
+                left.object &&
+                left.object.name === 'module' &&
+                left.property &&
+                left.property.name === 'exports')) {
+                return;
+            }
+
+            var firstToken = file.getFirstNodeToken(node);
+            var prevToken = file.getPrevToken(firstToken, {includeComments: true});
+
+            errors.assert.linesBetween({
+                atMost: 1,
+                token: prevToken,
+                nextToken: firstToken,
+                message: 'Unexpected extra newline before export'
+            });
+        });
+    }
+
+};

--- a/lib/rules/require-padding-newlines-before-export.js
+++ b/lib/rules/require-padding-newlines-before-export.js
@@ -1,0 +1,70 @@
+/**
+ * Requires newline before module.exports
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requirePaddingNewLinesBeforeExport": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = 2;
+ *
+ * module.exports = a;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = 2;
+ * module.exports = a;
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(value) {
+        assert(
+            value === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requirePaddingNewLinesBeforeExport';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('AssignmentExpression', function(node) {
+            var left = node.left;
+            if (!(
+                left.object &&
+                left.object.name === 'module' &&
+                left.property &&
+                left.property.name === 'exports')) {
+                return;
+            }
+
+            var firstToken = file.getFirstNodeToken(node);
+            var prevToken = file.getPrevToken(firstToken);
+
+            errors.assert.linesBetween({
+                atLeast: 2,
+                token: prevToken,
+                nextToken: firstToken,
+                message: 'Missing newline before export'
+            });
+        });
+    }
+
+};

--- a/test/specs/rules/disallow-padding-newlines-before-export.js
+++ b/test/specs/rules/disallow-padding-newlines-before-export.js
@@ -33,5 +33,10 @@ describe('rules/disallow-padding-newlines-before-export', function() {
         it('should not report comment with extra padding before export', function() {
             assert(checker.checkString('var a = 2;\n\n// foo\nmodule.exports = a;').isEmpty());
         });
+
+        it('should not report padding before object assignment', function() {
+            assert(checker.checkString('var a = 2;\n\nfoo.exports = a;').isEmpty());
+            assert(checker.checkString('var a = 2;\n\nmodule.foo = a;').isEmpty());
+        });
     });
 });

--- a/test/specs/rules/disallow-padding-newlines-before-export.js
+++ b/test/specs/rules/disallow-padding-newlines-before-export.js
@@ -1,0 +1,37 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-padding-newlines-before-export', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('value true', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewLinesBeforeExport: true });
+        });
+
+        it('should not report no padding before export', function() {
+            assert(checker.checkString('var a = 2;\nmodule.exports = a;').isEmpty());
+        });
+
+        it('should not report missing padding if first line', function() {
+            assert(checker.checkString('module.exports = 2;').isEmpty());
+        });
+
+        it('should report padding before export', function() {
+            assert(checker.checkString('var a = 2;\n\nmodule.exports = a;').getErrorCount() === 1);
+        });
+
+        it('should not report comment before export', function() {
+            assert(checker.checkString('var a = 2;\n// foo\nmodule.exports = a;').isEmpty());
+        });
+
+        it('should not report comment with extra padding before export', function() {
+            assert(checker.checkString('var a = 2;\n\n// foo\nmodule.exports = a;').isEmpty());
+        });
+    });
+});

--- a/test/specs/rules/require-padding-newlines-before-export.js
+++ b/test/specs/rules/require-padding-newlines-before-export.js
@@ -25,5 +25,10 @@ describe('rules/require-padding-newlines-before-export', function() {
         it('should not report padding before export', function() {
             assert(checker.checkString('var a = 2;\n\nmodule.exports = a;').isEmpty());
         });
+
+        it('should not report lack of padding before object assignment', function() {
+            assert(checker.checkString('var a = 2;\nfoo.exports = a;').isEmpty());
+            assert(checker.checkString('var a = 2;\nmodule.foo = a;').isEmpty());
+        });
     });
 });

--- a/test/specs/rules/require-padding-newlines-before-export.js
+++ b/test/specs/rules/require-padding-newlines-before-export.js
@@ -1,0 +1,29 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-padding-newlines-before-export', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('value true', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewLinesBeforeExport: true });
+        });
+
+        it('should report missing padding before export', function() {
+            assert(checker.checkString('var a = 2;\nmodule.exports = a;').getErrorCount() === 1);
+        });
+
+        it('should not report missing padding if first line', function() {
+            assert(checker.checkString('module.exports = 2;').isEmpty());
+        });
+
+        it('should not report padding before export', function() {
+            assert(checker.checkString('var a = 2;\n\nmodule.exports = a;').isEmpty());
+        });
+    });
+});


### PR DESCRIPTION
As discussed in #1220 

Closes #1220.