### PR TITLE
disallowCommaBeforeLineBreak: added ignoreFunction, lineBreak options

### DIFF
--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -5,12 +5,10 @@
  *
  * Values:
  *  - `true` for default behavior (strict mode, comma on the same line)
- *  - `"mode"` options:
- *    - `"all"` for strict mode
- *    - `"ignoreFunction"` ignores objects if one of the property values is a function expression
- *  - `"lineBreak"` options:
- *    - `"none"` comma can be on the same line with both operands
- *    - `"beforeComma"` comma must have a line break after it's first operand
+ *  - `Object`:
+ *    - `'lineBreak'` requires a line break between object key and comma
+ *    - `'allExcept'` array of exceptions:
+ *       - `'function'` ignores objects if one of their values is a function expression
  *
  * JSHint: [`laxcomma`](http://www.jshint.com/docs/options/#laxcomma)
  *
@@ -20,7 +18,7 @@
  * "disallowCommaBeforeLineBreak": true
  * ```
  *
- * ##### Valid
+ * ##### Valid for `true`
  *
  * ```js
  * var x = {
@@ -39,13 +37,16 @@
  * };
  * ```
  *
+ * ##### Valid for `{"allExcept": ["function"]}`
+ *
  * ```js
- * "disallowCommaBeforeLineBreak": {
- *     "lineBreak": "beforeComma"
- * }
+ * var x = {
+ *     one: 1,
+ *     two: function() {}
+ * };
  * ```
  *
- * ##### Valid
+ * ##### Valid for `{"lineBreak": true}`
  *
  * ```js
  * var x = {
@@ -54,7 +55,7 @@
  * };
  * ```
  *
- * ##### Invalid
+ * ##### Invalid for `{"lineBreak": true}`
  *
  * ```js
  * var y = { three: 3, four: 4};
@@ -68,35 +69,20 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        var modes = {
-            'all': 'all',
-            'ignoreFunction': 'ignoreFunction'
-        };
-        var lineBreaks = {
-            'none': 'none',
-            'beforeComma': 'beforeComma'
-        };
-        assert(
-            options === true || typeof options === 'object',
-            this.getOptionName() + ' option requires either a true value or an object'
-        );
-        if (typeof options === 'object') {
+        if (typeof options !== 'object') {
             assert(
-                !options.mode || modes[options.mode],
-                this.getOptionName() + ' option\'s parameter mode must be one of' +
-                    Object.keys(modes).join(', ')
+                options === true,
+                this.getOptionName() + ' option requires either a true value or an object'
             );
 
-            assert(
-                !options.lineBreak || lineBreaks[options.lineBreak],
-                this.getOptionName() + ' option\'s parameter lineBreaks must be one of' +
-                    Object.keys(lineBreaks).join(', ')
-            );
-        } else {
-            options = {};
+            var _options = {allExcept: [], lineBreak: false};
+            return this.configure(_options);
         }
-        this._mode = modes[options.mode] || modes.all;
-        this._lineBreak = lineBreaks[options.lineBreak] || lineBreaks.none;
+
+        if (Array.isArray(options.allExcept)) {
+            this._exceptFunction = options.allExcept.indexOf('function') > -1;
+        }
+        this._lineBreak = options.lineBreak === true;
     },
 
     getOptionName: function() {
@@ -104,11 +90,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var mode = this._mode;
+        var exceptFunction = this._exceptFunction;
         var lineBreak = this._lineBreak;
 
         function canSkip(token) {
-            if (mode === 'all') {
+            if (!exceptFunction) {
                 return false;
             }
             var node = file.getNodeByRange(token.range[0]);
@@ -120,7 +106,7 @@ module.exports.prototype = {
             }
 
             return node.properties.some(function(property) {
-                if (mode === 'ignoreFunction' && property.value.type === 'FunctionExpression') {
+                if (exceptFunction && property.value.type === 'FunctionExpression') {
                     return true;
                 }
             });
@@ -138,7 +124,7 @@ module.exports.prototype = {
                 message: 'Commas should be placed on new line'
             });
 
-            if (lineBreak === 'beforeComma') {
+            if (lineBreak) {
                 errors.assert.differentLine({
                     token: file.getPrevToken(token),
                     nextToken: token,

--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -6,7 +6,6 @@
  * Values:
  *  - `true` for default behavior (strict mode, comma on the same line)
  *  - `Object`:
- *    - `'lineBreak'` requires a line break between object key and comma
  *    - `'allExcept'` array of exceptions:
  *       - `'function'` ignores objects if one of their values is a function expression
  *
@@ -46,20 +45,6 @@
  * };
  * ```
  *
- * ##### Valid for `{"lineBreak": true}`
- *
- * ```js
- * var x = {
- *     one: 1
- *     , two: 2
- * };
- * ```
- *
- * ##### Invalid for `{"lineBreak": true}`
- *
- * ```js
- * var y = { three: 3, four: 4};
- * ```
  */
 
 var assert = require('assert');
@@ -75,14 +60,13 @@ module.exports.prototype = {
                 this.getOptionName() + ' option requires either a true value or an object'
             );
 
-            var _options = {allExcept: [], lineBreak: false};
+            var _options = {allExcept: []};
             return this.configure(_options);
         }
 
         if (Array.isArray(options.allExcept)) {
             this._exceptFunction = options.allExcept.indexOf('function') > -1;
         }
-        this._lineBreak = options.lineBreak === true;
     },
 
     getOptionName: function() {
@@ -91,26 +75,16 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var exceptFunction = this._exceptFunction;
-        var lineBreak = this._lineBreak;
 
         function canSkip(token) {
-            if (!exceptFunction) {
-                return false;
-            }
             var node = file.getNodeByRange(token.range[0]);
-
-            if (node.type !== 'ObjectExpression' ||
-                node.loc.start.line === node.loc.end.line ||
-                node.properties < 2) {
-                return false;
+            if (node.loc.start.line === node.loc.end.line) {
+                return true;
             }
 
-            return node.properties.some(function(property) {
-                if (exceptFunction && property.value.type === 'FunctionExpression') {
-                    return true;
-                }
+            return exceptFunction && node.properties.some(function(property) {
+                return exceptFunction && property.value.type === 'FunctionExpression';
             });
-
         }
 
         file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
@@ -121,16 +95,14 @@ module.exports.prototype = {
             errors.assert.sameLine({
                 token: token,
                 nextToken: file.getNextToken(token),
-                message: 'Commas should be placed on new line'
+                message: 'Commas should be placed on the same line as value'
             });
 
-            if (lineBreak) {
-                errors.assert.differentLine({
-                    token: file.getPrevToken(token),
-                    nextToken: token,
-                    message: 'Commas should be placed on new line'
-                });
-            }
+            errors.assert.differentLine({
+                token: file.getPrevToken(token),
+                nextToken: token,
+                message: 'Commas should be placed on new line'
+            });
         });
     }
 

--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -40,10 +40,35 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
+        var modes = {
+            'all': 'all',
+            'ignoreFunction': 'ignoreFunction'
+        };
+        var lineBreaks = {
+            'none': 'none',
+            'beforeComma': 'beforeComma'
+        };
         assert(
-            options === true,
-            this.getOptionName() + ' option requires a true value or should be removed'
+            options === true || typeof options === 'object',
+            this.getOptionName() + ' option requires either a true value or an object'
         );
+        if (typeof options === 'object') {
+            assert(
+                !options.mode || modes[options.mode],
+                this.getOptionName() + ' option\'s parameter mode must be one of' +
+                    Object.keys(modes).join(', ')
+            );
+
+            assert(
+                !options.lineBreak || lineBreaks[options.lineBreak],
+                this.getOptionName() + ' option\'s parameter lineBreaks must be one of' +
+                    Object.keys(lineBreaks).join(', ')
+            );
+        } else {
+            options = {};
+        }
+        this._mode = modes[options.mode] || modes.all;
+        this._lineBreak = lineBreaks[options.lineBreak] || lineBreaks.none;
     },
 
     getOptionName: function() {
@@ -51,12 +76,47 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var mode = this._mode;
+        var lineBreak = this._lineBreak;
+
+        function canSkip(token) {
+            if (mode === 'all') {
+                return false;
+            }
+            var node = file.getNodeByRange(token.range[0]);
+
+            if (node.type !== 'ObjectExpression' ||
+                node.loc.start.line === node.loc.end.line ||
+                node.properties < 2) {
+                return false;
+            }
+
+            return node.properties.some(function(property) {
+                if (mode === 'ignoreFunction' && property.value.type === 'FunctionExpression') {
+                    return true;
+                }
+            });
+
+        }
+
         file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
+            if (canSkip(token)) {
+                return;
+            }
+
             errors.assert.sameLine({
                 token: token,
                 nextToken: file.getNextToken(token),
                 message: 'Commas should be placed on new line'
             });
+
+            if (lineBreak === 'beforeComma') {
+                errors.assert.differentLine({
+                    token: file.getPrevToken(token),
+                    nextToken: token,
+                    message: 'Commas should be placed on new line'
+                });
+            }
         });
     }
 

--- a/lib/rules/disallow-comma-before-line-break.js
+++ b/lib/rules/disallow-comma-before-line-break.js
@@ -1,9 +1,16 @@
 /**
  * Disallows commas as last token on a line in lists.
  *
- * Type: `Boolean`
+ * Type: `Boolean`|`Object`
  *
- * Value: `true`
+ * Values:
+ *  - `true` for default behavior (strict mode, comma on the same line)
+ *  - `"mode"` options:
+ *    - `"all"` for strict mode
+ *    - `"ignoreFunction"` ignores objects if one of the property values is a function expression
+ *  - `"lineBreak"` options:
+ *    - `"none"` comma can be on the same line with both operands
+ *    - `"beforeComma"` comma must have a line break after it's first operand
  *
  * JSHint: [`laxcomma`](http://www.jshint.com/docs/options/#laxcomma)
  *
@@ -30,6 +37,27 @@
  *     one: 1,
  *     two: 2
  * };
+ * ```
+ *
+ * ```js
+ * "disallowCommaBeforeLineBreak": {
+ *     "lineBreak": "beforeComma"
+ * }
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var x = {
+ *     one: 1
+ *     , two: 2
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var y = { three: 3, four: 4};
  * ```
  */
 

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -61,38 +61,38 @@ describe('rules/disallow-comma-before-line-break', function() {
         assert(checker.checkString('var a = {a:1, c:3};').isEmpty());
     });
 
-    describe('mode option', function() {
-        describe('ignoreFunction value', function() {
-            var rules = {disallowCommaBeforeLineBreak: {mode: 'ignoreFunction'}};
-            beforeEach(function() {
-                checker.configure(rules);
-            });
-            it('should not report function with ignoreFunction', function() {
-                assert(
-                    checker.checkString(
-                        'var x = {\n' +
-                            'a : 1,\n' +
-                            'foo : function() {},\n' +
-                            'bcd : 2\n' +
-                        '};'
-                    ).isEmpty()
-                );
-            });
+    describe('options as object', function() {
+        describe('allExcept as option', function() {
+            describe('with value function', function() {
+                var rules = {disallowCommaBeforeLineBreak: {allExcept: ['function']}};
+                beforeEach(function() {
+                    checker.configure(rules);
+                });
+                it('should not report objects with function values', function() {
+                    assert(
+                        checker.checkString(
+                            'var x = {\n' +
+                                'a : 1,\n' +
+                                'foo : function() {},\n' +
+                                'bcd : 2\n' +
+                            '};'
+                        ).isEmpty()
+                    );
+                });
 
-            reportAndFix({
-                name: 'illegal comma placement in multiline object declaration',
-                rules: rules,
-                input: 'var a = {a:1,\nc:3};',
-                output: 'var a = {a:1, c:3};'
+                reportAndFix({
+                    name: 'illegal comma placement in multiline object declaration',
+                    rules: rules,
+                    input: 'var a = {a:1,\nc:3};',
+                    output: 'var a = {a:1, c:3};'
+                });
             });
         });
-    });
 
-    describe('lineBreak option', function() {
-        describe('beforeComma value', function() {
+        describe('lineBreak as option', function() {
             reportAndFix({
                 name: 'illegal comma placement in multiline object declaration',
-                rules: {disallowCommaBeforeLineBreak: {lineBreak: 'beforeComma'}},
+                rules: {disallowCommaBeforeLineBreak: {lineBreak: true}},
                 errors: 2,
                 input: 'var a = {a:1,\nc:3};',
                 output: 'var a = {a:1\n, c:3};'

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -63,12 +63,9 @@ describe('rules/disallow-comma-before-line-break', function() {
 
     describe('mode option', function() {
         describe('ignoreFunction value', function() {
+            var rules = {disallowCommaBeforeLineBreak: {mode: 'ignoreFunction'}};
             beforeEach(function() {
-                checker.configure({
-                    disallowCommaBeforeLineBreak: {
-                        mode: 'ignoreFunction'
-                    }
-                });
+                checker.configure(rules);
             });
             it('should not report function with ignoreFunction', function() {
                 assert(

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -60,4 +60,46 @@ describe('rules/disallow-comma-before-line-break', function() {
     it('should not report comma placement in single line object declaration', function() {
         assert(checker.checkString('var a = {a:1, c:3};').isEmpty());
     });
+
+    describe('mode option', function() {
+        describe('ignoreFunction value', function() {
+            beforeEach(function() {
+                checker.configure({
+                    disallowCommaBeforeLineBreak: {
+                        mode: 'ignoreFunction'
+                    }
+                });
+            });
+            it('should not report function with ignoreFunction', function() {
+                assert(
+                    checker.checkString(
+                        'var x = {\n' +
+                            'a : 1,\n' +
+                            'foo : function() {},\n' +
+                            'bcd : 2\n' +
+                        '};'
+                    ).isEmpty()
+                );
+            });
+
+            reportAndFix({
+                name: 'illegal comma placement in multiline object declaration',
+                rules: rules,
+                input: 'var a = {a:1,\nc:3};',
+                output: 'var a = {a:1, c:3};'
+            });
+        });
+    });
+
+    describe('lineBreak option', function() {
+        describe('beforeComma value', function() {
+            reportAndFix({
+                name: 'illegal comma placement in multiline object declaration',
+                rules: {disallowCommaBeforeLineBreak: {lineBreak: 'beforeComma'}},
+                errors: 2,
+                input: 'var a = {a:1,\nc:3};',
+                output: 'var a = {a:1\n, c:3};'
+            });
+        });
+    });
 });

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -15,22 +15,25 @@ describe('rules/disallow-comma-before-line-break', function() {
     reportAndFix({
         name: 'illegal comma placement in multiline var declaration',
         rules: rules,
+        errors: 2,
         input: 'var a,\nb;',
-        output: 'var a, b;'
+        output: 'var a\n, b;'
     });
 
     reportAndFix({
         name: 'illegal comma placement in multiline array declaration',
         rules: rules,
+        errors: 2,
         input: 'var a = [1,\n2];',
-        output: 'var a = [1, 2];'
+        output: 'var a = [1\n, 2];'
     });
 
     reportAndFix({
         name: 'illegal comma placement in multiline object declaration',
         rules: rules,
+        errors: 2,
         input: 'var a = {a:1,\nc:3};',
-        output: 'var a = {a:1, c:3};'
+        output: 'var a = {a:1\n, c:3};'
     });
 
     it('should not report legal comma placement in multiline var declaration', function() {
@@ -63,10 +66,11 @@ describe('rules/disallow-comma-before-line-break', function() {
 
     describe('options as object', function() {
         describe('allExcept as option', function() {
-            describe('with value function', function() {
-                var rules = {disallowCommaBeforeLineBreak: {allExcept: ['function']}};
+            describe('with value `function`', function() {
                 beforeEach(function() {
-                    checker.configure(rules);
+                    checker = new Checker();
+                    checker.registerDefaultRules();
+                    checker.configure({disallowCommaBeforeLineBreak: {allExcept: ['function']}});
                 });
                 it('should not report objects with function values', function() {
                     assert(
@@ -79,23 +83,11 @@ describe('rules/disallow-comma-before-line-break', function() {
                         ).isEmpty()
                     );
                 });
-
-                reportAndFix({
-                    name: 'illegal comma placement in multiline object declaration',
-                    rules: rules,
-                    input: 'var a = {a:1,\nc:3};',
-                    output: 'var a = {a:1, c:3};'
+                it('should report objects without function values', function() {
+                    assert(
+                        checker.checkString('var a = {a:1,\nc:3};').getErrorCount() === 2
+                    );
                 });
-            });
-        });
-
-        describe('lineBreak as option', function() {
-            reportAndFix({
-                name: 'illegal comma placement in multiline object declaration',
-                rules: {disallowCommaBeforeLineBreak: {lineBreak: true}},
-                errors: 2,
-                input: 'var a = {a:1,\nc:3};',
-                output: 'var a = {a:1\n, c:3};'
             });
         });
     });


### PR DESCRIPTION
Hi,

I needed to handle two corner cases in my project with disallowCommaBeforeLineBreak rule:
1. I wanted to have a line break before comma only in simple objects without methods
2. Fixed version would place a comma and both tokens before and after it on a single line while I wanted to have comma at the beginning of the next line

So I've added two options to the rule:
```javascript
{
    mode: ["all", "ignoreFunction"],
    lineBreak: ["none", "beforeComma"]
}
```

By default the rule would behave the same way as before (that is, accept `true` instead of options). Example for beforeComma:
*Invalid:*
```javascript
var y = { three: 3, four: 4};
```
*Valid:*
```javascript
var y = {
    three: 3
    , four: 4
};
```