### PR TITLE
(disallow|require)SpaceAfterObjectKeys: check object method shorthand (ES6)

### DIFF
--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -52,7 +52,7 @@ module.exports.prototype = {
         var mode = this._mode;
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                if (property.shorthand || property.method || property.kind !== 'init') {
+                if (property.shorthand || property.kind !== 'init') {
                     return;
                 }
                 if (mode === 'ignoreSingleLine' && node.loc.start.line === node.loc.end.line) {

--- a/lib/rules/require-space-after-object-keys.js
+++ b/lib/rules/require-space-after-object-keys.js
@@ -41,7 +41,7 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                if (property.shorthand || property.method || property.kind !== 'init') {
+                if (property.shorthand || property.kind !== 'init') {
                     return;
                 }
 

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -81,13 +81,24 @@ describe('rules/disallow-space-after-object-keys', function() {
         });
     });
 
-    it('should not report es6-methods. #1013', function() {
-        checker.configure({ esnext: true });
-        assert(checker.checkString('var x = { a() { } };').isEmpty());
-    });
-
     it('should not report es5 getters/setters #1037', function() {
+        checker.configure({ disallowSpaceAfterObjectKeys: true });
         assert(checker.checkString('var x = { get a() { } };').isEmpty());
         assert(checker.checkString('var x = { set a(val) { } };').isEmpty());
+    });
+
+    describe('es6', function() {
+        beforeEach(function() {
+            checker.configure({ esnext: true, disallowSpaceAfterObjectKeys: true });
+        });
+
+        it('should not report es6-methods without a space. #1013', function() {
+            assert(checker.checkString('var x = { a() { } };').isEmpty());
+        });
+
+        it('should report es6-methods with a space. #1013', function() {
+            assert(checker.checkString('var x = { a () { } };').getErrorCount() === 1);
+        });
+
     });
 });

--- a/test/specs/rules/require-space-after-object-keys.js
+++ b/test/specs/rules/require-space-after-object-keys.js
@@ -25,18 +25,28 @@ describe('rules/require-space-after-object-keys', function() {
         assert(checker.checkString('var x = {a, b};').isEmpty());
     });
 
-    it('should report mixed shorthand and normal object propertis', function() {
+    it('should report mixed shorthand and normal object properties', function() {
         checker.configure({ esnext: true });
         assert.equal(checker.checkString('var x = { a:1, b };').getErrorCount(), 1);
-    });
-
-    it('should not report es6-methods. #1013', function() {
-        checker.configure({ esnext: true });
-        assert(checker.checkString('var x = { a() { } };').isEmpty());
     });
 
     it('should not report es5 getters/setters #1037', function() {
         assert(checker.checkString('var x = { get a() { } };').isEmpty());
         assert(checker.checkString('var x = { set a(val) { } };').isEmpty());
     });
+
+    describe('es6', function() {
+        beforeEach(function() {
+            checker.configure({ esnext: true });
+        });
+
+        it('should report es6-methods without a space. #1013', function() {
+            assert(checker.checkString('var x = { a() { } };').getErrorCount() === 1);
+        });
+
+        it('should not report es6-methods with a space. #1013', function() {
+            assert(checker.checkString('var x = { a () { } };').isEmpty());
+        });
+    });
+
 });


### PR DESCRIPTION
Fixes #1365.

Not sure if this is right?