### PR TITLE
requireMultipleVarDecl: add exception for require statements

### DIFF
--- a/lib/rules/require-multiple-var-decl.js
+++ b/lib/rules/require-multiple-var-decl.js
@@ -23,6 +23,15 @@
  *     y = 2;
  * ```
  *
+ * ##### Valid for `exceptUndefined`
+ *
+ * ```js
+ * var a = require("a");
+ * var b = require("b");
+ * var c = 1,
+ *     d = 2;
+ * ```
+ *
  * ##### Invalid
  *
  * ```js
@@ -94,16 +103,59 @@ function onevar(file, errors) {
     });
 }
 
+function hasRequireStatements(node) {
+    if (!Array.isArray(node.declarations)) {
+        return false;
+    }
+
+    return node.declarations.some(function(declaration) {
+        var init = declaration.init;
+
+        return init &&
+            init.callee &&
+            init.callee.name === 'require';
+    });
+}
+
+function exceptRequire(file, errors) {
+    file.iterateNodesByType('VariableDeclaration', function(node) {
+        if (hasRequireStatements(node)) {
+            return;
+        }
+        var pos = node.parentCollection.indexOf(node);
+        if (pos < node.parentCollection.length - 1) {
+            var sibling = node.parentCollection[pos + 1];
+            if (hasRequireStatements(sibling)) {
+                return;
+            }
+            if (sibling.type === 'VariableDeclaration' && sibling.kind === node.kind) {
+                errors.add(
+                    node.kind[0].toUpperCase() + node.kind.slice(1) + ' declarations should be joined',
+                    sibling.loc.start
+                );
+            }
+        }
+    });
+}
+
 module.exports = function() {};
 
 module.exports.prototype = {
     configure: function(options) {
         assert(
-            options === true || options === 'onevar',
-            this.getOptionName() + ' option requires a true value or `onevar`'
+            options === true ||
+            options === 'onevar' ||
+            options === 'exceptRequire',
+            this.getOptionName() + ' option requires a true value, `onevar` or `exceptRequire`'
         );
 
-        this._check = typeof options === 'string' ? onevar : consecutive;
+        var checkers = {
+            true: consecutive,
+            onevar: onevar,
+            exceptRequire: exceptRequire
+        };
+
+        this._check = checkers[options];
     },
 
     getOptionName: function() {

--- a/test/specs/rules/require-multiple-var-decl.js
+++ b/test/specs/rules/require-multiple-var-decl.js
@@ -34,6 +34,36 @@ describe('rules/require-multiple-var-decl', function() {
         });
     });
 
+    describe('exceptRequire', function() {
+        var checker;
+        beforeEach(function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({ requireMultipleVarDecl: 'exceptRequire' });
+        });
+        it('should not report consecutive var decl if there is a require', function() {
+            assert(checker.checkString('var x; var y = require("a"); var z;').isEmpty());
+        });
+        it('should report consecutive var decl if there is a require and 2 consecutive vars', function() {
+            assert(checker.checkString('var x = require("b"); var y; var z;').getErrorCount() === 1);
+        });
+        it('should report consecutive var decl', function() {
+            assert(checker.checkString('var x; var y;').getErrorCount() === 1);
+        });
+        it('should not report multiple var decl', function() {
+            assert(checker.checkString('var x, y;').isEmpty());
+        });
+        it('should not report separated var decl', function() {
+            assert(checker.checkString('var x; x++; var y;').isEmpty());
+        });
+        it('supports var decl not contained by a parent with a `body` property (#916, #1163)', function() {
+            assert(checker.checkString('switch (1) { case 1: var x; }').isEmpty());
+        });
+        it('should report consecutive var decl not contained by a parent with a `body` property', function() {
+            assert(checker.checkString('switch (1) { case 1: var x; var y; }').getErrorCount() === 1);
+        });
+    });
+
     describe('onevar', function() {
         beforeEach(function() {
             checker = new Checker();


### PR DESCRIPTION
Issue #768

This add a `exceptRequire` option for `requireMultipleVarDecl` to allow multiple var declarations only when requiring external lib, tipically at the beginning of a nodejs module.

Related to https://github.com/jscs-dev/node-jscs/issues/768