### PR TITLE
Preset: update jquery and dependant presets

### DIFF
--- a/presets/jquery.json
+++ b/presets/jquery.json
@@ -45,7 +45,8 @@
         "catch"
     ],
     "requireSpacesInsideObjectBrackets": "all",
-    "requireSpacesInsideArrayBrackets": "all",
+    "requireSpacesInsideBrackets": true,
+    "requireSemicolons": true,
     "requireSpacesInConditionalExpression": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireLineFeedAtFileEnd": true,

--- a/presets/mdcs.json
+++ b/presets/mdcs.json
@@ -6,7 +6,9 @@
     },
     "requirePaddingNewlinesInBlocks": true,
     "requireSpacesInsideObjectBrackets": "all",
-    "requireSpacesInsideArrayBrackets": "allButNested",
+    "requireSpacesInsideBrackets": {
+        "allExcept": [ "[", "]" ]
+    },
     "requireSpaceBeforeBlockStatements": true,
     "requireSpacesInForStatement": true,
     "disallowKeywords": [ "with" ],

--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -24,7 +24,7 @@
     "requireBlocksOnNewline": 1,
     "disallowEmptyBlocks": true,
     "requireSpacesInsideObjectBrackets": "all",
-    "requireSpacesInsideArrayBrackets": "all",
+    "requireSpacesInsideBrackets": true,
     "requireSpacesInsideParentheses": "all",
     "disallowQuotedKeysInObjects": "allButReserved",
     "disallowDanglingUnderscores": true,

--- a/presets/wordpress.json
+++ b/presets/wordpress.json
@@ -4,6 +4,7 @@
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "maximumLineLength": null,
     "requireSpaceAfterPrefixUnaryOperators": ["!"],
+    "requireSpacesInsideBrackets": null,
     "requireSpacesInsideParentheses": {
         "all": true,
         "except": [ "{", "}", "[", "]", "function" ]


### PR DESCRIPTION
Fixes #985

/cc @Krinkle, @gero3, @paulschreiber

-- 
@paulschreiber in order to implement 
```js
// Exceptions:
// For consistency with our PHP standards, do not include a space around
// string literals or integers used as key values in array notation:
prop = object['default'];
firstArrayElement = arr[0];
```

style, we need to add new value for `requireSpacesInsideBrackets`, please ping us up if you are interested.