### PR TITLE
Fix quote at overview documentation

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -170,7 +170,7 @@ Extends defined rules with preset rules.
 
 Type: `String`
 
-Values: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"node-style-guide"`, `"wikimedia"`, `wordpress`, `"yandex"`
+Values: `"airbnb"`, `"crockford"`, `"google"`, `"jquery"`, `"mdcs"`, `"node-style-guide"`, `"wikimedia"`, `"wordpress"`, `"yandex"`
 
 #### Example
 


### PR DESCRIPTION
Hi, I discovered the error of the document.

![2015-05-22 22 07 17](https://cloud.githubusercontent.com/assets/221802/7771022/1b2537fe-00cf-11e5-8c4e-087d3e5e7e25.png)
