### PR TITLE
New Rule: disallowNodeTypes

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -719,6 +719,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/require-spaces-in-for-statement'));
     this.registerRule(require('../rules/disallow-spaces-in-for-statement'));
 
+    this.registerRule(require('../rules/disallow-node-types'));
+
     this.registerRule(require('../rules/disallow-keywords-in-comments'));
 
     this.registerRule(require('../rules/disallow-identifier-names'));

--- a/lib/rules/disallow-node-types.js
+++ b/lib/rules/disallow-node-types.js
@@ -1,0 +1,64 @@
+/**
+ * Disallow use of certain node types (from Esprima/ESTree).
+ * Esprima node types
+ *  - [list](https://github.com/jquery/esprima/blob/758196a1c5dd20c3ead6300283a1112428bc7045/esprima.js#L108-L169)
+ *
+ * Type: `Array`
+ *
+ * Value: Array of parser node types to be disallowed.
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowNodeTypes": ['LabeledStatement']
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * // use of an allowed node type
+ * var a = 1;
+ * // shorthand form of arrow function that returns an object
+ * var f = () => ({ a: 1 });
+ * ```
+ *
+ * ##### Invalid
+ * // label statement with loop
+ * loop1:
+ * for (i = 0; i < 10; i++) {
+ *     if (i === 3) {
+ *         break loop1;
+ *     }
+ * }
+ * // accidental label statement with arrow function
+ * var f = () => { a: 1 };
+ * ```js
+ * { a: 1 }
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(nodeTypes) {
+        assert(
+            Array.isArray(nodeTypes),
+            'disallowIdentifierNames option requires an array'
+        );
+
+        this._nodeTypes = nodeTypes;
+    },
+
+    getOptionName: function() {
+        return 'disallowNodeTypes';
+    },
+
+    check: function(file, errors) {
+        var disallowedNodeTypes = this._nodeTypes;
+        file.iterateNodesByType(disallowedNodeTypes, function(node) {
+            errors.add('Illegal use of disallowed node type: ' + node.type, node.loc.start);
+        });
+    }
+};

--- a/test/specs/rules/disallow-node-types.js
+++ b/test/specs/rules/disallow-node-types.js
@@ -1,0 +1,41 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-node-types', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+
+        checker.configure({
+            disallowNodeTypes: ['LabeledStatement', 'DebuggerStatement', 'DoWhileStatement'],
+            esnext: true
+        });
+    });
+
+    it('should report on use of LabeledStatement', function() {
+        assert(checker.checkString('var f = () => { a: 1 };').getErrorCount() === 1);
+        assert(checker.checkString([
+            'loop1:',
+            'for (i = 0; i < 10; i++) {',
+                'if (i === 3) {',
+                    'break loop1;',
+                '}',
+            '}'
+        ].join('\n')).getErrorCount() === 1);
+    });
+
+    it('should report on use of DebuggerStatement', function() {
+        assert(checker.checkString('debugger;').getErrorCount() === 1);
+    });
+
+    it('should report on use of DoWhileStatement', function() {
+        assert(checker.checkString('do keep(); while (true)').getErrorCount() === 1);
+    });
+
+    it('should report on use of another statement', function() {
+        assert(checker.checkString('var a = { a: 1 };').isEmpty());
+        assert(checker.checkString('var f = () => ({ a: 1 });').isEmpty());
+    });
+});


### PR DESCRIPTION
Fixes #1389 

Need some help here.

Esprima node types: https://github.com/jquery/esprima/blob/758196a1c5dd20c3ead6300283a1112428bc7045/esprima.js#L108-L169

Acorn/babel node types:
https://github.com/babel/babel/blob/65a44a1e131c8bc336b218991bae7548176de283/src/babel/types/alias-keys.json#L2-L121

Espree node types: https://github.com/eslint/espree/blob/a23b65db10648daf7d4b0761b0ce09eea864550a/lib/ast-node-types.js#L41-L115

Do we want to check if the node types given in the array are supported by the parser or just let it error?