### PR TITLE
maximumLineLength: allow function declarations to exceed limit

### DIFF
--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -8,7 +8,7 @@
  *  - `Object`:
  *     - `value`: (required) lines should be at most the number of characters specified
  *     - `tabSize`: (default: `1`) considered the tab character as number of specified spaces
- *     - `allExcept`: (default: `[]`) an array of conditions that will exempt a line
+ *     - `ignore`: (default: `[]`) an array of conditions that will exempt a line
  *        - `regex`: allows regular expression literals to break the rule
  *        - `comments`: allows comments to break the rule
  *        - `urlComments`: allows comments with long urls to break the rule
@@ -38,7 +38,7 @@
 var assert = require('assert');
 var chalk  = require('chalk');
 var DEPRECATED = '[ ' + chalk.yellow('WARN') + ' ] ${option}.${setting} is deprecated.' +
-                 'Please use the corresponding `allExcept` setting instead';
+                 'Please use the corresponding `ignore` setting instead';
 
 module.exports = function() {};
 
@@ -63,7 +63,7 @@ module.exports.prototype = {
                 this._tabSize += ' ';
             }
 
-            var exceptions = maximumLineLength.allExcept || [];
+            var exceptions = maximumLineLength.ignore || [];
             this._allowRegex = (exceptions.indexOf('regex') !== -1);
             this._allowComments = (exceptions.indexOf('comments') !== -1);
             this._allowUrlComments = (exceptions.indexOf('urlComments') !== -1);
@@ -141,14 +141,12 @@ module.exports.prototype = {
                         searchBodyForDecl(bodyNode.body);
                         return;
 
-                    } else if (bodyNode.type === 'ClassBody') {
-                        searchBodyForDecl(bodyNode.body);
-                        return;
                     } else if (bodyNode.type === 'MethodDefinition') {
                         // get the loc for method name
                         functionDeclarationLocs.push(bodyNode.key.loc);
                         // get the locs for the params
                         bodyNode.value.params.forEach(function(param) { functionDeclarationLocs.push(param.loc); });
+                        return;
                     }
                 });
             };

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -8,9 +8,11 @@
  *  - `Object`:
  *     - `value`: (required) lines should be at most the number of characters specified
  *     - `tabSize`: (default: `1`) considered the tab character as number of specified spaces
- *     - `allowComments`: (default: `false`) allows comments to break the rule
- *     - `allowUrlComments`: (default: `false`) allows comments with long urls to break the rule
- *     - `allowRegex`: (default: `false`) allows regular expression literals to break the rule
+ *     - `allExcept`: (default: `[]`) an array of conditions that will exempt a line
+ *        - `regex`: allows regular expression literals to break the rule
+ *        - `comments`: allows comments to break the rule
+ *        - `urlComments`: allows comments with long urls to break the rule
+ *        - `functionSignature`: allows function definitions to break the rule
  *
  * JSHint: [`maxlen`](http://jshint.com/docs/options/#maxlen)
  *
@@ -58,9 +60,11 @@ module.exports.prototype = {
                 this._tabSize += ' ';
             }
 
-            this._allowRegex = (maximumLineLength.allowRegex === true);
-            this._allowComments = (maximumLineLength.allowComments === true);
-            this._allowUrlComments = (maximumLineLength.allowUrlComments === true);
+            var exceptions = maximumLineLength.allExcept || [];
+            this._allowRegex = (exceptions.indexOf('regex') !== -1);
+            this._allowComments = (exceptions.indexOf('comments') !== -1);
+            this._allowUrlComments = (exceptions.indexOf('urlComments') !== -1);
+            this._allowFunctionSignature = (exceptions.indexOf('functionSignature') !== -1);
         } else {
             assert(
                 typeof maximumLineLength === 'number',
@@ -97,6 +101,41 @@ module.exports.prototype = {
             file.iterateTokensByType(['Line', 'Block'], function(comment) {
                 for (var i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
                     lines[i - 1] = lines[i - 1].replace(/(http|https|ftp):\/\/[^\s$]+/, '');
+                }
+            });
+        }
+
+        if (this._allowFunctionSignature) {
+            var functionDeclarationLocs = [];
+            var searchBodyForDecl = function searchBodyForDecl(node) {
+                node.body.forEach(function(bodyNode) {
+                    if (bodyNode.type === 'FunctionDeclaration') {
+                        // get the loc for the `function Identifier` portion
+                        functionDeclarationLocs.push(bodyNode.id.loc);
+                        // get the locs for the params
+                        bodyNode.params.forEach(function(param) { functionDeclarationLocs.push(param.loc); });
+                        return;
+
+                    } else if (bodyNode.type === 'ClassDeclaration') {
+                        searchBodyForDecl(bodyNode.body);
+                        return;
+
+                    } else if (bodyNode.type === 'ClassBody') {
+                        searchBodyForDecl(bodyNode.body);
+                        return;
+                    } else if (bodyNode.type === 'MethodDefinition') {
+                        // get the loc for method name
+                        functionDeclarationLocs.push(bodyNode.key.loc);
+                        // get the locs for the params
+                        bodyNode.value.params.forEach(function(param) { functionDeclarationLocs.push(param.loc); });
+                    }
+                });
+            };
+            searchBodyForDecl(file.getTree());
+
+            functionDeclarationLocs.forEach(function(loc) {
+                for (var i = loc.start.line; i <= loc.end.line; i++) {
+                    lines[i - 1] = '';
                 }
             });
         }

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -36,6 +36,9 @@
  */
 
 var assert = require('assert');
+var chalk  = require('chalk');
+var DEPRECATED = '[ ' + chalk.yellow('WARN') + ' ] ${option}.${setting} is deprecated.' +
+                 'Please use the corresponding `allExcept` setting instead';
 
 module.exports = function() {};
 
@@ -65,6 +68,23 @@ module.exports.prototype = {
             this._allowComments = (exceptions.indexOf('comments') !== -1);
             this._allowUrlComments = (exceptions.indexOf('urlComments') !== -1);
             this._allowFunctionSignature = (exceptions.indexOf('functionSignature') !== -1);
+
+            if (maximumLineLength.hasOwnProperty('allowRegex')) {
+                console.log(DEPRECATED.replace('${option}', this.getOptionName())
+                            .replace('${setting}', 'allowRegex'));
+                this._allowRegex = (maximumLineLength.allowRegex === true);
+            }
+            if (maximumLineLength.hasOwnProperty('allowComments')) {
+                console.log(DEPRECATED.replace('${option}', this.getOptionName())
+                            .replace('${setting}', 'allowComments'));
+                this._allowComments = (maximumLineLength.allowComments === true);
+            }
+            if (maximumLineLength.hasOwnProperty('allowUrlComments')) {
+                console.log(DEPRECATED.replace('${option}', this.getOptionName())
+                            .replace('${setting}', 'allowUrlComments'));
+                this._allowUrlComments = (maximumLineLength.allowUrlComments === true);
+            }
+
         } else {
             assert(
                 typeof maximumLineLength === 'number',
@@ -80,6 +100,7 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        // console.log('check file: ', file._source);
         var maximumLineLength = this._maximumLineLength;
 
         var line;

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -8,11 +8,14 @@
  *  - `Object`:
  *     - `value`: (required) lines should be at most the number of characters specified
  *     - `tabSize`: (default: `1`) considered the tab character as number of specified spaces
- *     - `ignore`: (default: `[]`) an array of conditions that will exempt a line
+ *     - `allExcept`: (default: `[]`) an array of conditions that will exempt a line
  *        - `regex`: allows regular expression literals to break the rule
  *        - `comments`: allows comments to break the rule
  *        - `urlComments`: allows comments with long urls to break the rule
  *        - `functionSignature`: allows function definitions to break the rule
+ *     - `allowRegex`: *deprecated* use `allExcept: ["regex"]` instead
+ *     - `allowComments`: *deprecated* use `allExcept: ["comments"]` instead
+ *     - `allowUrlComments`: *deprecated* use `allExcept: ["urlComments"]` instead
  *
  * JSHint: [`maxlen`](http://jshint.com/docs/options/#maxlen)
  *
@@ -36,9 +39,6 @@
  */
 
 var assert = require('assert');
-var chalk  = require('chalk');
-var DEPRECATED = '[ ' + chalk.yellow('WARN') + ' ] ${option}.${setting} is deprecated.' +
-                 'Please use the corresponding `ignore` setting instead';
 
 module.exports = function() {};
 
@@ -63,25 +63,19 @@ module.exports.prototype = {
                 this._tabSize += ' ';
             }
 
-            var exceptions = maximumLineLength.ignore || [];
+            var exceptions = maximumLineLength.allExcept || [];
             this._allowRegex = (exceptions.indexOf('regex') !== -1);
             this._allowComments = (exceptions.indexOf('comments') !== -1);
             this._allowUrlComments = (exceptions.indexOf('urlComments') !== -1);
             this._allowFunctionSignature = (exceptions.indexOf('functionSignature') !== -1);
 
             if (maximumLineLength.hasOwnProperty('allowRegex')) {
-                console.log(DEPRECATED.replace('${option}', this.getOptionName())
-                            .replace('${setting}', 'allowRegex'));
                 this._allowRegex = (maximumLineLength.allowRegex === true);
             }
             if (maximumLineLength.hasOwnProperty('allowComments')) {
-                console.log(DEPRECATED.replace('${option}', this.getOptionName())
-                            .replace('${setting}', 'allowComments'));
                 this._allowComments = (maximumLineLength.allowComments === true);
             }
             if (maximumLineLength.hasOwnProperty('allowUrlComments')) {
-                console.log(DEPRECATED.replace('${option}', this.getOptionName())
-                            .replace('${setting}', 'allowUrlComments'));
                 this._allowUrlComments = (maximumLineLength.allowUrlComments === true);
             }
 
@@ -100,7 +94,6 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        // console.log('check file: ', file._source);
         var maximumLineLength = this._maximumLineLength;
 
         var line;

--- a/presets/google.json
+++ b/presets/google.json
@@ -12,7 +12,7 @@
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "maximumLineLength": {
       "value": 80,
-      "allExcept": ["comments", "regex"]
+      "ignore": ["comments", "regex"]
     },
     "validateIndentation": 2,
     "validateQuoteMarks": "'",

--- a/presets/google.json
+++ b/presets/google.json
@@ -12,8 +12,7 @@
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "maximumLineLength": {
       "value": 80,
-      "allowComments": true,
-      "allowRegex": true
+      "allExcept": ["comments", "regex"]
     },
     "validateIndentation": 2,
     "validateQuoteMarks": "'",

--- a/presets/google.json
+++ b/presets/google.json
@@ -12,7 +12,7 @@
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "maximumLineLength": {
       "value": 80,
-      "ignore": ["comments", "regex"]
+      "allExcept": ["comments", "regex"]
     },
     "validateIndentation": 2,
     "validateQuoteMarks": "'",

--- a/presets/jquery.json
+++ b/presets/jquery.json
@@ -18,7 +18,7 @@
     "maximumLineLength": {
         "value": 100,
         "tabSize": 4,
-        "allExcept": ["urlComments", "regex"]
+        "ignore": ["urlComments", "regex"]
     },
     "validateQuoteMarks": { "mark": "\"", "escape": true },
 

--- a/presets/jquery.json
+++ b/presets/jquery.json
@@ -18,8 +18,7 @@
     "maximumLineLength": {
         "value": 100,
         "tabSize": 4,
-        "allowUrlComments": true,
-        "allowRegex": true
+        "allExcept": ["urlComments", "regex"]
     },
     "validateQuoteMarks": { "mark": "\"", "escape": true },
 

--- a/presets/jquery.json
+++ b/presets/jquery.json
@@ -18,7 +18,7 @@
     "maximumLineLength": {
         "value": 100,
         "tabSize": 4,
-        "ignore": ["urlComments", "regex"]
+        "allExcept": ["urlComments", "regex"]
     },
     "validateQuoteMarks": { "mark": "\"", "escape": true },
 

--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -88,7 +88,7 @@
 
     "maximumLineLength": {
         "value": 120,
-        "allowUrlComments": true
+        "allExcept": ["urlComments"]
     },
     "requireSpaceAfterLineComment": true,
     "requireLineFeedAtFileEnd": true,

--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -88,7 +88,7 @@
 
     "maximumLineLength": {
         "value": 120,
-        "allExcept": ["urlComments"]
+        "ignore": ["urlComments"]
     },
     "requireSpaceAfterLineComment": true,
     "requireLineFeedAtFileEnd": true,

--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -88,7 +88,7 @@
 
     "maximumLineLength": {
         "value": 120,
-        "ignore": ["urlComments"]
+        "allExcept": ["urlComments"]
     },
     "requireSpaceAfterLineComment": true,
     "requireLineFeedAtFileEnd": true,

--- a/test/data/options/preset/google.js
+++ b/test/data/options/preset/google.js
@@ -51,3 +51,8 @@ var arr = [1, 2, 3];
 var obj = {a: 1, b: 2, c: 3};
 // disallowSpacesInsideParentheses
 console.log('string');
+
+// maximumLineLength
+// should ignore really long comment lines .......................................
+// and regex
+var regex = /somesuperlongregex..................................................../;

--- a/test/data/options/preset/jquery.js
+++ b/test/data/options/preset/jquery.js
@@ -110,6 +110,11 @@ jQuery.extend = jQuery.fn.extend = function() {
   return target;
 };
 
+// maximumLineLength
+// long comment with a URL ................................................................. http://www.google.com
+// regex
+var seventyeightchars = /............................................................................../;
+
 // requireSpacesInFunctionExpression: before curly
 var each = function( obj, callback, args ) {
 

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -43,7 +43,7 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('allowComments option', function() {
+    describe('allExcept["comments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
@@ -59,9 +59,21 @@ describe('rules/maximum-line-length', function() {
         it('should not report comments but still report long code', function() {
             assert(checker.checkString('// a comment\nvar a = tooLong;').getErrorCount() === 1);
         });
+        it('should still allow the old setting', function() {
+            // we need a clean checker or we'll end up validating the file twice
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                maximumLineLength: {
+                    value: 4,
+                    allowComments: true
+                }
+            });
+            assert(checker.checkString('// a comment\nvar a = tooLong;').getErrorCount() === 1);
+        });
     });
 
-    describe('allowUrlComments option', function() {
+    describe('allExcept["urlComments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
@@ -101,9 +113,22 @@ describe('rules/maximum-line-length', function() {
             assert(checker.checkString('// www.example.com/is/not/a/url').getErrorCount() === 1);
             assert(checker.checkString('// example.com/is/not/a/url').getErrorCount() === 1);
         });
+        it('should should still support the old setting', function() {
+            // we need a clean checker or we'll end up validating the file twice
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                maximumLineLength: {
+                    value: 15,
+                    allowUrlComments: true
+                }
+            });
+            assert(checker.checkString('// <16 chars https://example.com' +
+                '\n/* <16 chars http://example.com\n <16 chars http://example.com*/').isEmpty());
+        });
     });
 
-    describe('allowRegex option', function() {
+    describe('allExcept["regex"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
@@ -125,7 +150,18 @@ describe('rules/maximum-line-length', function() {
         it('should not be destructive to original data', function() {
             assert(checker.checkString('var a = /regex/;')._file._lines[0].length > 1);
         });
-
+        it('should still should support the old setting', function() {
+            // we need a clean checker or we'll end up validating the file twice
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                maximumLineLength: {
+                    value: 4,
+                    allowRegex: true
+                }
+            });
+            assert(checker.checkString('var a = /longregex/;\nvar b = tooLong;').getErrorCount() === 1);
+        });
     });
 
     describe('allExcept["functionSignature"] option', function() {

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -48,7 +48,7 @@ describe('rules/maximum-line-length', function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    allowComments: true
+                    allExcept: ['comments']
                 }
             });
         });
@@ -66,7 +66,7 @@ describe('rules/maximum-line-length', function() {
             checker.configure({
                 maximumLineLength: {
                     value: 15,
-                    allowUrlComments: true
+                    allExcept: ['urlComments']
                 }
             });
         });
@@ -108,7 +108,7 @@ describe('rules/maximum-line-length', function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    allowRegex: true
+                    allExcept: ['regex']
                 }
             });
         });
@@ -126,5 +126,33 @@ describe('rules/maximum-line-length', function() {
             assert(checker.checkString('var a = /regex/;')._file._lines[0].length > 1);
         });
 
+    });
+
+    describe('allExcept["functionSignature"] option', function() {
+        beforeEach(function() {
+            checker.configure({
+                esnext: true,
+                maximumLineLength: {
+                    value: 20,
+                    allExcept: ['functionSignature']
+                }
+            });
+        });
+
+        it('should not report named functions', function() {
+            var code = 'function myCoolFunction(argument) { }';
+            assert(checker.checkString(code).isEmpty());
+        });
+        it('should not report class methods', function() {
+            var code = 'class MyClass {\n' +
+                    '  myMethodName(withArgs) {\n' +
+                    '  }\n' +
+                    '}';
+            assert(checker.checkString(code).isEmpty());
+        });
+        it('should report functions stored in variables', function() {
+            var code = 'var fn = function() {};';
+            assert(checker.checkString(code).getErrorCount() === 1);
+        });
     });
 });

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -43,12 +43,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('allExcept["comments"] option', function() {
+    describe('ignore["comments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    allExcept: ['comments']
+                    ignore: ['comments']
                 }
             });
         });
@@ -73,12 +73,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('allExcept["urlComments"] option', function() {
+    describe('ignore["urlComments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 15,
-                    allExcept: ['urlComments']
+                    ignore: ['urlComments']
                 }
             });
         });
@@ -128,12 +128,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('allExcept["regex"] option', function() {
+    describe('ignore["regex"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    allExcept: ['regex']
+                    ignore: ['regex']
                 }
             });
         });
@@ -164,13 +164,13 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('allExcept["functionSignature"] option', function() {
+    describe('ignore["functionSignature"] option', function() {
         beforeEach(function() {
             checker.configure({
                 esnext: true,
                 maximumLineLength: {
                     value: 20,
-                    allExcept: ['functionSignature']
+                    ignore: ['functionSignature']
                 }
             });
         });

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -43,12 +43,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('ignore["comments"] option', function() {
+    describe('allExcept["comments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    ignore: ['comments']
+                    allExcept: ['comments']
                 }
             });
         });
@@ -73,12 +73,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('ignore["urlComments"] option', function() {
+    describe('allExcept["urlComments"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 15,
-                    ignore: ['urlComments']
+                    allExcept: ['urlComments']
                 }
             });
         });
@@ -128,12 +128,12 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('ignore["regex"] option', function() {
+    describe('allExcept["regex"] option', function() {
         beforeEach(function() {
             checker.configure({
                 maximumLineLength: {
                     value: 4,
-                    ignore: ['regex']
+                    allExcept: ['regex']
                 }
             });
         });
@@ -164,13 +164,13 @@ describe('rules/maximum-line-length', function() {
         });
     });
 
-    describe('ignore["functionSignature"] option', function() {
+    describe('allExcept["functionSignature"] option', function() {
         beforeEach(function() {
             checker.configure({
                 esnext: true,
                 maximumLineLength: {
                     value: 20,
-                    ignore: ['functionSignature']
+                    allExcept: ['functionSignature']
                 }
             });
         });


### PR DESCRIPTION

As is this will break existing configurations. It sounded like that was the desired change from the issue, but I can put backwards compatibility back in (with an appropriate warning message).

Fixes #1412