### PR TITLE
requireCamelCaseOrUpperCaseIdentifiers: skip es5 getters if ignoreProper...

### DIFF
--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -86,7 +86,8 @@ module.exports.prototype = {
                     return;
                 }
 
-                if (prevToken && prevToken.value === '.') {
+                if (prevToken && (prevToken.value === '.' ||
+                    prevToken.value === 'get' || prevToken.value === 'set')) {
                     return;
                 }
             }

--- a/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
@@ -83,5 +83,13 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
         it('should report identifiers that are the first token', function() {
             assert(checker.checkString('snake_case = a;').getErrorCount() === 1);
         });
+
+        it('should not report es5 getters', function() {
+            assert(checker.checkString('var extend = { get a_b() { } };').isEmpty());
+        });
+
+        it('should not report es5 setters', function() {
+            assert(checker.checkString('var extend = { set c_d(v) { } };').isEmpty());
+        });
     });
 });


### PR DESCRIPTION
...ties is set

Fixes #1269