### PR TITLE
requirePaddingNewLinesAfterBlocks: fixing blocks that end with semicolon

### DIFF
--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -173,14 +173,14 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('BlockStatement', function(node) {
 
-            var closingBracket = file.getLastNodeToken(node);
+            var endToken = file.getLastNodeToken(node);
             var parentNode = node.parentNode;
 
             if (isException(parentNode)) {
                 return;
             }
 
-            var nextToken = file.getNextToken(closingBracket);
+            var nextToken = file.getNextToken(endToken);
 
             while (nextToken.type !== 'EOF') {
                 var excludeValues = excludes[parentNode.type];
@@ -188,7 +188,8 @@ module.exports.prototype = {
                     return;
                 }
 
-                if (closingBracket.loc.end.line === nextToken.loc.start.line) {
+                if (endToken.loc.end.line === nextToken.loc.start.line) {
+                    endToken = nextToken;
                     nextToken = file.getNextToken(nextToken);
                     continue;
                 }
@@ -198,7 +199,7 @@ module.exports.prototype = {
                 }
 
                 errors.assert.linesBetween({
-                    token: closingBracket,
+                    token: endToken,
                     nextToken: nextToken,
                     atLeast: 2,
                     message: 'Missing newline after block'

--- a/test/specs/rules/require-padding-newlines-after-blocks.js
+++ b/test/specs/rules/require-padding-newlines-after-blocks.js
@@ -1,5 +1,6 @@
-var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-padding-newlines-after-blocks', function() {
     var checker;
@@ -48,26 +49,44 @@ describe('rules/require-padding-newlines-after-blocks', function() {
     });
 
     describe('value true', function() {
+        var rules = { requirePaddingNewLinesAfterBlocks: true };
         beforeEach(function() {
-            checker.configure({ requirePaddingNewLinesAfterBlocks: true });
+            checker.configure(rules);
         });
 
-        it('should report missing padding after block', function() {
-            assert(checker.checkString('if(true){}\nvar a = 2;').getErrorCount() === 1);
+        reportAndFix({
+            name: 'missing padding after block',
+            rules: rules,
+            input: 'if(true){}\nvar a = 2;',
+            output: 'if(true){}\n\nvar a = 2;'
         });
 
-        it('should report missing padding after nested block', function() {
-            assert(checker.checkString('if(true){\nif(true) {}\nvar a = 2;}').getErrorCount() === 1);
+        reportAndFix({
+            name: 'after function definitions',
+            rules: rules,
+            input: 'var a = function() {\n};\nvar b = 2;',
+            output: 'var a = function() {\n};\n\nvar b = 2;'
         });
 
-        it('should report missing padding after obj func definition', function() {
-            assert(checker.checkString(
-                'var a = {\nfoo: function() {\n},\nbar: function() {\n}}'
-            ).getErrorCount() === 1);
+        reportAndFix({
+            name: 'missing padding after nested block',
+            rules: rules,
+            input: 'if(true){\nif(true) {}\nvar a = 2;}',
+            output: 'if(true){\nif(true) {}\n\nvar a = 2;}'
         });
 
-        it('should report missing padding after immed func', function() {
-            assert(checker.checkString('(function(){\n})()\nvar a = 2;').getErrorCount() === 1);
+        reportAndFix({
+            name: 'missing padding after obj func definition',
+            rules: rules,
+            input: 'var a = {\nfoo: function() {\n},\nbar: function() {\n}}',
+            output: 'var a = {\nfoo: function() {\n},\n\nbar: function() {\n}}'
+        });
+
+        reportAndFix({
+            name: 'missing padding after immed func',
+            rules: rules,
+            input: '(function(){\n})()\nvar a = 2;',
+            output: '(function(){\n})()\n\nvar a = 2;'
         });
 
         it('should not report end of file', function() {
@@ -134,11 +153,11 @@ describe('rules/require-padding-newlines-after-blocks', function() {
             assert(checker.checkString('func(\n2,\n3,\nfunction() {\n}\n)').getErrorCount() === 1);
         });
 
-        it('should not report missing padding when function is last in array', function() {
+        it('should report missing padding when function is last in array', function() {
             assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').getErrorCount() === 1);
         });
 
-        it('should not report missing padding when function is middle in array', function() {
+        it('should report missing padding when function is middle in array', function() {
             assert(checker.checkString('[\n3,\nfunction() {\n},\n2\n]').getErrorCount() === 1);
         });
     });


### PR DESCRIPTION
Currently,

```javascript
var a = function() {
};
var b = 2;
```

reports a missing blank line between the function and var b, but it won't be autofixed. This PR fixes it. I believe this is patch release worthy.