### PR TITLE
New Rule: (require|disallow)PaddingNewlinesInFiles

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -640,6 +640,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-padding-newlines-before-line-comments'));
     this.registerRule(require('../rules/require-padding-newlines-before-line-comments'));
 
+    this.registerRule(require('../rules/require-padding-newlines-in-files'));
+
     this.registerRule(require('../rules/disallow-trailing-comma'));
     this.registerRule(require('../rules/require-trailing-comma'));
 

--- a/lib/rules/require-padding-newlines-in-files.js
+++ b/lib/rules/require-padding-newlines-in-files.js
@@ -1,0 +1,53 @@
+ /**
+ * Requires the file to start and/or end with a newline.
+ *
+ * Types: `Boolean` or `String`
+ *
+ * Values: `true`, `"beginningOfFileOnly"` or `"endOfFileOnly"`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requirePaddingNewlinesInFiles": true
+ * "requirePaddingNewlinesInFiles": "beginningOfFileOnly"
+ * "requirePaddingNewlinesInFiles": "endOfFileOnly"
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true || options === 'beginningOfFileOnly' || options === 'endOfFileOnly',
+            this.getOptionName() + ' option requires value to be `true`, `beginningOfFileOnly` or `endOfFileOnly`'
+        );
+
+        if (options === 'beginningOfFileOnly') {
+            this._atBOF = true;
+            this._atEOF = false;
+        } else if (options === 'endOfFileOnly') {
+            this._atBOF = false;
+            this._atEOF = true;
+        } else {
+            this._atBOF = true;
+            this._atEOF = true;
+        }
+    },
+
+    getOptionName: function() {
+        return 'requirePaddingNewlinesInFiles';
+    },
+
+    check: function(file, errors) {
+        if (this._atBOF && file.getLines()[0] !== '') {
+            errors.add('Missing padding new line at beginning of file', 1, 0);
+        }
+
+        if (this._atEOF && file.getLines()[file.getLines().length - 2] !== '') {
+            errors.add('Missing padding new line at end of file', 1, 0);
+        }
+    }
+};

--- a/lib/rules/require-padding-newlines-in-files.js
+++ b/lib/rules/require-padding-newlines-in-files.js
@@ -25,16 +25,8 @@ module.exports.prototype = {
             this.getOptionName() + ' option requires value to be `true`, `beginningOfFileOnly` or `endOfFileOnly`'
         );
 
-        if (options === 'beginningOfFileOnly') {
-            this._atBOF = true;
-            this._atEOF = false;
-        } else if (options === 'endOfFileOnly') {
-            this._atBOF = false;
-            this._atEOF = true;
-        } else {
-            this._atBOF = true;
-            this._atEOF = true;
-        }
+        this._atBOF = options === true || options === 'beginningOfFileOnly';
+        this._atEOF = options === true || options === 'endOfFileOnly';
     },
 
     getOptionName: function() {
@@ -42,12 +34,14 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        if (this._atBOF && file.getLines()[0] !== '') {
+        var lines = file.getLines();
+
+        if (this._atBOF && lines[0] !== '') {
             errors.add('Missing padding new line at beginning of file', 1, 0);
         }
 
-        if (this._atEOF && file.getLines()[file.getLines().length - 2] !== '') {
-            errors.add('Missing padding new line at end of file', 1, 0);
+        if (lines.length > 1 && this._atEOF && lines[lines.length - 2] !== '') {
+            errors.add('Missing padding new line at end of file', lines.length - 2, 0);
         }
     }
 };

--- a/test/specs/rules/require-padding-newlines-in-files.js
+++ b/test/specs/rules/require-padding-newlines-in-files.js
@@ -1,0 +1,46 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-padding-newlines-in-files', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    it('should report no padding new lines at file start and end', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: true });
+        assert(checker.checkString('var x;\n').getErrorCount() === 2);
+    });
+
+    it('should not report padding new lines at file start and end', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: true });
+        assert(checker.checkString('\nvar x;\n\n').isEmpty());
+    });
+
+    it('should report no padding new line at file start', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: 'beginningOfFileOnly' });
+        assert(checker.checkString('var x;').getErrorCount() === 1);
+        assert(checker.checkString('var x;\n').getErrorCount() === 1);
+        assert(checker.checkString('var x;\n\n').getErrorCount() === 1);
+    });
+
+    it('should not report padding new line at file start', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: 'beginningOfFileOnly' });
+        assert(checker.checkString('\nvar x;').isEmpty());
+        assert(checker.checkString('\nvar x;\n').isEmpty());
+        assert(checker.checkString('\nvar x;\n\n').isEmpty());
+    });
+
+    it('should report no padding new line at file end', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: 'endOfFileOnly' });
+        assert(checker.checkString('var x;\n').getErrorCount() === 1);
+        assert(checker.checkString('\nvar x;\n').getErrorCount() === 1);
+    });
+
+    it('should not report padding new line at file end', function() {
+        checker.configure({ requirePaddingNewlinesInFiles: 'endOfFileOnly' });
+        assert(checker.checkString('var x;\n\n').isEmpty());
+        assert(checker.checkString('\nvar x;\n\n').isEmpty());
+    });
+});


### PR DESCRIPTION
I am actually more interested in `disallowPaddingNewlinesInFiles` (to make sure there is no blank line at the top and bottom of the file, regardless of the EOF line feed) but I figured it would be nice to mirror and I started with the `require` rule.

I am not finished on the `disallow` rule, but since this is my first rule, any feedback will be helpful :-)

I am having a hard time interacting this with `requireLineFeedAtFileEnd`.
When `requireLineFeedAtFileEnd` and `requirePaddingNewlinesInFiles` are both specified, the file should end with 2 lines. Similarly, when `requireLineFeedAtFileEnd` and `disallowPaddingNewlinesInFiles`, the files must still end with an newline. Any idea how I could do that? Is it possible to know, from a `check()` method, if another rule (in that case, `requireLineFeedAtFileEnd`) is enabled?
