### PR TITLE
Don't BSOD on throws in rules

### DIFF
--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -130,7 +130,16 @@ StringChecker.prototype = {
 
         this._configuredRules.forEach(function(rule) {
             errors.setCurrentRule(rule.getOptionName());
-            rule.check(file, errors);
+
+            try {
+                rule.check(file, errors);
+            } catch (e) {
+                errors.add('Error running rule ' + rule.getOptionName() + ': ' +
+                    'This is an issue with JSCS and not your codebase.\n' +
+                    'Please file an issue (with the stack trace below) at: ' +
+                    'https://github.com/jscs-dev/node-jscs/issues/new\n' +
+                    e.stack, 1, 0);
+            }
         }, this);
 
         this._configuration.getUnsupportedRuleNames().forEach(function(rulename) {

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -357,6 +357,33 @@ describe('modules/string-checker', function() {
         });
     });
 
+    describe('throwing rules', function() {
+        function _beforeEach(_verbose) {
+            checker = new StringChecker({verbose: _verbose});
+            // register rule that throw
+            checker.registerRule({
+                configure : function() {},
+                getOptionName: function() { return 'thrower'; },
+                check : function() {
+                    throw Error('Here we are!');
+                }
+            });
+            checker.configure({thrower: true});
+        }
+
+        it('should be handled internally with verbose', function() {
+            _beforeEach(true);
+
+            var errs = checker.checkString('var a');
+            assert.equal(errs.getErrorCount(), 1);
+
+            var err = errs.getErrorList()[0];
+            assert.equal(err.rule, 'thrower');
+            assert.ok(err.message.indexOf('Error running rule thrower:') !== -1);
+            assert.ok(err.message.indexOf('Error: Here we are!') !== -1);
+        });
+    });
+
     describe('presets', function() {
         testPreset('airbnb');
         testPreset('crockford');


### PR DESCRIPTION
See #1271 

I'm not sure about cases, I see now just one: we shouldn't stop checking if 1 rule failed in 1 file.

For that case I think we can notify user about that via common mechanism: errors object.

Your thoughts about message?