### PR TITLE
Update mixup between rules in docstring example

### DIFF
--- a/lib/rules/disallow-padding-newlines-before-export.js
+++ b/lib/rules/disallow-padding-newlines-before-export.js
@@ -8,7 +8,7 @@
  * #### Example
  *
  * ```js
- * "requirePaddingNewLinesBeforeExport": true
+ * "disallowPaddingNewLinesBeforeExport": true
  * ```
  *
  * ##### Valid


### PR DESCRIPTION
`requirePaddingNewLinesBeforeExport` was mentioned instead of `disallowPaddingNewLinesBeforeExport`.