### PR TITLE
Add "fix" field in rule declaration

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -165,6 +165,15 @@ exports.getReporter = function(reporter, colors) {
         writer = null;
     }
 
+    if (!writer) {
+        try {
+            writer = require(reporter);
+            writerPath = reporter;
+        } catch (e) {
+            writer = null;
+        }
+    }
+
     return {
         path: writerPath,
         writer: writer

--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -169,9 +169,7 @@ exports.getReporter = function(reporter, colors) {
         try {
             writer = require(reporter);
             writerPath = reporter;
-        } catch (e) {
-            writer = null;
-        }
+        } catch (e) {}
     }
 
     return {

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -220,6 +220,17 @@ Configuration.prototype.getConfiguredRules = function() {
 };
 
 /**
+ * Returns configured rule.
+ *
+ * @returns {Rule | null}
+ */
+Configuration.prototype.getConfiguredRule = function(name) {
+    return this._configuredRules.filter(function(rule) {
+        return rule.getOptionName() === name;
+    })[0] || null;
+};
+
+/**
  * Returns the list of unsupported rule names.
  *
  * @return {String[]}

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -60,23 +60,8 @@ Configuration.prototype.load = function(config) {
     copyConfiguration(overrides, currentConfig);
 
     var ruleSettings = this._processConfig(currentConfig);
-    var processedSettings = {};
 
-    Object.keys(ruleSettings).forEach(function(optionName) {
-        var rule = this._rules[optionName];
-        if (rule) {
-            var optionValue = ruleSettings[optionName];
-            if (optionValue !== null) {
-                rule.configure(ruleSettings[optionName]);
-                this._configuredRules.push(rule);
-                processedSettings[optionName] = ruleSettings[optionName];
-            }
-        } else {
-            this._unsupportedRuleNames.push(optionName);
-        }
-    }, this);
-
-    this._ruleSettings = processedSettings;
+    this._loadRules(ruleSettings);
 };
 
 /**
@@ -285,19 +270,6 @@ Configuration.prototype._processConfig = function(config) {
         options.plugins.forEach(this._loadPlugin, this);
     }
 
-    // Apply presets
-    var presetName = options.preset;
-    if (presetName) {
-        this._presetName = presetName;
-        assert(typeof presetName === 'string', '`preset` option requires string value');
-        var presetData = this._presets[presetName];
-        assert(Boolean(presetData), 'Preset "' + presetName + '" does not exist');
-        var presetResult = this._processConfig(presetData);
-        Object.keys(presetResult).forEach(function(key) {
-            ruleSettings[key] = presetResult[key];
-        });
-    }
-
     // File extensions
     if (options.fileExtensions) {
         assert(
@@ -367,6 +339,11 @@ Configuration.prototype._processConfig = function(config) {
         this._loadVerbose(options.verbose);
     }
 
+    // Apply presets
+    if (options.hasOwnProperty('preset')) {
+        this._loadPreset(options.preset);
+    }
+
     // NOTE: rule setting must come last in order to
     // override any rules that are loaded from a preset
     Object.keys(config).forEach(function(key) {
@@ -388,6 +365,30 @@ Configuration.prototype._loadPlugin = function(plugin) {
     assert(typeof plugin === 'function', '`plugin` should be a function');
     plugin(this);
 };
+
+/**
+ * Load rules.
+ * @param {Object} ruleSettings
+ * @protected
+ */
+Configuration.prototype._loadRules = function(ruleSettings) {
+    Object.keys(ruleSettings).forEach(function(optionName) {
+        var rule = this._rules[optionName];
+        if (rule) {
+            var optionValue = ruleSettings[optionName];
+            if (optionValue !== null) {
+                rule.configure(ruleSettings[optionName]);
+                this._configuredRules.push(rule);
+
+                this._ruleSettings[optionName] = ruleSettings[optionName]
+            }
+        } else {
+            if (!~this._unsupportedRuleNames.indexOf(optionName)) {
+                this._unsupportedRuleNames.push(optionName);
+            }
+        }
+    }, this);
+}
 
 /**
  * Loads an error filter.
@@ -431,6 +432,25 @@ Configuration.prototype._loadEsprima = function(esprima) {
         '`esprima` option requires a null value or an object with a parse function'
     );
     this._esprima = esprima;
+};
+
+/**
+ * Loads preset.
+ *
+ * @param {Object} preset
+ * @protected
+ */
+Configuration.prototype._loadPreset = function(preset) {
+    if (!this._presetName) {
+        this._presetName = preset;
+    }
+    assert(typeof preset === 'string', '`preset` option requires string value');
+
+    var presetData = this._presets[preset];
+    assert(Boolean(presetData), 'Preset "' + preset + '" does not exist');
+
+    var ruleSettings = this._processConfig(this._presets[preset]);
+    this._loadRules(ruleSettings);
 };
 
 /**

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -62,6 +62,7 @@ Configuration.prototype.load = function(config) {
     var ruleSettings = this._processConfig(currentConfig);
 
     this._loadRules(ruleSettings);
+    this._useRules();
 };
 
 /**
@@ -372,23 +373,39 @@ Configuration.prototype._loadPlugin = function(plugin) {
  * @protected
  */
 Configuration.prototype._loadRules = function(ruleSettings) {
+    this._configuredRules = [];
+
     Object.keys(ruleSettings).forEach(function(optionName) {
-        var rule = this._rules[optionName];
-        if (rule) {
+        if (this._rules[optionName]) {
             var optionValue = ruleSettings[optionName];
             if (optionValue !== null) {
-                rule.configure(ruleSettings[optionName]);
-                this._configuredRules.push(rule);
+                this._ruleSettings[optionName] = ruleSettings[optionName];
 
-                this._ruleSettings[optionName] = ruleSettings[optionName]
+            } else {
+                delete this._ruleSettings[optionName];
             }
-        } else {
-            if (!~this._unsupportedRuleNames.indexOf(optionName)) {
-                this._unsupportedRuleNames.push(optionName);
-            }
+
+        } else if (this._unsupportedRuleNames.indexOf(optionName) === -1) {
+            this._unsupportedRuleNames.push(optionName);
         }
+
     }, this);
-}
+};
+
+/**
+ * Apply the rules
+ * @protected
+ */
+Configuration.prototype._useRules = function() {
+    this._configuredRules = [];
+
+    Object.keys(this._ruleSettings).forEach(function(optionName) {
+        var rule = this._rules[optionName];
+        rule.configure(this._ruleSettings[optionName]);
+        this._configuredRules.push(rule);
+
+    }, this);
+};
 
 /**
  * Loads an error filter.
@@ -575,6 +592,15 @@ Configuration.prototype.getRegisteredPresets = function() {
  */
 Configuration.prototype.hasPreset = function(presetName) {
     return this._presets.hasOwnProperty(presetName);
+};
+
+/**
+ * Returns name of the active preset.
+ *
+ * @return {String}
+ */
+Configuration.prototype.getPresetName = function() {
+    return this._presetName;
 };
 
 /**

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -690,7 +690,6 @@ Configuration.prototype._useRules = function() {
         var rule = this._rules[optionName];
         rule.configure(this._ruleSettings[optionName]);
         this._configuredRules.push(rule);
-
     }, this);
 };
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -25,22 +25,148 @@ var BUILTIN_OPTIONS = {
  * @name Configuration
  */
 function Configuration() {
+    /**
+     * List of the registered (not used) presets.
+     *
+     * @protected
+     * @type {Object}
+     */
     this._presets = {};
-    this._rules = {};
-    this._configuredRules = [];
-    this._unsupportedRuleNames = [];
-    this._fileExtensions = ['.js'];
-    this._excludedFileMasks = [];
-    this._excludedFileMatchers = [];
-    this._ruleSettings = {};
-    this._maxErrors = null;
-    this._basePath = '.';
-    this._overrides = {};
+
+    /**
+     * Name of the preset (if used).
+     *
+     * @protected
+     * @type {String|null}
+     */
     this._presetName = null;
+
+    /**
+     * List of loaded presets.
+     *
+     * @protected
+     * @type {String|null}
+     */
+    this._loadedPresets = [];
+
+    /**
+     * List of rules instances.
+     *
+     * @protected
+     * @type {Object}
+     */
+    this._rules = {};
+
+    /**
+     * List of configurated rule instances.
+     *
+     * @protected
+     * @type {Object}
+     */
+    this._ruleSettings = {};
+
+    /**
+     * List of configured rules.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._configuredRules = [];
+
+    /**
+     * List of unsupported rules.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._unsupportedRuleNames = [];
+
+    /**
+     * File extensions that would be checked.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._fileExtensions = ['.js'];
+
+    /**
+     * Exclusion masks.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._excludedFileMasks = [];
+
+    /**
+     * List of existing files that falls under exclusion masks.
+     *
+     * @protected
+     * @type {Array}
+     */
+    this._excludedFileMatchers = [];
+
+    /**
+     * Maxixum amount of error that would be reportered.
+     *
+     * @protected
+     * @type {Number}
+     */
+    this._maxErrors = Infinity;
+
+    /**
+     * JSCS CWD.
+     *
+     * @protected
+     * @type {String}
+     */
+    this._basePath = '.';
+
+    /**
+     * List of overrided options (usually from CLI).
+     *
+     * @protected
+     * @type {Object}
+     */
+    this._overrides = {};
+
+    /**
+     * Is "esnext" mode enabled?
+     *
+     * @protected
+     * @type {Boolean}
+     */
     this._esnextEnabled = false;
+
+    /**
+     * Is "ES3" mode enabled?.
+     *
+     * @protected
+     * @type {Boolean}
+     */
     this._es3Enabled = true;
+
+    /**
+     * Custom version of esprima if specified.
+     *
+     * @protected
+     * @type {Object|null}
+     */
     this._esprima = null;
+
+    /**
+     * Options that would be passed to esprima.
+     *
+     * @protected
+     * @type {Object}
+     */
     this._esprimaOptions = {};
+
+    /**
+     * A filter function that determines whether or not to report an error.
+     *
+     * @protected
+     * @type {Function|null}
+     */
     this._errorFilter = null;
     this._verbose = null;
 }
@@ -51,17 +177,14 @@ function Configuration() {
  * @param {Object} config
  */
 Configuration.prototype.load = function(config) {
+
+    // This is when we were young, need to remove at 2.0
     this._throwNonCamelCaseErrorIfNeeded(config);
 
-    var overrides = this._overrides;
-    var currentConfig = {};
+    // Apply all the options
+    this._processConfig(config);
 
-    copyConfiguration(config, currentConfig);
-    copyConfiguration(overrides, currentConfig);
-
-    var ruleSettings = this._processConfig(currentConfig);
-
-    this._loadRules(ruleSettings);
+    // Load and apply all the rules
     this._useRules();
 };
 
@@ -247,14 +370,20 @@ Configuration.prototype._getOptionsFromConfig = function(config) {
  * Processes configuration and returns config options.
  *
  * @param {Object} config
- * @returns {Object}
  */
 Configuration.prototype._processConfig = function(config) {
-    var ruleSettings = {};
+    var overrides = this._overrides;
+    var currentConfig = {};
+
+    // Copy configuration so original config would be intact
+    copyConfiguration(config, currentConfig);
+
+    // Override the properties
+    copyConfiguration(overrides, currentConfig);
 
     // NOTE: options is a separate object to ensure that future options must be added
     // to BUILTIN_OPTIONS to work, which also assures they aren't mistaken for a rule
-    var options = this._getOptionsFromConfig(config);
+    var options = this._getOptionsFromConfig(currentConfig);
 
     // Base path
     if (options.configPath) {
@@ -265,63 +394,34 @@ Configuration.prototype._processConfig = function(config) {
         this._basePath = path.dirname(options.configPath);
     }
 
-    // Load plugins
-    if (options.plugins) {
+    if (options.hasOwnProperty('plugins')) {
         assert(Array.isArray(options.plugins), '`plugins` option requires array value');
         options.plugins.forEach(this._loadPlugin, this);
     }
 
-    // File extensions
-    if (options.fileExtensions) {
-        assert(
-            typeof options.fileExtensions === 'string' || Array.isArray(options.fileExtensions),
-            '`fileExtensions` option requires string or array value'
-        );
-        this._fileExtensions = [].concat(options.fileExtensions).map(function(ext) {
-            return ext.toLowerCase();
-        });
-    }
-
-    // File excludes
-    if (options.excludeFiles) {
-        assert(Array.isArray(options.excludeFiles), '`excludeFiles` option requires array value');
-        this._excludedFileMasks = options.excludeFiles;
-        this._excludedFileMatchers = this._excludedFileMasks.map(function(fileMask) {
-            return new minimatch.Minimatch(path.resolve(this._basePath, fileMask), {
-                dot: true
-            });
-        }, this);
-    }
-
-    // Additional rules
-    if (options.additionalRules) {
+    if (options.hasOwnProperty('additionalRules')) {
         assert(Array.isArray(options.additionalRules), '`additionalRules` option requires array value');
         options.additionalRules.forEach(this._loadAdditionalRule, this);
     }
 
+    if (options.hasOwnProperty('fileExtensions')) {
+        this._loadFileExtensions(options.fileExtensions);
+    }
+
+    if (options.hasOwnProperty('excludeFiles')) {
+        this._loadExcludedFiles(options.excludeFiles);
+    }
+
     if (options.hasOwnProperty('maxErrors')) {
-        var maxErrors = options.maxErrors === null ? null : Number(options.maxErrors);
-        assert(
-            maxErrors > 0 || isNaN(maxErrors) || maxErrors === null,
-            '`maxErrors` option requires number or null value'
-        );
-        this._maxErrors = maxErrors;
+        this._loadMaxError(options.maxErrors);
     }
 
     if (options.hasOwnProperty('esnext')) {
-        assert(
-            typeof options.esnext === 'boolean' || options.esnext === null,
-            '`esnext` option requires boolean or null value'
-        );
-        this._esnextEnabled = Boolean(options.esnext);
+        this._loadESNext(options.esnext);
     }
 
     if (options.hasOwnProperty('es3')) {
-        assert(
-            typeof options.es3 === 'boolean' || options.es3 === null,
-            '`es3` option requires boolean or null value'
-        );
-        this._es3Enabled = Boolean(options.es3);
+        this._loadES3(options.es3);
     }
 
     if (options.hasOwnProperty('esprima')) {
@@ -345,15 +445,7 @@ Configuration.prototype._processConfig = function(config) {
         this._loadPreset(options.preset);
     }
 
-    // NOTE: rule setting must come last in order to
-    // override any rules that are loaded from a preset
-    Object.keys(config).forEach(function(key) {
-        if (!BUILTIN_OPTIONS[key]) {
-            ruleSettings[key] = config[key];
-        }
-    });
-
-    return ruleSettings;
+    this._loadRules(currentConfig);
 };
 
 /**
@@ -369,41 +461,31 @@ Configuration.prototype._loadPlugin = function(plugin) {
 
 /**
  * Load rules.
- * @param {Object} ruleSettings
+ *
+ * @param {Object} config
  * @protected
  */
-Configuration.prototype._loadRules = function(ruleSettings) {
-    this._configuredRules = [];
+Configuration.prototype._loadRules = function(config) {
+    Object.keys(config).forEach(function(key) {
 
-    Object.keys(ruleSettings).forEach(function(optionName) {
-        if (this._rules[optionName]) {
-            var optionValue = ruleSettings[optionName];
-            if (optionValue !== null) {
-                this._ruleSettings[optionName] = ruleSettings[optionName];
-
-            } else {
-                delete this._ruleSettings[optionName];
-            }
-
-        } else if (this._unsupportedRuleNames.indexOf(optionName) === -1) {
-            this._unsupportedRuleNames.push(optionName);
+        // Only rules should be processed
+        if (BUILTIN_OPTIONS[key]) {
+            return;
         }
 
-    }, this);
-};
+        if (this._rules[key]) {
+            var optionValue = config[key];
 
-/**
- * Apply the rules
- * @protected
- */
-Configuration.prototype._useRules = function() {
-    this._configuredRules = [];
+            if (optionValue !== null) {
+                this._ruleSettings[key] = config[key];
 
-    Object.keys(this._ruleSettings).forEach(function(optionName) {
-        var rule = this._rules[optionName];
-        rule.configure(this._ruleSettings[optionName]);
-        this._configuredRules.push(rule);
+            } else {
+                delete this._ruleSettings[key];
+            }
 
+        } else if (this._unsupportedRuleNames.indexOf(key) === -1) {
+            this._unsupportedRuleNames.push(key);
+        }
     }, this);
 };
 
@@ -436,6 +518,50 @@ Configuration.prototype._loadVerbose = function(verbose) {
     this._verbose = verbose;
 };
 
+/*
+ * Load "esnext" option.
+ *
+ * @param {Boolean} esnext
+ * @protected
+ */
+Configuration.prototype._loadESNext = function(esnext) {
+    assert(
+        typeof esnext === 'boolean' || esnext === null,
+        '`esnext` option requires boolean or null value'
+    );
+    this._esnextEnabled = Boolean(esnext);
+};
+
+/**
+ * Load "es3" option.
+ *
+ * @param {Boolean} es3
+ * @protected
+ */
+Configuration.prototype._loadES3 = function(es3) {
+    assert(
+        typeof es3 === 'boolean' || es3 === null,
+        '`es3` option requires boolean or null value'
+    );
+    this._es3Enabled = Boolean(es3);
+};
+
+/**
+ * Load "maxError" option.
+ *
+ * @param {Number|null} maxErrors
+ * @protected
+ */
+Configuration.prototype._loadMaxError = function(maxErrors) {
+    maxErrors = maxErrors === null ? null : Number(maxErrors);
+
+    assert(
+        maxErrors > 0 || isNaN(maxErrors) || maxErrors === null,
+        '`maxErrors` option requires number or null value'
+    );
+    this._maxErrors = maxErrors;
+};
+
 /**
  * Loads a custom esprima.
  *
@@ -452,12 +578,19 @@ Configuration.prototype._loadEsprima = function(esprima) {
 };
 
 /**
- * Loads preset.
+ * Load preset.
  *
  * @param {Object} preset
  * @protected
  */
 Configuration.prototype._loadPreset = function(preset) {
+    if (this._loadedPresets.indexOf(preset) > -1) {
+        return;
+    }
+
+    this._loadedPresets.push(preset);
+
+    // If preset is loaded from another preset - preserve the original name
     if (!this._presetName) {
         this._presetName = preset;
     }
@@ -466,8 +599,41 @@ Configuration.prototype._loadPreset = function(preset) {
     var presetData = this._presets[preset];
     assert(Boolean(presetData), 'Preset "' + preset + '" does not exist');
 
-    var ruleSettings = this._processConfig(this._presets[preset]);
-    this._loadRules(ruleSettings);
+    // Process config from the preset
+    this._processConfig(this._presets[preset]);
+};
+
+/**
+ * Load file extensions.
+ *
+ * @param {String|Array} extensions
+ * @protected
+ */
+Configuration.prototype._loadFileExtensions = function(extensions) {
+    assert(
+        typeof extensions === 'string' || Array.isArray(extensions),
+        '`fileExtensions` option requires string or array value'
+    );
+    this._fileExtensions = [].concat(extensions).map(function(ext) {
+        return ext.toLowerCase();
+    });
+};
+
+/**
+ * Load excluded paths.
+ *
+ * @param {Array} masks
+ * @protected
+ */
+Configuration.prototype._loadExcludedFiles = function(masks) {
+    assert(Array.isArray(masks), '`excludeFiles` option requires array value');
+
+    this._excludedFileMasks = masks;
+    this._excludedFileMatchers = this._excludedFileMasks.map(function(fileMask) {
+        return new minimatch.Minimatch(path.resolve(this._basePath, fileMask), {
+            dot: true
+        });
+    }, this);
 };
 
 /**
@@ -482,15 +648,6 @@ Configuration.prototype._loadEsprimaOptions = function(esprimaOptions) {
 };
 
 /**
- * Includes plugin in the configuration environment.
- *
- * @param {function(Configuration)|*} plugin
- */
-Configuration.prototype.usePlugin = function(plugin) {
-    this._loadPlugin(plugin);
-};
-
-/**
  * Loads additional rule.
  *
  * @param {Rule} additionalRule
@@ -502,12 +659,38 @@ Configuration.prototype._loadAdditionalRule = function(additionalRule) {
 };
 
 /**
- * Throws error for non camel-case options.
+ * Includes plugin in the configuration environment.
  *
- * @param {Object} ruleSettings
+ * @param {function(Configuration)|*} plugin
+ */
+Configuration.prototype.usePlugin = function(plugin) {
+    this._loadPlugin(plugin);
+};
+
+/**
+ * Apply the rules.
+ *
  * @protected
  */
-Configuration.prototype._throwNonCamelCaseErrorIfNeeded = function(ruleSettings) {
+Configuration.prototype._useRules = function() {
+    this._configuredRules = [];
+
+    Object.keys(this._ruleSettings).forEach(function(optionName) {
+        var rule = this._rules[optionName];
+        rule.configure(this._ruleSettings[optionName]);
+        this._configuredRules.push(rule);
+
+    }, this);
+};
+
+/**
+ * Throws error for non camel-case options.
+ * Not thorough method, but it should be removed anyway.
+ *
+ * @param {Object} config
+ * @protected
+ */
+Configuration.prototype._throwNonCamelCaseErrorIfNeeded = function(config) {
     function symbolToUpperCase(s, symbol) {
         return symbol.toUpperCase();
     }
@@ -524,13 +707,13 @@ Configuration.prototype._throwNonCamelCaseErrorIfNeeded = function(ruleSettings)
         return result;
     }
 
-    Object.keys(ruleSettings).forEach(function(key) {
+    Object.keys(config).forEach(function(key) {
         if (key.indexOf('_') !== -1) {
             throw new Error(
                 'JSCS now accepts configuration options in camel case. Sorry for inconvenience. ' +
                 'On the bright side, we tried to convert your jscs config to camel case.\n' +
                 '----------------------------------------\n' +
-                JSON.stringify(fixSettings(ruleSettings), null, 4) +
+                JSON.stringify(fixSettings(config), null, 4) +
                 '\n----------------------------------------\n'
             );
         }

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -83,6 +83,30 @@ NodeConfiguration.prototype._loadPlugin = function(plugin) {
 };
 
 /**
+ * Loads preset.
+ *
+ * @param {String|null} preset
+ * @private
+ */
+NodeConfiguration.prototype._loadPreset = function(preset) {
+    var registeredPresets = this.getRegisteredPresets();
+
+    if (preset in registeredPresets) {
+        Configuration.prototype._loadPreset.call(this, preset);
+
+    } else {
+        var name = path.basename(preset).split('.')[0];
+
+        // Suppress it, since missing preset error will be handled by the caller
+        try {
+            this.registerPreset(name, this.loadExternal(preset, 'preset'));
+        } catch (e) {}
+
+        Configuration.prototype._loadPreset.call(this, name);
+    }
+};
+
+/**
  * Loads an error filter module.
  *
  * @param {String|null} filter
@@ -116,7 +140,7 @@ NodeConfiguration.prototype._loadEsprima = function(esprima) {
  */
 NodeConfiguration.prototype._loadAdditionalRule = function(additionalRule) {
     if (typeof additionalRule === 'string') {
-        if(glob.hasMagic(additionalRule)) {
+        if (glob.hasMagic(additionalRule)) {
             glob.sync(path.resolve(this._basePath, additionalRule)).forEach(function(path) {
                 var Rule = require(path);
                 Configuration.prototype._loadAdditionalRule.call(this, new Rule());

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -47,37 +47,52 @@ NodeConfiguration.prototype.overrideFromCLI = function(program) {
 };
 
 /**
+ * [loadExternal description]
+ * @param {String|null} external - path (relative or absolute) or name to the external module
+ * @param {String} type - type of the module
+ * @return {Module}
+ */
+NodeConfiguration.prototype.loadExternal = function(external, type) {
+    assert(
+        typeof external === 'string' || external === null,
+        '"' + type + '" option requires a string or null value'
+    );
+
+    if (external) {
+        return require(
+            utils.normalizePath(external, this._basePath)
+        );
+
+    } else {
+        return null;
+    }
+};
+
+/**
  * Loads plugin data.
  *
- * @param {String|function(Configuration)} plugin
+ * @param {String|null|Function} plugin
  * @protected
  */
 NodeConfiguration.prototype._loadPlugin = function(plugin) {
-    if (typeof plugin === 'string') {
-        var pluginPath = utils.normalizePath(plugin, this._basePath);
-        plugin = require(pluginPath);
+    if (typeof plugin !== 'function') {
+        plugin = this.loadExternal(plugin, 'plugin');
     }
-    Configuration.prototype._loadPlugin.call(this, plugin);
+
+    return Configuration.prototype._loadPlugin.call(this, plugin);
 };
 
 /**
  * Loads an error filter module
  *
- * @param {String|null} errorFilter
+ * @param {String|null} filter
  * @protected
  */
-NodeConfiguration.prototype._loadErrorFilter = function(errorFilter) {
-    assert(
-        typeof errorFilter === 'string' || errorFilter === null,
-        '`errorFilter` option requires a string or null value'
+NodeConfiguration.prototype._loadErrorFilter = function(filter) {
+    Configuration.prototype._loadErrorFilter.call(
+        this,
+        this.loadExternal(filter, 'errorFilter')
     );
-
-    if (errorFilter) {
-        errorFilter = utils.normalizePath(errorFilter, this._basePath);
-        errorFilter = require(errorFilter);
-    }
-
-    Configuration.prototype._loadErrorFilter.call(this, errorFilter);
 };
 
 /**
@@ -87,17 +102,10 @@ NodeConfiguration.prototype._loadErrorFilter = function(errorFilter) {
  * @protected
  */
 NodeConfiguration.prototype._loadEsprima = function(esprima) {
-    assert(
-        typeof esprima === 'string' || esprima === null,
-        '`esprima` option requires a string or null value'
+    Configuration.prototype._loadEsprima.call(
+        this,
+        this.loadExternal(esprima, 'esprima')
     );
-
-    if (esprima) {
-        esprima = utils.normalizePath(esprima, this._basePath);
-        esprima = require(esprima);
-    }
-
-    Configuration.prototype._loadEsprima.call(this, esprima);
 };
 
 /**
@@ -108,10 +116,15 @@ NodeConfiguration.prototype._loadEsprima = function(esprima) {
  */
 NodeConfiguration.prototype._loadAdditionalRule = function(additionalRule) {
     if (typeof additionalRule === 'string') {
-        glob.sync(path.resolve(this._basePath, additionalRule)).forEach(function(path) {
-            var Rule = require(path);
+        if(glob.hasMagic(additionalRule)) {
+            glob.sync(path.resolve(this._basePath, additionalRule)).forEach(function(path) {
+                var Rule = require(path);
+                Configuration.prototype._loadAdditionalRule.call(this, new Rule());
+            }, this);
+        } else {
+            var Rule = this.loadExternal(additionalRule);
             Configuration.prototype._loadAdditionalRule.call(this, new Rule());
-        }, this);
+        }
     } else {
         Configuration.prototype._loadAdditionalRule.call(this, additionalRule);
     }

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -47,7 +47,7 @@ NodeConfiguration.prototype.overrideFromCLI = function(program) {
 };
 
 /**
- * [loadExternal description]
+ * Load external module.
  * @param {String|null} external - path (relative or absolute) or name to the external module
  * @param {String} type - type of the module
  * @return {Module}
@@ -72,7 +72,7 @@ NodeConfiguration.prototype.loadExternal = function(external, type) {
  * Loads plugin data.
  *
  * @param {String|null|Function} plugin
- * @protected
+ * @private
  */
 NodeConfiguration.prototype._loadPlugin = function(plugin) {
     if (typeof plugin !== 'function') {
@@ -83,10 +83,10 @@ NodeConfiguration.prototype._loadPlugin = function(plugin) {
 };
 
 /**
- * Loads an error filter module
+ * Loads an error filter module.
  *
  * @param {String|null} filter
- * @protected
+ * @private
  */
 NodeConfiguration.prototype._loadErrorFilter = function(filter) {
     Configuration.prototype._loadErrorFilter.call(
@@ -99,7 +99,7 @@ NodeConfiguration.prototype._loadErrorFilter = function(filter) {
  * Loads a custom esprima.
  *
  * @param {String|null} esprima
- * @protected
+ * @private
  */
 NodeConfiguration.prototype._loadEsprima = function(esprima) {
     Configuration.prototype._loadEsprima.call(
@@ -112,7 +112,7 @@ NodeConfiguration.prototype._loadEsprima = function(esprima) {
  * Loads additional rule.
  *
  * @param {String|Rule} additionalRule
- * @protected
+ * @private
  */
 NodeConfiguration.prototype._loadAdditionalRule = function(additionalRule) {
     if (typeof additionalRule === 'string') {

--- a/lib/config/node-configuration.js
+++ b/lib/config/node-configuration.js
@@ -48,9 +48,11 @@ NodeConfiguration.prototype.overrideFromCLI = function(program) {
 
 /**
  * Load external module.
+ *
  * @param {String|null} external - path (relative or absolute) or name to the external module
  * @param {String} type - type of the module
- * @return {Module}
+ * @returns {Module|null}
+ * @protected
  */
 NodeConfiguration.prototype.loadExternal = function(external, type) {
     assert(
@@ -71,8 +73,8 @@ NodeConfiguration.prototype.loadExternal = function(external, type) {
 /**
  * Loads plugin data.
  *
- * @param {String|null|Function} plugin
- * @private
+ * @param {String|function(Configuration)} plugin
+ * @protected
  */
 NodeConfiguration.prototype._loadPlugin = function(plugin) {
     if (typeof plugin !== 'function') {
@@ -86,7 +88,7 @@ NodeConfiguration.prototype._loadPlugin = function(plugin) {
  * Loads preset.
  *
  * @param {String|null} preset
- * @private
+ * @protected
  */
 NodeConfiguration.prototype._loadPreset = function(preset) {
     var registeredPresets = this.getRegisteredPresets();
@@ -110,7 +112,7 @@ NodeConfiguration.prototype._loadPreset = function(preset) {
  * Loads an error filter module.
  *
  * @param {String|null} filter
- * @private
+ * @protected
  */
 NodeConfiguration.prototype._loadErrorFilter = function(filter) {
     Configuration.prototype._loadErrorFilter.call(

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -37,17 +37,42 @@ Errors.prototype = {
             line = line.line;
         }
 
-        // line and column numbers should be explicit
-        assert(typeof line === 'number' && line > 0,
-            'Unable to add an error, `line` should be a number greater than 0 but ' + line + ' given');
-        assert(typeof column === 'number' && column >= 0,
-            'Unable to add an error, `column` should be a positive number but ' + column + ' given');
-
-        this._addError({
+        var errorInfo = {
             message: message,
             line: line,
             column: column
-        });
+        };
+
+        this._validateInput(errorInfo);
+        this._addError(errorInfo);
+    },
+
+    /**
+     * Adds style error to the list
+     *
+     * @param {Object} errorInfo
+     */
+    cast: function(errorInfo) {
+        var additional = errorInfo.additional;
+
+        assert(typeof additional !== undefined,
+               '`additional` argument should not be empty');
+
+        this._addError(errorInfo);
+    },
+
+    _validateInput: function(errorInfo) {
+        var line = errorInfo.line;
+        var column = errorInfo.column;
+
+        // line and column numbers should be explicit
+        assert(typeof line === 'number' && line > 0,
+            'Unable to add an error, `line` should be a number greater than 0 but ' +
+                line + ' given');
+
+        assert(typeof column === 'number' && column >= 0,
+            'Unable to add an error, `column` should be a positive number but ' +
+                column + ' given');
     },
 
     /**
@@ -61,12 +86,15 @@ Errors.prototype = {
             return;
         }
 
+        this._validateInput(errorInfo);
+
         this._errorList.push({
             filename: this._file.getFilename(),
             rule: this._currentRule,
             message: this._prepareMessage(errorInfo),
             line: errorInfo.line,
             column: errorInfo.column,
+            additional: errorInfo.additional,
             fixed: errorInfo.fixed
         });
     },

--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -106,13 +106,20 @@ module.exports.prototype = {
                     return;
                 }
 
-                errors.add(
-                    'Invalid quote mark found',
-                    token.loc.start.line,
-                    token.loc.start.column
-                );
+                errors.cast({
+                    message: 'Invalid quote mark found',
+                    line: token.loc.start.line,
+                    column: token.loc.start.column,
+                    additional: token
+                });
             }
         });
-    }
+    },
 
+    fix: function(error) {
+        var token = error.additional;
+        var fixer = require(this._quoteMark === '"' ? 'to-double-quotes' : 'to-single-quotes');
+
+        token.value = fixer(token.value);
+    }
 };

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -274,7 +274,7 @@ StringChecker.prototype = {
      * @returns {Boolean}
      */
     _maxErrorsEnabled: function() {
-        return this._maxErrors !== null && !isNaN(this._maxErrors);
+        return !isNaN(this._maxErrors) && this._maxErrors !== Infinity;
     },
 
     /**

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -6,6 +6,13 @@ var Configuration = require('./config/configuration');
 
 var MAX_FIX_ATTEMPTS = 5;
 
+function getErrorMessage(rule, e) {
+    return 'Error running rule ' + rule + ': ' +
+        'This is an issue with JSCS and not your codebase.\n' +
+        'Please file an issue (with the stack trace below) at: ' +
+        'https://github.com/jscs-dev/node-jscs/issues/new\n' + e;
+}
+
 /**
  * Starts Code Style checking process.
  * Params are deprecated, should be removed in 2.0
@@ -126,6 +133,41 @@ StringChecker.prototype = {
     },
 
     /**
+     * Fix provided error.
+     *
+     * @param {JsFile} file
+     * @param {Errors} errors
+     * @protected
+     */
+    _fixJsFile: function(file, errors) {
+        var list = errors.getErrorList();
+        var configuration = this.getConfiguration();
+
+        list.forEach(function(error) {
+            if (error.fixed) {
+                return;
+            }
+
+            var instance = configuration.getConfiguredRule(error.rule);
+
+            if (instance && instance.fix) {
+                try {
+
+                    // "error.fixed = true" should go first, so rule can
+                    // decide for itself (with "error.fixed = false")
+                    // if it can fix this particular error
+                    error.fixed = true;
+                    instance.fix(error);
+
+                } catch (e) {
+                    error.fixed = undefined;
+                    errors.add(getErrorMessage(error.rule, e), 1, 0);
+                }
+            }
+        });
+    },
+
+    /**
      * Checks a file specified using JsFile instance.
      * Fills Errors instance with validation errors.
      *
@@ -146,11 +188,7 @@ StringChecker.prototype = {
             try {
                 rule.check(file, errors);
             } catch (e) {
-                errors.add('Error running rule ' + rule.getOptionName() + ': ' +
-                    'This is an issue with JSCS and not your codebase.\n' +
-                    'Please file an issue (with the stack trace below) at: ' +
-                    'https://github.com/jscs-dev/node-jscs/issues/new\n' +
-                    e.stack, 1, 0);
+                errors.add(getErrorMessage(rule.getOptionName(), e.stack), 1, 0);
             }
         }, this);
 
@@ -249,6 +287,10 @@ StringChecker.prototype = {
 
                 // Changes to current sources are made in rules through assertions.
                 this._checkJsFile(file, errors);
+
+                // If assertions weren't used but rule has "fix" method,
+                // which we could use.
+                this._fixJsFile(file, errors);
 
                 var hasFixes = errors.getErrorList().some(function(err) {
                     return err.fixed;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "pathval": "~0.1.1",
     "prompt": "~0.2.14",
     "strip-json-comments": "~1.0.2",
+    "to-double-quotes": "^1.0.0",
+    "to-single-quotes": "^1.0.2",
     "vow": "~0.4.8",
     "vow-fs": "~0.3.4",
     "xmlbuilder": "^2.6.1"

--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -43,8 +43,15 @@ function execPresets(presets) {
         process.stdout.write(messages.start + '\n\n');
         process.stdout.write(chalk.magenta(' - ') + messages.fixStart + '\n');
 
+        child.stderr.setEncoding('utf8');
+
         // For some reason this makes subprocess to be more effective
         child.stdout.on('data', function() {});
+
+        child.stderr.on('data', function(data) {
+            process.stderr.write(chalk.red(' ! ') + 'Error:\n');
+            process.stderr.write(data);
+        });
 
         // Wait until autofix process is done
         child.on('close', function executeTests(code) {

--- a/test/specs/cli-config.js
+++ b/test/specs/cli-config.js
@@ -162,20 +162,6 @@ describe('modules/cli-config', function() {
             assert.equal(reporter.path, path.resolve('./lib/reporters/junit'));
         });
 
-        it('should get junit reporter with part of the path', function() {
-            var reporter = configFile.getReporter('./junit.js');
-
-            assert.equal(typeof reporter.writer, 'function');
-            assert.equal(reporter.path, path.resolve('./lib/reporters/junit.js'));
-        });
-
-        it('should get junit reporter with part of the path without extension', function() {
-            var reporter = configFile.getReporter('./junit');
-
-            assert.equal(typeof reporter.writer, 'function');
-            assert.equal(reporter.path, path.resolve('./lib/reporters/junit'));
-        });
-
         it('should get reporter with partial path', function() {
             var reporter = configFile.getReporter('./test/data/reporter/test-reporter.js');
 
@@ -201,6 +187,20 @@ describe('modules/cli-config', function() {
             assert.equal(reporter.path, path.resolve('./lib/reporters/text'));
 
             configFile.__set__('supportsColor', old);
+        });
+
+        it('should fake reporter from node', function() {
+            var reporter = configFile.getReporter('path');
+
+            assert.equal(typeof reporter.writer, 'object');
+            assert.equal(reporter.path, 'path');
+        });
+
+        it('should fake reporter from node_modules', function() {
+            var reporter = configFile.getReporter('sinon');
+
+            assert.equal(typeof reporter.writer, 'object');
+            assert.equal(reporter.path, 'sinon');
         });
     });
 });

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -81,7 +81,7 @@ describe('modules/cli', function() {
             preset: 'not-exist'
         });
 
-        return result.promise.fail(function() {
+        return result.promise.always(function() {
             assert.equal(console.error.getCall(0).args[0], 'Preset "not-exist" does not exist');
             console.error.restore();
         });

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -391,7 +391,7 @@ describe('modules/config/configuration', function() {
             };
             configuration.registerPreset('test1', {
                 es3: true,
-                ruleName: "test",
+                ruleName: 'test',
                 additionalRules: [rule]
             });
             configuration.registerPreset('test2', {
@@ -413,7 +413,7 @@ describe('modules/config/configuration', function() {
         it('should handle preset with custom rule which is not included', function() {
             configuration.registerPreset('test', {
                 es3: true,
-                ruleName: "test",
+                ruleName: 'test',
             });
 
             configuration.load({

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -38,6 +38,10 @@ describe('modules/config/configuration', function() {
         it('should have no default maximal error count', function() {
             assert(configuration.getMaxErrors() === null);
         });
+
+        it('should have no default preset', function() {
+            assert(configuration.getPresetName() === null);
+        });
     });
 
     describe('registerRule', function() {
@@ -363,7 +367,21 @@ describe('modules/config/configuration', function() {
             assert(configuration.getProcessedConfig().preset === 'test2');
             assert(configuration.getProcessedConfig().maxErrors === 1);
             assert(configuration.getProcessedConfig().es3);
+
             assert(configuration.getConfiguredRules()[0].exceptUndefined);
+        });
+
+        it('should load nullify rule from the preset', function() {
+            configuration.registerDefaultRules();
+            configuration.registerPreset('test', {
+                disallowMultipleVarDecl: true
+            });
+            configuration.load({
+                preset: 'test',
+                disallowMultipleVarDecl: null
+            });
+            assert(configuration.getProcessedConfig().preset === 'test');
+            assert.equal(configuration.getConfiguredRules().length, 0);
         });
 
         it('should not add duplicative values to list of unsupported rules', function() {
@@ -412,15 +430,14 @@ describe('modules/config/configuration', function() {
 
         it('should handle preset with custom rule which is not included', function() {
             configuration.registerPreset('test', {
-                es3: true,
-                ruleName: 'test',
+                ruleName: 'test'
             });
 
             configuration.load({
                 preset: 'test'
             });
 
-            assert(configuration.getUnsupportedRuleNames()[ 0 ], 'ruleName')
+            assert(configuration.getUnsupportedRuleNames()[ 0 ], 'ruleName');
             assert(!('ruleName' in configuration.getProcessedConfig()));
         });
 

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -297,6 +297,21 @@ describe('modules/config/configuration', function() {
         });
     });
 
+    describe('getConfiguredRule', function() {
+        it('should return configured rule after config load', function() {
+            assert(configuration.getConfiguredRule('ruleName') === null);
+            var rule = {
+                getOptionName: function() {
+                    return 'ruleName';
+                },
+                configure: function() {}
+            };
+            configuration.registerRule(rule);
+            configuration.load({ruleName: true});
+            assert(typeof configuration.getConfiguredRule('ruleName') === 'object');
+        });
+    });
+
     describe('isFileExcluded', function() {
         it('should return `false` if no `excludeFiles` are defined', function() {
             assert(!configuration.isFileExcluded('1.js'));

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -18,6 +18,42 @@ describe('modules/config/node-configuration', function() {
         });
     });
 
+    describe('loadExternal', function() {
+        it('should check type', function() {
+            assert.throws(
+                configuration.loadExternal.bind(configuration, 'test', 1),
+                "test option requires a string or null value"
+            );
+        });
+
+        it('should not load or throw if value is null', function() {
+            assert.equal(configuration.loadExternal(null), null);
+        });
+
+        it('should load relative path', function() {
+            assert.equal(
+                typeof configuration.loadExternal('./test/data/plugin/plugin'),
+                "function"
+            );
+        });
+
+        it('should load absolute path', function() {
+            assert.equal(
+                typeof configuration.loadExternal(
+                    path.resolve('./test/data/plugin/plugin')
+                ),
+                "function"
+            );
+        });
+
+        it('should load node module', function() {
+            assert.equal(
+                typeof configuration.loadExternal('path'),
+                "object"
+            );
+        });
+    });
+
     describe('overrideFromCLI', function() {
         it('should override allowed options from CLI', function() {
             configuration.overrideFromCLI({
@@ -68,7 +104,7 @@ describe('modules/config/node-configuration', function() {
 
         it('should accept `additionalRules` to register rule paths', function() {
             configuration.load({
-                additionalRules: ['rules/additional-rules.js'],
+                additionalRules: ['./rules/additional-rules.js'],
                 configPath: path.resolve(__dirname + '/../../data/config.json')
             });
             assert(configuration.getRegisteredRules().length === 1);
@@ -77,7 +113,7 @@ describe('modules/config/node-configuration', function() {
 
         it('should accept `additionalRules` to register rule path masks', function() {
             configuration.load({
-                additionalRules: ['rules/*.js'],
+                additionalRules: ['./rules/*.js'],
                 configPath: path.resolve(__dirname + '/../../data/config.json')
             });
             assert(configuration.getRegisteredRules().length === 1);
@@ -120,10 +156,36 @@ describe('modules/config/node-configuration', function() {
             examplePluginSpy.reset();
         });
 
+        describe('esprima', function() {
+            it('should get esprima', function() {
+                configuration.load({
+                    esprima: 'esprima'
+                });
+
+                assert(typeof configuration.getCustomEsprima() === 'object');
+            });
+        });
+
         describe('error filter', function() {
             it('should accept `errorFilter` to register an error filter', function() {
                 configuration.load({
                     errorFilter: path.resolve(__dirname, '../../data/error-filter.js')
+                });
+
+                assert(typeof configuration.getErrorFilter() === 'function');
+            });
+
+            it('should accept `errorFilter` from node', function() {
+                configuration.load({
+                    errorFilter: 'stream'
+                });
+
+                assert(typeof configuration.getErrorFilter() === 'function');
+            });
+
+            it('should accept `errorFilter` from node_modules', function() {
+                configuration.load({
+                    errorFilter: 'browserify'
                 });
 
                 assert(typeof configuration.getErrorFilter() === 'function');

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -22,7 +22,7 @@ describe('modules/config/node-configuration', function() {
         it('should check type', function() {
             assert.throws(
                 configuration.loadExternal.bind(configuration, 'test', 1),
-                "test option requires a string or null value"
+                'test option requires a string or null value'
             );
         });
 
@@ -33,7 +33,7 @@ describe('modules/config/node-configuration', function() {
         it('should load relative path', function() {
             assert.equal(
                 typeof configuration.loadExternal('./test/data/plugin/plugin'),
-                "function"
+                'function'
             );
         });
 
@@ -42,14 +42,14 @@ describe('modules/config/node-configuration', function() {
                 typeof configuration.loadExternal(
                     path.resolve('./test/data/plugin/plugin')
                 ),
-                "function"
+                'function'
             );
         });
 
         it('should load node module', function() {
             assert.equal(
                 typeof configuration.loadExternal('path'),
-                "object"
+                'object'
             );
         });
     });
@@ -90,6 +90,70 @@ describe('modules/config/node-configuration', function() {
     });
 
     describe('load', function() {
+        it('should load existed preset', function() {
+            configuration.registerDefaultRules();
+            configuration.registerPreset('test', {
+                disallowMultipleVarDecl: 'exceptUndefined'
+            });
+            configuration.load({preset: 'test'});
+
+            assert(configuration.getRegisteredRules()[0].getOptionName(), 'exceptUndefined');
+        });
+
+        it('should load external preset', function() {
+            configuration.registerDefaultRules();
+
+            configuration.load({
+                preset: path.resolve(__dirname + '/../../../presets/jquery.json')
+            });
+
+            assert.equal(
+                configuration.getRegisteredRules()[0].getOptionName(),
+                'requireCurlyBraces'
+            );
+            assert.equal(configuration.getPresetName(), 'jquery');
+        });
+
+        it('should try to load preset from node', function() {
+            configuration.registerDefaultRules();
+            configuration.load({
+                preset: 'path'
+            });
+
+            assert.equal(configuration.getPresetName(), 'path');
+            assert(configuration.getUnsupportedRuleNames().indexOf('resolve') > -1);
+        });
+
+        it('should try to load preset from node_modules', function() {
+            configuration.registerDefaultRules();
+            configuration.load({
+                preset: 'sinon'
+            });
+
+            assert.equal(configuration.getPresetName(), 'sinon');
+            assert(configuration.getUnsupportedRuleNames().indexOf('spy') > -1);
+        });
+
+        it('should throw if preset is missing', function() {
+            configuration.registerDefaultRules();
+            assert.throws(
+                configuration.load.bind(configuration, {
+                    preset: 'not-exist'
+                }),
+                'Preset "not-exist" does not exist'
+            );
+        });
+
+        it('should try to load preset from node_modules', function() {
+            configuration.registerDefaultRules();
+            configuration.load({
+                preset: 'sinon'
+            });
+
+            assert.equal(configuration.getPresetName(), 'sinon');
+            assert(configuration.getUnsupportedRuleNames().indexOf('spy') > -1);
+        });
+
         it('should accept `additionalRules` to register rule instances', function() {
             var rule = {
                 getOptionName: function() {

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -107,10 +107,16 @@ describe('modules/config/node-configuration', function() {
                 preset: path.resolve(__dirname + '/../../../presets/jquery.json')
             });
 
-            assert.equal(
-                configuration.getRegisteredRules()[0].getOptionName(),
-                'requireCurlyBraces'
-            );
+            var exist = false;
+            configuration.getRegisteredRules().forEach(function(rule) {
+                if (exist) {
+                    return;
+                }
+
+                exist = rule.getOptionName() === 'requireCurlyBraces';
+            });
+
+            assert(exist);
             assert.equal(configuration.getPresetName(), 'jquery');
         });
 

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -90,7 +90,7 @@ describe('modules/config/node-configuration', function() {
     });
 
     describe('load', function() {
-        it('should load existed preset', function() {
+        it('should load existing preset', function() {
             configuration.registerDefaultRules();
             configuration.registerPreset('test', {
                 disallowMultipleVarDecl: 'exceptUndefined'

--- a/test/specs/errors.js
+++ b/test/specs/errors.js
@@ -128,6 +128,78 @@ describe('modules/errors', function() {
         });
     });
 
+    describe('cast', function() {
+        var errors;
+        beforeEach(function() {
+            errors = checker.checkString('yay');
+        });
+
+        it('should throw an error on invalid line type', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: '0'
+                });
+            });
+        });
+
+        it('should throw an error on invalid line value', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 0
+                });
+            });
+        });
+
+        it('should throw an error on invalid column type', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: '2'
+                });
+            });
+        });
+
+        it('should throw an error on invalid column value', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: -1
+                });
+            });
+        });
+
+        it('should throw without "additional" argument', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: -1
+                });
+            });
+        });
+
+        it('should correctly set error', function() {
+            errors.setCurrentRule('anyRule');
+            errors.cast({
+                message: 'msg',
+                column: 0,
+                line: 1,
+                additional: 'test'
+            });
+
+            var error = errors.getErrorList()[0];
+
+            assert.equal(error.rule, 'anyRule');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 0);
+            assert.equal(error.additional, 'test');
+        });
+    });
+
     describe('add with verbose', function() {
         var errors;
         beforeEach(function() {

--- a/test/specs/reporters/checkstyle.js
+++ b/test/specs/reporters/checkstyle.js
@@ -7,12 +7,12 @@ var Checker = require('../../../lib/checker');
 var checkstyle = require('../../../lib/reporters/checkstyle');
 
 describe('reporters/checkstyle', function() {
-    var checker = new Checker();
-
-    checker.registerDefaultRules();
-    checker.configure({ disallowKeywords: ['with'] });
-
     it('should correctly report error results', function(done) {
+        var checker = new Checker();
+
+        checker.registerDefaultRules();
+        checker.configure({ disallowKeywords: ['with'] });
+
         var output = '';
 
         sinon.stub(console, 'log', function(xml) {

--- a/test/specs/rules/validate-quote-marks.js
+++ b/test/specs/rules/validate-quote-marks.js
@@ -1,4 +1,5 @@
 var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 var assert = require('assert');
 
 describe('rules/validate-quote-marks', function() {
@@ -180,5 +181,29 @@ describe('rules/validate-quote-marks', function() {
         it('should not report inconsistent quotes in comments', function() {
             assert(checker.checkString('var x = "x", y = "y"; /*\'y\'*/').isEmpty());
         });
+    });
+
+    reportAndFix({
+        name: 'should fix (simple case)',
+        rules: {
+            validateQuoteMarks: {
+                mark: '"',
+                escape: true
+            }
+        },
+        input: '\'\'',
+        output: '""'
+    });
+
+    reportAndFix({
+        name: 'should fix \'1\'2\'',
+        rules: {
+            validateQuoteMarks: '\''
+        },
+        errors: 1,
+        input: ' "1\'2" ',
+
+        // Check string in the string with same quotes, had to use "\\\"
+        output: ' \'1\\\'2\' '
     });
 });


### PR DESCRIPTION
Addresses https://github.com/jscs-dev/node-jscs/issues/1201 https://github.com/jscs-dev/node-jscs/pull/1202 https://github.com/jscs-dev/node-jscs/pull/1265, but most importantly #1113.

Example with `validateQuoteMarks` is just that, example.

Since this pull incorporates #1150, diff is pretty big, i will create 2.0 branch merge #1150 and change target branch of this pull, it should make everything more clearer, meanwhile you could use  <a href="https://github.com/markelog/node-jscs/compare/8192eab...fb450">this</a> link instead.

This pull represents two different ideas for autofix infrastructure - "fix" field and assertion interface. 

Which is bad, we need to make them complimentary to each other or unite approaches, but we need to keep ball rolling need to release 2.0 soon, we can improve/refactor later. 