### PR TITLE
Reporters: add new machine readable unix-style reporter

### DIFF
--- a/bin/jscs
+++ b/bin/jscs
@@ -25,7 +25,7 @@ program
     .option('-v, --verbose', 'adds rule names to the error output')
     .option('-m, --max-errors <number>', 'maximum number of errors to report')
     .option('-f, --error-filter <path>', 'a module to filter errors')
-    .option('-r, --reporter <reporter>', 'error reporter, console - default, text, checkstyle, junit, inline')
+    .option('-r, --reporter <reporter>', 'error reporter, console - default, text, checkstyle, junit, inline, unix')
     .option('', 'Also accepts relative or absolute path to custom reporter')
     .option('', 'For instance:')
     .option('', '\t  ../some-dir/my-reporter.js\t(relative path with extension)')

--- a/lib/reporters/unix.js
+++ b/lib/reporters/unix.js
@@ -4,13 +4,10 @@ var util = require('util');
  * @param {Errors[]} errorsCollection
  */
 module.exports = function(errorsCollection) {
-    var errorCount = 0;
-
     errorsCollection.forEach(function(errors) {
         var file = errors.getFilename();
         if (!errors.isEmpty()) {
             errors.getErrorList().forEach(function(error) {
-                errorCount++;
                 console.log(util.format('%s:%d:%d: %s', file, error.line, error.column, error.message));
             });
         }

--- a/lib/reporters/unix.js
+++ b/lib/reporters/unix.js
@@ -1,0 +1,18 @@
+var util = require('util');
+
+/**
+ * @param {Errors[]} errorsCollection
+ */
+module.exports = function(errorsCollection) {
+    var errorCount = 0;
+
+    errorsCollection.forEach(function(errors) {
+        var file = errors.getFilename();
+        if (!errors.isEmpty()) {
+            errors.getErrorList().forEach(function(error) {
+                errorCount++;
+                console.log(util.format('%s:%d:%d: %s', file, error.line, error.column, error.message));
+            });
+        }
+    });
+};

--- a/test/specs/reporters/unix.js
+++ b/test/specs/reporters/unix.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var sinon = require('sinon');
+
+var Checker = require('../../../lib/checker');
+var unix = require('../../../lib/reporters/unix');
+
+describe('reporters/unix', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({disallowKeywords: ['with']});
+        sinon.stub(console, 'log');
+    });
+
+    afterEach(function() {
+        console.log.restore();
+    });
+
+    it('should correctly reports no errors', function() {
+        unix([checker.checkString('a++;')]);
+        assert(!console.log.called);
+    });
+
+    it('should correctly reports 1 error', function() {
+        unix([checker.checkString('with (x) {}')]);
+        assert.equal(console.log.getCall(0).args[0], 'input:1:0: Illegal keyword: with');
+        assert(console.log.calledOnce);
+    });
+
+    it('should correctly reports 2 errors', function() {
+        unix([checker.checkString('with (x) {} with (x) {}')]);
+        assert.equal(console.log.getCall(0).args[0], 'input:1:0: Illegal keyword: with');
+        assert.equal(console.log.getCall(1).args[0], 'input:1:12: Illegal keyword: with');
+        assert(console.log.calledTwice);
+    });
+});


### PR DESCRIPTION
Similar to `inline` and `inlinesingle`, but instead of outputting

	file.js: line 7, col 7, Unexpected token {

it outputs

	file.js:7:7: Unexpected token {

which is much like the output from other compilers and preprocessors.

The benefit is integration with existing tools that parse similar
output.  For example Emacs allows navigation by these “hyperlinks”
through the rules in `compilation-error-regexp-alist`.  Other editors
such as acme, lets you right-click on such tokens to jump to the
file, line, and column.

Closes gh-1403