### PR TITLE
disallowMultipleVarDecl: add exception for require statements

### DIFF
--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -1,13 +1,16 @@
 /**
  * Disallows multiple `var` declaration (except for-loop).
  *
- * Types: `Boolean` or `String`
+ * Types: `Boolean` or `Object`
  *
  * Values:
  *
  * - `true` disallows multiple variable declarations except within a for loop
- * - `'strict'` disallows all multiple variable declarations
- * - `'exceptUndefined'` allows declarations where all variables are not defined
+ * - `Object`:
+ *    - `'strict'` disallows all multiple variable declarations
+ *    - `'allExcept'` array of exceptions:
+ *       - `'undefined'` allows declarations where all variables are not defined
+ *       - `'required'` allows declarations where all variables are importing external modules with require
  *
  * #### Example
  *
@@ -24,17 +27,28 @@
  * for (var i = 0, j = arr.length; i < j; i++) {}
  * ```
  *
- * ##### Valid for `strict`
+ * ##### Valid for `{ strict: true }`
  *
  * ```js
  * var x = 1;
  * var y = 2;
  * ```
  *
- * ##### Valid for `exceptUndefined`
+ * ##### Valid for `{ allExcept: ['undefined'] }`
  *
  * ```js
  * var a, b;
+ * var x = 1;
+ * var y = 2;
+ *
+ * for (var i = 0, j = arr.length; i < j; i++) {}
+ * ```
+ * ##### Valid for `{ allExcept: ['require'] }`
+ *
+ * ```js
+ * var a = require('a'),
+ *     b = require('b');
+ *
  * var x = 1;
  * var y = 2;
  *
@@ -58,15 +72,34 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            options === true ||
-            options === 'strict' ||
-            options === 'exceptUndefined',
-            this.getOptionName() + ' option requires a true value, "strict", or "exceptUndefined"'
-        );
+        // support for legacy options
+        if (typeof options !== 'object') {
+            assert(
+                options === true ||
+                options === 'strict' ||
+                options === 'exceptUndefined',
+                this.getOptionName() +
+                    ' option requires a true value, "strict", "exceptUndefined", or an object'
+            );
 
-        this.strictMode = options === 'strict';
-        this.exceptUndefined = options === 'exceptUndefined';
+            var _options = {
+                strict: options === 'strict',
+                allExcept: []
+            };
+
+            if (options === 'exceptUndefined') {
+                _options.allExcept.push('undefined');
+            }
+
+            return this.configure(_options);
+        }
+
+        if (Array.isArray(options.allExcept)) {
+            this._exceptUndefined = options.allExcept.indexOf('undefined') > -1;
+            this._exceptRequire = options.allExcept.indexOf('require') > -1;
+        }
+
+        this._strictMode = options.strict === true;
     },
 
     getOptionName: function() {
@@ -74,24 +107,53 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var inStrictMode = this.strictMode;
-        var exceptUndefined = this.exceptUndefined;
+        var inStrictMode = this._strictMode;
+        var exceptUndefined = this._exceptUndefined;
+        var exceptRequire = this._exceptRequire;
 
         file.iterateNodesByType('VariableDeclaration', function(node) {
-            var hasDefinedVariables = node.declarations.some(function(declaration) {
+            var definedVariables = node.declarations.filter(function(declaration) {
                 return !!declaration.init;
             });
+            var hasDefinedVariables = definedVariables.length > 0;
+
+            var requireStatements = node.declarations.filter(function(declaration) {
+                var init = declaration.init;
+
+                return init &&
+                    init.callee &&
+                    init.callee.name === 'require';
+            });
+            var allRequireStatements = requireStatements.length === node.declarations.length;
 
             var isForStatement = node.parentNode.type === 'ForStatement';
 
             // allow single var declarations
-            if (node.declarations.length === 1 ||
-                // allow multiple var declarations in for statement unless we're in strict mode
-                // for (var i = 0, j = myArray.length; i < j; i++) {}
-                !inStrictMode && isForStatement ||
-                // allow multiple var declarations with all undefined variables in exceptUndefined mode
-                // var a, b, c
-                exceptUndefined && !hasDefinedVariables) {
+            if (node.declarations.length === 1) {
+                return;
+            }
+
+            // allow multiple var declarations in for statement unless we're in strict mode
+            // for (var i = 0, j = myArray.length; i < j; i++) {}
+            if (!inStrictMode && isForStatement) {
+                return;
+            }
+
+            // allow multiple var declarations with all undefined variables in exceptUndefined mode
+            // var a, b, c
+            if (exceptUndefined && !hasDefinedVariables) {
+                return;
+            }
+
+            // allow multiple var declaration with all require
+            // var a = require("a"), b = require("b")
+            if (exceptRequire && allRequireStatements) {
+                return;
+            }
+
+            // allow multiple var declarations only with require && undefined
+            // var a = require("a"), b = require("b"), x, y
+            if (exceptUndefined && exceptRequire && definedVariables.length === requireStatements.length) {
                 return;
             }
 

--- a/test/specs/rules/disallow-multiple-var-decl.js
+++ b/test/specs/rules/disallow-multiple-var-decl.js
@@ -79,4 +79,52 @@ describe('rules/disallow-multiple-var-decl', function() {
             assert(checker.checkString('var x, y = 2, z;').getErrorCount() === 1);
         });
     });
+
+    describe('exceptRequire', function() {
+        beforeEach(function() {
+            checker.configure({ disallowMultipleVarDecl: { allExcept: ['require'] } });
+        });
+        it('should not report multiple var decls with require', function() {
+            assert(checker.checkString('var first = require("first"), second = require("second");').isEmpty());
+        });
+        it('should report multiple var decls with require mixed with normal', function() {
+            assert.equal(1, checker.checkString('var first = require("first"), second = 1;').getErrorCount());
+        });
+        it('should report multiple var decls', function() {
+            assert.equal(1, checker.checkString('var x, y;').getErrorCount());
+        });
+        it('should not report consecutive var decls', function() {
+            assert(checker.checkString('var x; var y;').isEmpty());
+        });
+    });
+
+    describe('options as object', function() {
+        it('should accept undefined as allExcept value', function() {
+            checker.configure({ disallowMultipleVarDecl: { allExcept: ['undefined'] } });
+
+            assert(checker.checkString('var x, y;').isEmpty());
+        });
+        it('should accept require and undefined as allExcept value', function() {
+            checker.configure({ disallowMultipleVarDecl: { allExcept: ['undefined', 'require'] } });
+
+            assert(checker.checkString('var a = require("a"), b = require("b"), x, y, z;').isEmpty());
+            assert.equal(
+                1,
+                checker.checkString('var a = require("a"), b = require("b"), x, y, c = 1;').getErrorCount()
+            );
+        });
+        it('should accept strict as option', function() {
+            checker.configure({ disallowMultipleVarDecl: { strict: true } });
+
+            assert(!checker.checkString('for (var i = 0, j = arr.length; i < j; i++) {}').isEmpty());
+        });
+        it('should accept all options at the same time', function() {
+            checker.configure({ disallowMultipleVarDecl: { strict: true, allExcept: ['undefined', 'require'] } });
+
+            assert(!checker.checkString(
+                'var a = require("a"), b = require("b"), x, y;' +
+                'for (var i = 0, j = arr.length; i < j; i++) {}'
+            ).isEmpty());
+        });
+    });
 });


### PR DESCRIPTION
This PR adds a `exceptRequire` option for `disallowMultipleVarDecl` to allow multiple var declarations only when requiring external lib, tipically at the beginning of a nodejs module.