### PR TITLE
New Rule: (disallow|require)ObjectKeysOnNewLine

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -599,6 +599,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/validate-indentation'));
     this.registerRule(require('../rules/disallow-trailing-whitespace'));
     this.registerRule(require('../rules/disallow-mixed-spaces-and-tabs'));
+    this.registerRule(require('../rules/require-object-keys-on-new-line'));
+    this.registerRule(require('../rules/disallow-object-keys-on-new-line'));
     this.registerRule(require('../rules/require-keywords-on-new-line'));
     this.registerRule(require('../rules/disallow-keywords-on-new-line'));
     this.registerRule(require('../rules/require-line-feed-at-file-end'));

--- a/lib/rules/disallow-object-keys-on-new-line.js
+++ b/lib/rules/disallow-object-keys-on-new-line.js
@@ -1,0 +1,64 @@
+/**
+ * Disallows placing object keys on new line
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowObjectKeysOnNewLine": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b', c: 'c'
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b',
+ *     c: 'c'
+ * };
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowObjectKeysOnNewLine';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            for (var i = 1; i < node.properties.length; i++) {
+                var lastValueToken = file.getLastNodeToken(node.properties[i - 1].value);
+                var comma = file.findNextToken(lastValueToken, 'Punctuator', ',');
+
+                var firstKeyToken = file.getFirstNodeToken(node.properties[i].key);
+
+                errors.assert.sameLine({
+                    token: comma,
+                    nextToken: firstKeyToken,
+                    message: 'Object keys must go on a new line'
+                });
+            }
+        });
+    }
+};

--- a/lib/rules/require-object-keys-on-new-line.js
+++ b/lib/rules/require-object-keys-on-new-line.js
@@ -1,0 +1,64 @@
+/**
+ * Requires placing object keys on new line
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireObjectKeysOnNewLine": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b',
+ *     c: 'c'
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b', c: 'c'
+ * };
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireObjectKeysOnNewLine';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            for (var i = 1; i < node.properties.length; i++) {
+                var lastValueToken = file.getLastNodeToken(node.properties[i - 1].value);
+                var comma = file.findNextToken(lastValueToken, 'Punctuator', ',');
+
+                var firstKeyToken = file.getFirstNodeToken(node.properties[i].key);
+
+                errors.assert.differentLine({
+                    token: comma,
+                    nextToken: firstKeyToken,
+                    message: 'Object keys must go on a new line'
+                });
+            }
+        });
+    }
+};

--- a/test/specs/rules/disallow-object-keys-on-new-line.js
+++ b/test/specs/rules/disallow-object-keys-on-new-line.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
+
+describe('rules/disallow-object-keys-on-new-line', function() {
+    var rules = { disallowObjectKeysOnNewLine: true };
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+    });
+
+    reportAndFix({
+        name: 'object assignment with missing padding',
+        rules: rules,
+        input: 'var a = {foo: "bar",\nbar: "baz"}',
+        output: 'var a = {foo: "bar", bar: "baz"}'
+    });
+
+    reportAndFix({
+        name: 'function argument with missing padding',
+        rules: rules,
+        input: 'foo({foo: "bar",\nbar: "baz"})',
+        output: 'foo({foo: "bar", bar: "baz"})'
+    });
+
+    it('should not report object without padding', function() {
+        assert(checker.checkString('var a = {foo: "bar", bar: "baz"}').isEmpty());
+    });
+
+    it('should not report argument without padding', function() {
+        assert(checker.checkString('foo({foo: "bar", bar: "baz"})').isEmpty());
+    });
+
+    it('should not report object with one key', function() {
+        assert(checker.checkString('var a = {a: "b"};').isEmpty());
+    });
+});

--- a/test/specs/rules/require-object-declarations-on-new-line.js
+++ b/test/specs/rules/require-object-declarations-on-new-line.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
+
+describe('rules/require-object-keys-on-new-line', function() {
+    var rules = { requireObjectKeysOnNewLine: true };
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+    });
+
+    reportAndFix({
+        name: 'object assignment with missing padding',
+        rules: rules,
+        input: 'var a = {foo: "bar",bar: "baz"}',
+        output: 'var a = {foo: "bar",\nbar: "baz"}'
+    });
+
+    reportAndFix({
+        name: 'function argument with missing padding',
+        rules: rules,
+        input: 'foo({foo: "bar", bar: "baz"})',
+        output: 'foo({foo: "bar",\n bar: "baz"})'
+    });
+
+    it('should not report object with padding', function() {
+        assert(checker.checkString('var a = {foo: "bar",\nbar: "baz"}').isEmpty());
+    });
+
+    it('should not report argument with padding', function() {
+        assert(checker.checkString('foo({foo: "bar",\nbar: "baz"})').isEmpty());
+    });
+
+    it('should not report object with one key', function() {
+        assert(checker.checkString('var a = {a: "b"};').isEmpty());
+    });
+});


### PR DESCRIPTION
Fixes #1249 