### PR TITLE
Adding a test helper for asserting errors and fixes

### DIFF
--- a/test/assertHelpers.js
+++ b/test/assertHelpers.js
@@ -1,0 +1,51 @@
+var assert = require('assert');
+var Checker = require('../lib/checker');
+
+var AssertHelpers = {
+
+    /**
+     * Assert that the input fails with a certain number of errors and when fixed matches output with no errors.
+     *
+     * @param {Object} options
+     * @param {String} options.name the name of the test that will be put in the describe block
+     * @param {Object} options.rules the object that will be passed to checker.configure
+     * @param {String} options.input the input string to check
+     * @param {String} options.output the output string that input should match after being fixed
+     * @param {Number} [options.errors='1'] the expected number of errors when checking input
+     */
+    reportAndFix: function(options) {
+        assert.equal(typeof(options), 'object');
+        assert.equal(typeof(options.name), 'string');
+        assert.equal(typeof(options.rules), 'object');
+        assert.equal(typeof(options.input), 'string');
+        assert.equal(typeof(options.output), 'string');
+
+        if (options.errors !== undefined) {
+            assert.equal(typeof(options.errors), 'number');
+        }
+
+        options.errors = options.errors || 1;
+
+        describe(options.name, function() {
+            var checker;
+
+            beforeEach(function() {
+                checker = new Checker();
+                checker.registerDefaultRules();
+                checker.configure(options.rules);
+            });
+
+            it('should report', function() {
+                assert(checker.checkString(options.input).getErrorCount() === options.errors);
+            });
+
+            it('should fix', function() {
+                var result = checker.fixString(options.input);
+                assert(result.errors.isEmpty());
+                assert.equal(result.output, options.output);
+            });
+        });
+    }
+};
+
+module.exports = AssertHelpers;

--- a/test/lib/assertHelpers.js
+++ b/test/lib/assertHelpers.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Checker = require('../lib/checker');
+var Checker = require('../../lib/checker');
 
 var AssertHelpers = {
 

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -1,6 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
-var reportAndFix = require('../../assertHelpers').reportAndFix;
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-comma-before-line-break', function() {
     var rules = { disallowCommaBeforeLineBreak: true };

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -1,66 +1,36 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../assertHelpers').reportAndFix;
 
 describe('rules/disallow-comma-before-line-break', function() {
+    var rules = { disallowCommaBeforeLineBreak: true };
     var checker;
-    var input;
-    var output;
 
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ disallowCommaBeforeLineBreak: true });
+        checker.configure(rules);
     });
 
-    describe('illegal comma placement in multiline var declaration', function() {
-        beforeEach(function() {
-            input = 'var a,\nb;';
-            output = 'var a, b;';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+    reportAndFix({
+        name: 'illegal comma placement in multiline var declaration',
+        rules: rules,
+        input: 'var a,\nb;',
+        output: 'var a, b;'
     });
 
-    describe('illegal comma placement in multiline array declaration', function() {
-        beforeEach(function() {
-            input = 'var a = [1,\n2];';
-            output = 'var a = [1, 2];';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+    reportAndFix({
+        name: 'illegal comma placement in multiline array declaration',
+        rules: rules,
+        input: 'var a = [1,\n2];',
+        output: 'var a = [1, 2];'
     });
 
-    describe('illegal comma placement in multiline object declaration', function() {
-        beforeEach(function() {
-            input = 'var a = {a:1,\nc:3};';
-            output = 'var a = {a:1, c:3};';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+    reportAndFix({
+        name: 'illegal comma placement in multiline object declaration',
+        rules: rules,
+        input: 'var a = {a:1,\nc:3};',
+        output: 'var a = {a:1, c:3};'
     });
 
     it('should not report legal comma placement in multiline var declaration', function() {

--- a/test/specs/rules/disallow-keywords-on-new-line.js
+++ b/test/specs/rules/disallow-keywords-on-new-line.js
@@ -1,72 +1,45 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../assertHelpers').reportAndFix;
 
 describe('rules/disallow-keywords-on-new-line', function() {
     var checker;
-    var input;
-    var output;
 
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
     });
 
-    describe('illegal comma illegal keyword placement for catch', function() {
-        beforeEach(function() {
-            checker.configure({ disallowKeywordsOnNewLine: ['catch'] });
-
-            input = 'try {\n' +
+    reportAndFix({
+        name: 'illegal comma illegal keyword placement for catch',
+        rules: { disallowKeywordsOnNewLine: ['catch'] },
+        input: 'try {\n' +
                     'x++;\n' +
                 '}\n' +
                 'catch(e) {\n' +
                     'x--;\n' +
-                '}';
-
-            output = 'try {\n' +
+                '}',
+        output: 'try {\n' +
                     'x++;\n' +
                 '} catch(e) {\n' +
                     'x--;\n' +
-                '}';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+                '}'
     });
 
-    describe('illegal keyword placement', function() {
-        beforeEach(function() {
-            checker.configure({ disallowKeywordsOnNewLine: ['else'] });
-
-            input = 'if (x) {\n' +
+    reportAndFix({
+        name: 'illegal comma illegal keyword placement for catch',
+        rules: { disallowKeywordsOnNewLine: ['else'] },
+        input: 'if (x) {\n' +
                     'x++;\n' +
                 '}\n' +
                 'else {\n' +
                     'x--;\n' +
-                '}';
-
-            output = 'if (x) {\n' +
+                '}',
+        output: 'if (x) {\n' +
                     'x++;\n' +
                 '} else {\n' +
                     'x--;\n' +
-                '}';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+                '}'
     });
 
     it('should not report legal keyword placement', function() {

--- a/test/specs/rules/disallow-keywords-on-new-line.js
+++ b/test/specs/rules/disallow-keywords-on-new-line.js
@@ -1,6 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
-var reportAndFix = require('../../assertHelpers').reportAndFix;
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-keywords-on-new-line', function() {
     var checker;

--- a/test/specs/rules/disallow-newline-before-block-statements.js
+++ b/test/specs/rules/disallow-newline-before-block-statements.js
@@ -1,10 +1,9 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../assertHelpers').reportAndFix;
 
 describe('rules/disallow-newline-before-block-statements', function() {
     var checker;
-    var input;
-    var output;
 
     beforeEach(function() {
         checker = new Checker();
@@ -16,55 +15,26 @@ describe('rules/disallow-newline-before-block-statements', function() {
             checker.configure({ disallowNewlineBeforeBlockStatements: true });
         });
 
-        describe('disallowed newline if there is one', function() {
-            beforeEach(function() {
-                input = 'function test()\n{abc();}';
-                output = 'function test() {abc();}';
-            });
-
-            it('should report', function() {
-                assert(checker.checkString(input).getErrorCount() === 1);
-            });
-
-            it('should fix', function() {
-                var result = checker.fixString(input);
-                assert(result.errors.isEmpty());
-                assert.equal(result.output, output);
-            });
+        reportAndFix({
+            name: 'disallowed newline if there is one',
+            rules: { disallowNewlineBeforeBlockStatements: true },
+            input: 'function test()\n{abc();}',
+            output: 'function test() {abc();}'
         });
 
-        describe('disallowed newline only for function definition block statement', function() {
-            beforeEach(function() {
-                input = 'function test()\n{var obj = \n{a:1,\nb:2,\nc:3\n};\n\n return {\nval:1\n};\n}';
-                output = 'function test() {var obj = \n{a:1,\nb:2,\nc:3\n};\n\n return {\nval:1\n};\n}';
-            });
-
-            it('should report', function() {
-                assert(checker.checkString(input).getErrorCount() === 1);
-            });
-
-            it('should fix', function() {
-                var result = checker.fixString(input);
-                assert(result.errors.isEmpty());
-                assert.equal(result.output, output);
-            });
+        reportAndFix({
+            name: 'disallowed newline only for function definition block statement',
+            rules: { disallowNewlineBeforeBlockStatements: true },
+            input: 'function test()\n{var obj = \n{a:1,\nb:2,\nc:3\n};\n\n return {\nval:1\n};\n}',
+            output: 'function test() {var obj = \n{a:1,\nb:2,\nc:3\n};\n\n return {\nval:1\n};\n}'
         });
 
-        describe('disallowed newline for all 3 statements', function() {
-            beforeEach(function() {
-                input = 'function test()\n{\nif(true)\n{\nreturn 1;\n}\nfor(var i in [1,2,3])\n{\n}\n}';
-                output = 'function test() {\nif(true) {\nreturn 1;\n}\nfor(var i in [1,2,3]) {\n}\n}';
-            });
-
-            it('should report', function() {
-                assert(checker.checkString(input).getErrorCount() === 3);
-            });
-
-            it('should fix', function() {
-                var result = checker.fixString(input);
-                assert(result.errors.isEmpty());
-                assert.equal(result.output, output);
-            });
+        reportAndFix({
+            name: 'disallowed newline for all 3 statements',
+            rules: { disallowNewlineBeforeBlockStatements: true },
+            input: 'function test()\n{\nif(true)\n{\nreturn 1;\n}\nfor(var i in [1,2,3])\n{\n}\n}',
+            output: 'function test() {\nif(true) {\nreturn 1;\n}\nfor(var i in [1,2,3]) {\n}\n}',
+            errors: 3
         });
 
         it('should not report disallowed newline before opening brace', function() {

--- a/test/specs/rules/disallow-newline-before-block-statements.js
+++ b/test/specs/rules/disallow-newline-before-block-statements.js
@@ -1,6 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
-var reportAndFix = require('../../assertHelpers').reportAndFix;
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-newline-before-block-statements', function() {
     var checker;

--- a/test/specs/rules/disallow-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/disallow-padding-newlines-after-use-strict.js
@@ -1,6 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
-var reportAndFix = require('../../assertHelpers').reportAndFix;
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-padding-newlines-after-use-strict', function() {
     var rules = { disallowPaddingNewLinesAfterUseStrict: true };

--- a/test/specs/rules/disallow-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/disallow-padding-newlines-after-use-strict.js
@@ -1,37 +1,26 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../assertHelpers').reportAndFix;
 
 describe('rules/disallow-padding-newlines-after-use-strict', function() {
+    var rules = { disallowPaddingNewLinesAfterUseStrict: true };
     var checker;
 
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ disallowPaddingNewLinesAfterUseStrict: true });
+        checker.configure(rules);
     });
 
     it('should not report if use strict is not present', function() {
         assert(checker.checkString('var a = 2;').isEmpty());
     });
 
-    describe('with blank line', function() {
-        var input;
-        var output;
-
-        beforeEach(function() {
-            input = '"use strict";\n\nvar a = 2;';
-            output = '"use strict";\nvar a = 2;';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+    reportAndFix({
+        name: 'with blank line',
+        rules: rules,
+        input: '"use strict";\n\nvar a = 2;',
+        output: '"use strict";\nvar a = 2;'
     });
 
     it('should not report when followed by comment without blank line', function() {

--- a/test/specs/rules/require-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/require-padding-newlines-after-use-strict.js
@@ -1,6 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
-var reportAndFix = require('../../assertHelpers').reportAndFix;
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-padding-newlines-after-use-strict', function() {
     var rules = { requirePaddingNewLinesAfterUseStrict: true };

--- a/test/specs/rules/require-padding-newlines-after-use-strict.js
+++ b/test/specs/rules/require-padding-newlines-after-use-strict.js
@@ -1,37 +1,26 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../assertHelpers').reportAndFix;
 
 describe('rules/require-padding-newlines-after-use-strict', function() {
+    var rules = { requirePaddingNewLinesAfterUseStrict: true };
     var checker;
 
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requirePaddingNewLinesAfterUseStrict: true });
+        checker.configure(rules);
     });
 
     it('should not report if use strict is not present', function() {
         assert(checker.checkString('var a = 2;').isEmpty());
     });
 
-    describe('with no blank line', function() {
-        var input;
-        var output;
-
-        beforeEach(function() {
-            input = '"use strict";\nvar a = 2;';
-            output = '"use strict";\n\nvar a = 2;';
-        });
-
-        it('should report', function() {
-            assert(checker.checkString(input).getErrorCount() === 1);
-        });
-
-        it('should fix', function() {
-            var result = checker.fixString(input);
-            assert(result.errors.isEmpty());
-            assert.equal(result.output, output);
-        });
+    reportAndFix({
+        name: 'with no blank line',
+        rules: rules,
+        input: '"use strict";\nvar a = 2;',
+        output: '"use strict";\n\nvar a = 2;'
     });
 
     it('should report when followed by comment without blank line', function() {


### PR DESCRIPTION
Enabling tests to be easily written to confirm that we are writing tests that are fixing properly.

Refs @mikesherov's recommendation in #1128
Should be useful for updating the rules in #1127
Needed for #1202 