### PR TITLE
Reporters: make inline and inlinesingle machine readable

### DIFF
--- a/lib/reporters/inline.js
+++ b/lib/reporters/inline.js
@@ -1,9 +1,11 @@
 var util = require('util');
+
 /**
  * @param {Errors[]} errorsCollection
  */
 module.exports = function(errorsCollection) {
     var errorCount = 0;
+
     /**
      * Formatting every error set.
      */
@@ -12,7 +14,7 @@ module.exports = function(errorsCollection) {
         if (!errors.isEmpty()) {
             errors.getErrorList().forEach(function(error) {
                 errorCount++;
-                console.log(util.format('%s: line %d, col %d, %s', file, error.line, error.column, error.message));
+                console.log(util.format('%s:%d:%d: %s', file, error.line, error.column, error.message));
             });
         }
     });

--- a/lib/reporters/inlinesingle.js
+++ b/lib/reporters/inlinesingle.js
@@ -16,7 +16,7 @@ module.exports = function(errorsCollection) {
         if (!errors.isEmpty()) {
             var file = errors.getFilename();
             var out = errors.getErrorList().map(function(error) {
-                return util.format('%s: line %d, col %d, %s', file, error.line, error.column, error.message);
+                return util.format('%s:%d:%d: %s', file, error.line, error.column, error.message);
             });
             console.log(out.join('\n'));
         }

--- a/test/specs/reporters/inline.js
+++ b/test/specs/reporters/inline.js
@@ -28,15 +28,15 @@ describe('reporters/inline', function() {
     it('should correctly reports 1 error', function() {
         inline([checker.checkString('with (x) {}')]);
 
-        assert.equal(console.log.getCall(0).args[0], 'input: line 1, col 0, Illegal keyword: with');
+        assert.equal(console.log.getCall(0).args[0], 'input:1:0: Illegal keyword: with');
         assert(console.log.calledOnce);
     });
 
     it('should correctly reports 2 errors', function() {
         inline([checker.checkString('with (x) {} with (x) {}')]);
 
-        assert.equal(console.log.getCall(0).args[0], 'input: line 1, col 0, Illegal keyword: with');
-        assert.equal(console.log.getCall(1).args[0], 'input: line 1, col 12, Illegal keyword: with');
+        assert.equal(console.log.getCall(0).args[0], 'input:1:0: Illegal keyword: with');
+        assert.equal(console.log.getCall(1).args[0], 'input:1:12: Illegal keyword: with');
         assert(console.log.calledTwice);
     });
 });

--- a/test/specs/reporters/inlinesingle.js
+++ b/test/specs/reporters/inlinesingle.js
@@ -28,7 +28,7 @@ describe('reporters/inlinesingle', function() {
     it('should correctly reports 1 error', function() {
         inlinesingle([checker.checkString('with (x) {}')]);
 
-        assert.equal(console.log.getCall(0).args[0], 'input: line 1, col 0, Illegal keyword: with');
+        assert.equal(console.log.getCall(0).args[0], 'input:1:0: Illegal keyword: with');
         assert(console.log.calledOnce);
     });
 
@@ -37,7 +37,7 @@ describe('reporters/inlinesingle', function() {
 
         assert.equal(
             console.log.getCall(0).args[0],
-            'input: line 1, col 0, Illegal keyword: with\ninput: line 1, col 12, Illegal keyword: with'
+            'input:1:0: Illegal keyword: with\ninput:1:12: Illegal keyword: with'
         );
         assert(console.log.calledOnce);
     });


### PR DESCRIPTION
Changes the formatting of the reporters `inline` and `inlinesingle`
from

	file.js: line 7, col 7, Unexpected token {

to

	file.js:7:7: Unexpected token {

which is much like the output from other compilers and preprocessors.

The benefit is integration with existing tools that parse similar
output.  For example Emacs allows navigation by these “hyperlinks”
through the rules in `compilation-error-regexp-alist`.  Other
editors, like acme, lets you right-click on such tokens to jump to
the file, line, and column.

**Please let me know if you’d rather see this implemented as a separate, new reporter.  Unless there are any backwards compatibility concerns, I do however think that this approach is uncontroversial.**