### PR TITLE
Preset: Mozilla

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -10,6 +10,7 @@ Note: the easiest way to use a preset is with the [preset](#preset) option descr
  * [Grunt](https://github.com/jscs-dev/node-jscs/blob/master/presets/grunt.json) — http://gruntjs.com/contributing#syntax
  * [jQuery](https://github.com/jscs-dev/node-jscs/blob/master/presets/jquery.json) — https://contribute.jquery.org/style-guide/js/
  * [MDCS](https://github.com/jscs-dev/node-jscs/blob/master/presets/mdcs.json) — [https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style™](https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2)
+ * [Mozilla](https://github.com/jscs-dev/node-jscs/blob/master/presets/mozilla.json) — https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style
  * [node-style-guide](https://github.com/jscs-dev/node-jscs/blob/master/presets/node-style-guide.json) - https://github.com/felixge/node-style-guide
  * [Wikimedia](https://github.com/jscs-dev/node-jscs/blob/master/presets/wikimedia.json) — https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
  * [Wordpress](https://github.com/jscs-dev/node-jscs/blob/master/presets/wordpress.json) — https://make.wordpress.org/core/handbook/coding-standards/javascript/
@@ -157,7 +158,7 @@ Extends defined rules with preset rules.
 
 Type: `String`
 
-Values: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"node-style-guide"`, `"wikimedia"`, `wordpress`, `"yandex"`
+Values: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"mozilla"`, `"node-style-guide"`, `"wikimedia"`, `wordpress`, `"yandex"`
 
 #### Example
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -718,6 +718,9 @@ Configuration.prototype.registerDefaultPresets = function() {
     // https://github.com/felixge/node-style-guide#nodejs-style-guide
     this.registerPreset('node-style-guide', require('../../presets/node-style-guide.json'));
 
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style#JavaScript_practices
+    this.registerPreset('mozilla', require('../../presets/mozilla.json'));
+
     // https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript
     this.registerPreset('wikimedia', require('../../presets/wikimedia.json'));
 

--- a/presets/mozilla.json
+++ b/presets/mozilla.json
@@ -1,0 +1,26 @@
+{
+    "validateIndentation": 2,
+    "validateLineBreaks": "LF",
+    "disallowTrailingWhitespace": true,
+    "requireLineFeedAtFileEnd": true,
+    "maximumLineLength": 80,
+    "disallowKeywordsOnNewLine": ["else"],
+    "requireAnonymousFunctions": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "requireSpaceBeforeObjectValues": true,
+    "requireSpacesInsideObjectBrackets": "all",
+    "requireCapitalizedConstructors": true,
+    "validateQuoteMarks": {
+         "mark": "\"",
+         "escape": true
+     },
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ]
+}

--- a/test/data/options/preset/mozilla.js
+++ b/test/data/options/preset/mozilla.js
@@ -1,0 +1,35 @@
+// Capitalized constructors.
+var foo = new Foo();
+
+// Use double quotes, except for escaping.
+var foo = "bar";
+var fooBar = "b'a'r";
+
+// Two space indentation
+if (true) {
+  console.log("winning");
+}
+
+// else should be on same line as closing brace
+if (true) {
+  console.log("winning");
+} else {
+  console.log("still winning");
+}
+
+// Objects should use spaces around braces
+var o = { a: "b" };
+
+// Braces required after keywords
+if (true) {
+}
+
+do {
+} while(true);
+
+for (;;) {
+}
+
+try {
+} catch(e) {
+}

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -218,6 +218,7 @@ describe('modules/config/configuration', function() {
             assert(configuration.hasPreset('grunt'));
             assert(configuration.hasPreset('node-style-guide'));
             assert(configuration.hasPreset('wordpress'));
+            assert(configuration.hasPreset('mozilla'));
         });
     });
 

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -391,6 +391,7 @@ describe('modules/string-checker', function() {
         testPreset('grunt');
         testPreset('jquery');
         testPreset('mdcs');
+        testPreset('mozilla');
         testPreset('node-style-guide');
         testPreset('wikimedia');
         testPreset('wordpress');


### PR DESCRIPTION
My first try at making a preset, hopefully not too bad. Is there any rule about the order of the rules in the preset? Alphabetic, some grouping, etc.

Style-guide: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Coding_Style

The Java part mentions `One declaration per line`. Should `requireMultipleVarDecl` be included?

It's mentioned that `case` that declares variables should have braces, but not others. Any rule fitting for that? In JS not so relevant, maybe (unless using `let`)?

K&R bracing style, any way to differentiate between class/function declarations and control structures? Like options to `requireNewlineBeforeBlockStatements`

> Break long conditions after `&&` and `||`

Any way to assert that?