### PR TITLE
ensure options to path.resolve are strings

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -143,6 +143,7 @@ exports.getReporter = function(reporter, colors) {
     }
 
     if (reporter) {
+        // ensure reporter is a string (and allow non-string types to be coerced)
         reporter = reporter.toString();
         writerPath = path.resolve(process.cwd(), reporter);
 

--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -143,6 +143,7 @@ exports.getReporter = function(reporter, colors) {
     }
 
     if (reporter) {
+        reporter = reporter.toString();
         writerPath = path.resolve(process.cwd(), reporter);
 
         if (!fs.existsSync(writerPath)) {


### PR DESCRIPTION
This makes it even cleaner to provide a jscs reporter by passing in the reporter module itself, so long as it has a `toString` method that returns its path.

This also helps ensure that `path.resolve` doesn't throw a type error if given a non-string reporter.

This change is related to https://github.com/jscs-dev/grunt-jscs/commit/99b319892c38a4a5a915ec212dd336bb6581dbc7 and was requested by @markelog 