### PR TITLE
(require|disallow)SpacesIn(Function|FunctionExpression): support clas…

### DIFF
--- a/lib/rules/disallow-spaces-in-function-expression.js
+++ b/lib/rules/disallow-spaces-in-function-expression.js
@@ -89,7 +89,14 @@ module.exports.prototype = {
 
             if (beforeOpeningRoundBrace) {
                 // for a named function, use node.id
-                var functionToken = file.getFirstNodeToken(node.id || node);
+                var functionNode = node.id || node;
+
+                // for a class method
+                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
+                    functionNode = parent.key;
+                }
+
+                var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.noWhitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/lib/rules/disallow-spaces-in-function.js
+++ b/lib/rules/disallow-spaces-in-function.js
@@ -95,7 +95,14 @@ module.exports.prototype = {
 
             if (beforeOpeningRoundBrace) {
                 // for a named function, use node.id
-                var functionToken = file.getFirstNodeToken(node.id || node);
+                var functionNode = node.id || node;
+
+                // for a class method
+                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
+                    functionNode = parent.key;
+                }
+
+                var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.noWhitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/lib/rules/require-spaces-in-function-expression.js
+++ b/lib/rules/require-spaces-in-function-expression.js
@@ -89,7 +89,14 @@ module.exports.prototype = {
 
             if (beforeOpeningRoundBrace) {
                 // for a named function, use node.id
-                var functionToken = file.getFirstNodeToken(node.id || node);
+                var functionNode = node.id || node;
+
+                // for a class method
+                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
+                    functionNode = parent.key;
+                }
+
+                var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.whitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/lib/rules/require-spaces-in-function.js
+++ b/lib/rules/require-spaces-in-function.js
@@ -95,7 +95,14 @@ module.exports.prototype = {
 
             if (beforeOpeningRoundBrace) {
                 // for a named function, use node.id
-                var functionToken = file.getFirstNodeToken(node.id || node);
+                var functionNode = node.id || node;
+
+                // for a class method
+                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
+                    functionNode = parent.key;
+                }
+
+                var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.whitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/test/specs/rules/disallow-spaces-in-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-function-expression.js
@@ -48,6 +48,16 @@ describe('rules/disallow-spaces-in-function-expression', function() {
         it('should not report missing space before round brace in setter expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should report space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render () { return 1; } };').getErrorCount() === 1);
+        });
+
+        it('should not report missing space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render() { return 1; } };').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {

--- a/test/specs/rules/disallow-spaces-in-function.js
+++ b/test/specs/rules/disallow-spaces-in-function.js
@@ -52,6 +52,16 @@ describe('rules/disallow-spaces-in-function', function() {
         it('should not report missing space before round brace in setter', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should report space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render () { return 1; } };').getErrorCount() === 1);
+        });
+
+        it('should not report missing space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render() { return 1; } };').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {

--- a/test/specs/rules/require-spaces-in-function-expression.js
+++ b/test/specs/rules/require-spaces-in-function-expression.js
@@ -48,6 +48,16 @@ describe('rules/require-spaces-in-function-expression', function() {
         it('should not report missing space before round brace in setter expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should not report space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render () { return 1; } };').isEmpty());
+        });
+
+        it('should report missing space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render() { return 1; } };').getErrorCount() === 1);
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {

--- a/test/specs/rules/require-spaces-in-function.js
+++ b/test/specs/rules/require-spaces-in-function.js
@@ -52,6 +52,16 @@ describe('rules/require-spaces-in-function', function() {
         it('should not report missing space before round brace in setter', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should not report space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render () { return 1; } };').isEmpty());
+        });
+
+        it('should report missing space before round brace in class method', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('const Component = class { render() { return 1; } };').getErrorCount() === 1);
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {


### PR DESCRIPTION
…s methods (ES6)

Fixes #1066.

```js
Component = class {
  render() { return <div />; }
------------^
```

Issue was that it wasn't checking `render` and `(` spacing but `{` and `return` or `)` and `{`.