### PR TITLE
requireSpaceBeforeBlockStatements: Fix doc

### DIFF
--- a/lib/rules/require-space-before-block-statements.js
+++ b/lib/rules/require-space-before-block-statements.js
@@ -5,7 +5,7 @@
  *
  * Values:
  *
- * - `true` require a single space
+ * - `true` require *at least* a single space
  * - `Integer` require *at least* specified number of spaces
  *
  * #### Example


### PR DESCRIPTION
`true` does not assert exactly a single space, but at least a single space – just as `1` does.
