### PR TITLE
validateQuoteMarks: support disabling

### DIFF
--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -7,6 +7,7 @@
  *  - `"\""`: all strings require double quotes
  *  - `"'"`: all strings require single quotes
  *  - `true`: all strings require the quote mark first encountered in the source code
+ *  - `false`: disable validation of quote marks
  *  - `Object`:
  *     - `escape`: allow the "other" quote mark to be used, but only to avoid having to escape
  *     - `mark`: the same effect as the non-object values
@@ -73,8 +74,8 @@ module.exports.prototype = {
         }
 
         assert(
-            quoteMark === '"' || quoteMark === '\'' || quoteMark === true,
-            this.getOptionName() + ' option requires \'"\', "\'", or boolean true'
+            quoteMark === '"' || quoteMark === '\'' || typeof quoteMark === 'boolean',
+            this.getOptionName() + ' option requires \'"\', "\'", or a boolean value'
         );
 
         this._quoteMark = quoteMark;
@@ -91,6 +92,10 @@ module.exports.prototype = {
             '"': '\'',
             '\'': '"'
         };
+
+        if (quoteMark === false) {
+            return;
+        }
 
         file.iterateTokensByType('String', function(token) {
             var str = token.value;

--- a/test/specs/rules/validate-quote-marks.js
+++ b/test/specs/rules/validate-quote-marks.js
@@ -181,4 +181,14 @@ describe('rules/validate-quote-marks', function() {
             assert(checker.checkString('var x = "x", y = "y"; /*\'y\'*/').isEmpty());
         });
     });
+
+    describe('option value false', function() {
+        beforeEach(function() {
+            checker.configure({ validateQuoteMarks: false });
+        });
+
+        it('should not report inconsistent quotes', function() {
+            assert(checker.checkString('var x = \'x\', y = "y";').getErrorCount() === 0);
+        });
+    });
 });


### PR DESCRIPTION
When using a preset which configures the validateQuoteMarks rule, there
was no way to opt-out.

Change this rule to allow `validateQuoteMarks: false` which disables
this rule explicitely.