### PR TITLE
Add link to overcommit under "Friendly packages"

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -21,6 +21,7 @@ Note: the easiest way to use a preset is with the [preset](#preset) option descr
  * Brackets Extension: https://github.com/globexdesigns/brackets-jscs
  * Grunt task: https://github.com/jscs-dev/grunt-jscs/
  * Gulp task: https://github.com/jscs-dev/gulp-jscs/
+ * Overcommit Git pre-commit hook manager: https://github.com/brigade/overcommit/
  * SublimeText 3 Plugin: https://github.com/SublimeLinter/SublimeLinter-jscs/
  * Syntastic VIM Plugin: [https://github.com/scrooloose/syntastic/.../syntax_checkers/javascript/jscs.vim/](https://github.com/scrooloose/syntastic/blob/master/syntax_checkers/javascript/jscs.vim/)
  * Web Essentials for Visual Studio 2013: https://github.com/madskristensen/WebEssentials2013/


### PR DESCRIPTION
overcommit is a fully configurable and extendable Git hook manager that
includes out-of-the-box support for running JSCS as a Git pre-commit
hook.