### PR TITLE
requireArrowFunctions: don't check AssignmentExpression or Property

### DIFF
--- a/lib/rules/require-arrow-functions.js
+++ b/lib/rules/require-arrow-functions.js
@@ -33,9 +33,16 @@
  * ##### Invalid
  *
  * ```js
+ * // function expression in a callback
  * [1, 2, 3].map(function (x) {
  *     return x * x;
  * });
+ * // function expression in a return statement
+ * function a(x) {
+ *     return function(x) { return x };
+ * };
+ * // function expression in a variable declaration
+ * var a = function(x) { return x };
  * ```
  */
 
@@ -57,18 +64,24 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType(['FunctionExpression'], function(node) {
-            if (node.parentNode && (
+            var parent = node.parentNode;
+            if (parent && (
                 // exception for object shorthand methods
-                node.parentNode.method === true ||
-                // exception for class methods
-                node.parentNode.type === 'MethodDefinition' ||
+                parent.method === true ||
                 // exception for getter
-                node.parentNode.kind === 'get' ||
+                parent.kind === 'get' ||
                 // exception for setter
-                node.parentNode.kind === 'set')
+                parent.kind === 'set' ||
+                // exception for class methods
+                parent.type === 'MethodDefinition' ||
+                // don't error due to possible use of 'this' #1413
+                parent.type === 'AssignmentExpression' ||
+                // don't error due to possible use of 'this' #1413
+                parent.type === 'Property')
             ) {
                 return;
             }
+
             errors.add('Use arrow functions instead of function expressions', node.loc.start);
         });
     }

--- a/test/specs/rules/require-arrow-functions.js
+++ b/test/specs/rules/require-arrow-functions.js
@@ -10,7 +10,7 @@ describe('rules/require-arrow-functions', function() {
         checker.configure({ requireArrowFunctions: true, esnext: true });
     });
 
-    it('should report use of anonymous function expression', function() {
+    it('should report use of anonymous function expression in VariableDeclaration', function() {
         assert(checker.checkString([
             'var anon = function(n) {',
                 'return n + 1;',
@@ -18,7 +18,7 @@ describe('rules/require-arrow-functions', function() {
         ].join('\n')).getErrorCount() === 1);
     });
 
-    it('should report use of named function expression', function() {
+    it('should report use of named function expression in VariableDeclaration', function() {
         assert(checker.checkString([
             'var a = function named(n) {',
                 'return n + 1;',
@@ -34,16 +34,25 @@ describe('rules/require-arrow-functions', function() {
         ].join('\n')).getErrorCount() === 1);
     });
 
-    it('should report use of object property function expression', function() {
+    it('should report use of function expression in a ReturnStatement', function() {
+        assert(checker.checkString('function a() { return function() {} }').getErrorCount() === 1);
+    });
+
+    it('should not report use of object property function expression #1413', function() {
         assert(checker.checkString([
             'var foo = {};',
             'foo.bar = function() {};'
-        ].join('\n')).getErrorCount() === 1);
+        ].join('\n')).isEmpty());
         assert(checker.checkString([
             'var foo = {',
               'bar: function() {}',
             '};'
-        ].join('\n')).getErrorCount() === 1);
+        ].join('\n')).isEmpty());
+    });
+
+    it('should not report function expression in a AssignmentExpression', function() {
+        assert(checker.checkString('a.b = function() {}').isEmpty());
+        assert(checker.checkString('a.b.c = function() {}').isEmpty());
     });
 
     it('should not report a function declaration', function() {


### PR DESCRIPTION
Fixes #1413 

Current idea is don't check for those.

```js
// should use method shorthand syntax instead, otherwise `this` becomes undefined.
var a = {
  b: 1,
  normalFunction: function() { return this.b; },
  arrowFunc: () => { return this.b; },  // undefined.b;
  methodShorthand() { return this.b; }
};
var a.arrow = () => { return this.b }; // undefined.b;
```

Or we figure out if `this` is being used or some other idea.