### PR TITLE
Verbose option and dependent parts

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -235,6 +235,19 @@ Value: `true`
 "esnext": true
 ```
 
+### verbose
+Prepends the name of the offending rule to all error messages.
+
+Type: `Boolean`
+
+Default: `false`
+
+#### Example
+
+```js
+"verbose": true
+```
+
 ### esprimaOptions
 
 Custom `options` to be passed to `esprima.parse(code, options)`

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,10 +19,7 @@ module.exports = function(program) {
     var checkerPromise;
     var defer = Vow.defer();
     var promise = defer.promise();
-    var checker = new Checker({
-        verbose: program.verbose,
-        esnext: program.esnext
-    });
+    var checker = new Checker();
     var args = program.args;
     var returnArgs = {
         checker: checker,

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -14,7 +14,8 @@ var BUILTIN_OPTIONS = {
     es3: true,
     esprima: true,
     esprimaOptions: true,
-    errorFilter: true
+    errorFilter: true,
+    verbose: true
 };
 
 /**
@@ -41,6 +42,7 @@ function Configuration() {
     this._esprima = null;
     this._esprimaOptions = {};
     this._errorFilter = null;
+    this._verbose = null;
 }
 
 /**
@@ -191,6 +193,15 @@ Configuration.prototype.hasCustomEsprima = function() {
  */
 Configuration.prototype.getCustomEsprima = function() {
     return this._esprima;
+};
+
+/**
+ * Returns verbose option.
+ *
+ * @returns {Object|null}
+ */
+Configuration.prototype.getVerbose = function() {
+    return this._verbose || false;
 };
 
 /**
@@ -352,6 +363,10 @@ Configuration.prototype._processConfig = function(config) {
         this._loadErrorFilter(options.errorFilter);
     }
 
+    if (options.hasOwnProperty('verbose')) {
+        this._loadVerbose(options.verbose);
+    }
+
     // NOTE: rule setting must come last in order to
     // override any rules that are loaded from a preset
     Object.keys(config).forEach(function(key) {
@@ -387,6 +402,20 @@ Configuration.prototype._loadErrorFilter = function(errorFilter) {
         '`errorFilter` option requires a function or null value'
     );
     this._errorFilter = errorFilter;
+};
+
+/**
+ * Loads verbose option.
+ *
+ * @param {Boolean|null} verbose
+ * @protected
+ */
+Configuration.prototype._loadVerbose = function(verbose) {
+    assert(
+        typeof verbose === 'boolean' || verbose === null,
+        '`verbose` option requires a boolean or null value'
+    );
+    this._verbose = verbose;
 };
 
 /**

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -10,7 +10,8 @@ var OVERRIDE_OPTIONS = [
     'maxErrors',
     'errorFilter',
     'esprima',
-    'es3'
+    'es3',
+    'verbose'
 ];
 
 /**

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -64,11 +64,25 @@ Errors.prototype = {
         this._errorList.push({
             filename: this._file.getFilename(),
             rule: this._currentRule,
-            message: this._verbose ? this._currentRule + ': ' + errorInfo.message : errorInfo.message,
+            message: this._prepareMessage(errorInfo),
             line: errorInfo.line,
             column: errorInfo.column,
             fixed: errorInfo.fixed
         });
+    },
+
+    /**
+     * Prepare error message.
+     *
+     * @param {Object} errorInfo
+     * @private
+     */
+    _prepareMessage: function(errorInfo) {
+        if (this._verbose && this._currentRule) {
+            return this._currentRule + ': ' + errorInfo.message;
+        }
+
+        return errorInfo.message;
     },
 
     /**
@@ -129,7 +143,7 @@ Errors.prototype = {
      * Formats error for further output.
      *
      * @param {Object} error
-     * @param {Boolean} colorize
+     * @param {Boolean} [colorize = false]
      * @returns {String}
      */
     explainError: function(error, colorize) {
@@ -199,7 +213,7 @@ function prependSpaces(s, len) {
  *
  * @param {Number} n line number
  * @param {String} line
- * @param {Boolean} colorize
+ * @param {Boolean} [colorize = false]
  * @returns {String}
  */
 function renderLine(n, line, colorize) {
@@ -217,7 +231,7 @@ function renderLine(n, line, colorize) {
  * ---------------^
  *
  * @param {Number} column
- * @param {Boolean} colorize
+ * @param {Boolean} [colorize = false]
  * @returns {String}
  */
 function renderPointer(column, colorize) {

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -10,6 +10,8 @@ var MAX_FIX_ATTEMPTS = 5;
  * Starts Code Style checking process.
  *
  * @name StringChecker
+ *
+ * Following params are deprecated, should be removed in 2.0
  * @param {Boolean|Object} options either a boolean flag representing verbosity (deprecated), or an options object
  * @param {Boolean} options.verbose true adds the rule name to the error messages it produces, false does not
  * @param {Boolean} options.esnext true attempts to parse the code as es6, false does not
@@ -71,6 +73,10 @@ StringChecker.prototype = {
             this._esprima = this._configuration.getCustomEsprima();
         } else if (this._configuration.isESNextEnabled()) {
             this._esprima = harmonyEsprima;
+        }
+
+        if (this._verbose === false) {
+            this._verbose = this._configuration.getVerbose();
         }
 
         this._configuredRules = this._configuration.getConfiguredRules();

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -123,6 +123,28 @@ describe('modules/config/configuration', function() {
         });
     });
 
+    describe('verbose', function() {
+        it('should return false when null is specified', function() {
+            configuration.load({verbose: null});
+            assert.equal(configuration.getVerbose(), false);
+        });
+
+        it('should return false when false is specified', function() {
+            configuration.load({verbose: false});
+            assert.equal(configuration.getVerbose(), false);
+        });
+
+        it('should return true when unspecified', function() {
+            configuration.load({});
+            assert.equal(configuration.getVerbose(), false);
+        });
+
+        it('should return true when true is specified', function() {
+            configuration.load({verbose: true});
+            assert.equal(configuration.getVerbose(), true);
+        });
+    });
+
     describe('getRegisteredPresets', function() {
         it('should return registered presets object', function() {
             var preset = {maxErrors: 5};

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -25,7 +25,8 @@ describe('modules/config/node-configuration', function() {
                 maxErrors: '2',
                 errorFilter: path.resolve(__dirname, '../../data/error-filter.js'),
                 esprima: 'esprima-harmony-jscs',
-                es3: true
+                es3: true,
+                verbose: true
             });
 
             configuration.registerPreset('jquery', {});
@@ -36,6 +37,7 @@ describe('modules/config/node-configuration', function() {
             assert.equal(configuration.isES3Enabled(), true);
             assert.equal(typeof configuration.getErrorFilter, 'function');
             assert.equal(configuration.hasCustomEsprima(), true);
+            assert.equal(configuration.getVerbose(), true);
         });
 
         it('should not override disallowed options from CLI', function() {

--- a/test/specs/errors.js
+++ b/test/specs/errors.js
@@ -195,7 +195,7 @@ describe('modules/errors', function() {
                 var error = errors.getErrorList()[0];
 
                 assert.equal(
-                    errors.explainError(error).indexOf( ": Unsupported rule: unsupported" ), -1
+                    errors.explainError(error).indexOf(': Unsupported rule: unsupported'), -1
                 );
             }
         );

--- a/test/specs/errors.js
+++ b/test/specs/errors.js
@@ -183,6 +183,22 @@ describe('modules/errors', function() {
 
             assert.ok(errors.explainError(error, true).indexOf('\u001b') !== -1);
         });
+
+        it('should show correct error message for "verbose" option and unsupported rule error',
+           function() {
+                checker = new Checker({ verbose: true });
+
+                checker.registerDefaultRules();
+                checker.configure({ unsupported: true });
+
+                var errors = checker.checkString('var x = { "a": 1 };');
+                var error = errors.getErrorList()[0];
+
+                assert.equal(
+                    errors.explainError(error).indexOf( ": Unsupported rule: unsupported" ), -1
+                );
+            }
+        );
     });
 
     describe('filter', function() {

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -114,6 +114,16 @@ describe('modules/string-checker', function() {
             }
         });
 
+        it('should set verbose option', function() {
+            checker.configure({
+                verbose: true,
+                requireSpaceBeforeBinaryOperators: ['=']
+            });
+
+            var errors = checker.checkString('var foo=1;\n var bar=2;').getErrorList();
+            assert(errors[0].message.indexOf('requireSpaceBeforeBinaryOperators') > -1);
+        });
+
         describe('rules registration', function() {
             it('should report rules in config which don\'t match any registered rules', function() {
                 checker.configure({ doesNotExist: true, noSuchRule: true });


### PR DESCRIPTION
* Add "verbose" option as a config option

* Do not show rule for "Unsupported rule" error 

* Deprecate params for "Checker" constructor

Fixes #1193