### PR TITLE
(disallow|require)SpacesInFunctionDeclaration: check export default f…

### DIFF
--- a/lib/rules/disallow-spaces-in-function-declaration.js
+++ b/lib/rules/disallow-spaces-in-function-declaration.js
@@ -75,6 +75,10 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionDeclaration'], function(node) {
+            // Exception for `export default function` #1376
+            if (!node.id) {
+                return;
+            }
 
             if (beforeOpeningRoundBrace) {
                 var functionToken = file.getFirstNodeToken(node.id);

--- a/lib/rules/require-spaces-in-function-declaration.js
+++ b/lib/rules/require-spaces-in-function-declaration.js
@@ -75,6 +75,10 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionDeclaration'], function(node) {
+            // Exception for `export default function` #1376
+            if (!node.id) {
+                return;
+            }
 
             if (beforeOpeningRoundBrace) {
                 // for a named function, use node.id

--- a/test/specs/rules/disallow-spaces-in-function-declaration.js
+++ b/test/specs/rules/disallow-spaces-in-function-declaration.js
@@ -21,6 +21,10 @@ describe('rules/disallow-spaces-in-function-declaration', function() {
             assert(checker.checkString('function abc (){}').getErrorCount() === 1);
         });
 
+        it('should not report missing space before round brace in export default function', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('export default function(){}').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -36,8 +40,9 @@ describe('rules/disallow-spaces-in-function-declaration', function() {
             assert(checker.checkString('function abc() {}').getErrorCount() === 1);
         });
 
-        it('should not report missing space before round brace without option', function() {
-            assert(checker.checkString('function abc (){}').isEmpty());
+        it('should not report missing space before curly brace in export default function', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('export default function(){}').isEmpty());
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-function-declaration.js
+++ b/test/specs/rules/require-spaces-in-function-declaration.js
@@ -21,6 +21,10 @@ describe('rules/require-spaces-in-function-declaration', function() {
             assert(checker.checkString('function abc (){}').isEmpty());
         });
 
+        it('should not report space before round brace in export default function', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('export default function (){}').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -36,8 +40,9 @@ describe('rules/require-spaces-in-function-declaration', function() {
             assert(checker.checkString('function abc() {}').isEmpty());
         });
 
-        it('should not report missing space before round brace without option', function() {
-            assert(checker.checkString('function abc() {}').isEmpty());
+        it('should not report space before curly brace in export default function', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('export default function() {}').isEmpty());
         });
     });
 });


### PR DESCRIPTION
…unction

WIP? If we don't want to do this now that's cool since it's before it's needed.

Basically `export default function() {}` is a `FunctionExpression` right now but when we update `esprima` it's going to be `FunctionDeclaration`. After this I think I can push `babel-jscs`?

So thus it would have no `node.id` and should be skipped in this rule.

I commented out some test's since they won't pass without updating `esprima` at the moment. Or we could just remove them.

For #1376