### PR TITLE
New Rules: (require|disallow)ParenthesesAroundArrowParam (ES6)

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -567,6 +567,11 @@ Configuration.prototype.registerDefaultRules = function() {
         These rules are linked explicitly to keep browser-version supported.
     */
 
+    /* ES6 only */
+    this.registerRule(require('../rules/require-parentheses-around-arrow-param'));
+    this.registerRule(require('../rules/disallow-parentheses-around-arrow-param'));
+    /* ES6 only (end) */
+
     this.registerRule(require('../rules/require-curly-braces'));
     this.registerRule(require('../rules/disallow-curly-braces'));
     this.registerRule(require('../rules/require-multiple-var-decl'));

--- a/lib/rules/disallow-parentheses-around-arrow-param.js
+++ b/lib/rules/disallow-parentheses-around-arrow-param.js
@@ -1,0 +1,70 @@
+/**
+ * Disallows parentheses around arrow function expressions with a single parameter.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowParenthesesAroundArrowParam": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * [1, 2, 3].map(x => x * x);
+ * // params are always required for multiple parameters
+ * [1, 2, 3].map((x, y, z) => x * x);
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * [1, 2, 3].map((x) => x * x);
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowParenthesesAroundArrowParam';
+    },
+
+    check: function(file, errors) {
+        function isWrapped(node) {
+            var openParensToken = file.getPrevToken(file.getFirstNodeToken(node));
+            var closingParensToken = file.getNextToken(file.getLastNodeToken(node));
+            var closingTokenValue = closingParensToken ? closingParensToken.value : '';
+
+            return openParensToken.value + closingTokenValue === '()';
+        }
+
+        file.iterateNodesByType('ArrowFunctionExpression', function(node) {
+            var params = node.params;
+            var firstParam = params[0];
+
+            if (params.length === 1 && isWrapped(firstParam)) {
+                errors.add(
+                    'Illegal wrap of arrow function expressions in parentheses',
+                    firstParam.loc.start
+                );
+            }
+        });
+    }
+
+};

--- a/lib/rules/require-parentheses-around-arrow-param.js
+++ b/lib/rules/require-parentheses-around-arrow-param.js
@@ -1,0 +1,70 @@
+/**
+ * Requires parentheses around arrow function expressions with a single parameter.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireParenthesesAroundArrowParam": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * [1, 2, 3].map((x) => x * x);
+ * // params are always required for multiple parameters
+ * [1, 2, 3].map((x, y, z) => x * x);
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * [1, 2, 3].map(x => x * x);
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireParenthesesAroundArrowParam';
+    },
+
+    check: function(file, errors) {
+        function isWrapped(node) {
+            var openParensToken = file.getPrevToken(file.getFirstNodeToken(node));
+            var closingParensToken = file.getNextToken(file.getLastNodeToken(node));
+            var closingTokenValue = closingParensToken ? closingParensToken.value : '';
+
+            return openParensToken.value + closingTokenValue === '()';
+        }
+
+        file.iterateNodesByType('ArrowFunctionExpression', function(node) {
+            var params = node.params;
+            var firstParam = params[0];
+
+            if (params.length === 1 && !isWrapped(firstParam)) {
+                errors.add(
+                    'Wrap arrow function expressions in parentheses',
+                    firstParam.loc.start
+                );
+            }
+        });
+    }
+
+};

--- a/test/specs/rules/disallow-parentheses-around-arrow-param.js
+++ b/test/specs/rules/disallow-parentheses-around-arrow-param.js
@@ -1,0 +1,24 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-parentheses-around-arrow-param', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ esnext: true, disallowParenthesesAroundArrowParam: true });
+    });
+
+    it('should not report an arrow function expression without parens', function() {
+        assert(checker.checkString('[1, 2].map(x => x * x);').isEmpty());
+    });
+
+    it('should report an arrow function expression with parens around a single parameter', function() {
+        assert(checker.checkString('[1, 2].map((x) => x * x);').getErrorCount() === 1);
+    });
+
+    it('should not report an arrow function expression with parens around multiple parameters', function() {
+        assert(checker.checkString('[1, 2].map((x, y) => x * x);').isEmpty());
+    });
+});

--- a/test/specs/rules/require-parentheses-around-arrow-param.js
+++ b/test/specs/rules/require-parentheses-around-arrow-param.js
@@ -1,0 +1,24 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-parentheses-around-arrow-param', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ esnext: true, requireParenthesesAroundArrowParam: true });
+    });
+
+    it('should report an arrow function expression without parens', function() {
+        assert(checker.checkString('[1, 2].map(x => x * x);').getErrorCount() === 1);
+    });
+
+    it('should not report an arrow function expression with parens around a single parameter', function() {
+        assert(checker.checkString('[1, 2].map((x) => x * x);').isEmpty());
+    });
+
+    it('should not report an arrow function expression with parens around multiple parameters', function() {
+        assert(checker.checkString('[1, 2].map((x, y) => x * x);').isEmpty());
+    });
+});


### PR DESCRIPTION
Require/disallow parentheses around arrow function expressions with a single parameter.

```
// disallow
[1, 2, 3].map(x => x * x);
// require
[1, 2, 3].map((x) => x * x);
```

Fixes #1307.

~~Going to add the `disallow` rule after some feedback.~~

I just copied the `isWrapped` function from the `requireParenthesesAroundIIFE` rule.

~~I wasn't sure about the es6 test - so I did `file.getDialect() !== 'es6'` based on what @mikesherov said - I don't think we have any rules like this yet?~~

Also I used `ArrowFunctionExpression` since `ArrowExpression` didn't work - where should I be looking to know what to use (normally I can just find the jscs codebase). In the `validateIndentation` rule I see `ArrowExpression`.