### PR TITLE
disallowMultipleSpaces: fixed configuration error message

### DIFF
--- a/lib/rules/disallow-multiple-spaces.js
+++ b/lib/rules/disallow-multiple-spaces.js
@@ -35,7 +35,7 @@ module.exports.prototype = {
             options === true ||
             typeof options === 'object' &&
             options.allowEOLComments === true,
-            'options option requires true value ' +
+            this.getOptionName() + ' option requires true value ' +
             'or an object with `allowEOLComments` property'
         );
 


### PR DESCRIPTION
Fixed wrong & confusing error message when `disallowMultipleSpaces` option has an invalid value.