### PR TITLE
StringChecker: Remove grit processing includes

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -862,6 +862,16 @@ function parseJavaScriptSource(source, esprima, esprimaOptions) {
         return '//' + str.slice(2);
     });
 
+    var gritData = {};
+    var hasGritData = false;
+    // Process grit tags like `<if ...>` and `<include ...>`
+    source = source.replace(/^\s*<\/?\s*(if|include)[^]*?>/gm, function(str, p1, pos) {
+        hasGritData = true;
+        gritData[pos] = str.substring(0, str.length - 1);
+        // Cut 4 characters to save correct line/column info for surrounding code
+        return '/*' + str.slice(4) + '*/';
+    });
+
     tree = esprima.parse(source, finalEsprimaOptions);
 
     // Change the bin annotation comment
@@ -876,6 +886,16 @@ function parseJavaScriptSource(source, esprima, esprimaOptions) {
             if (instrumentationData.hasOwnProperty(rangeStart)) {
                 token.type = 'InstrumentationDirective';
                 token.value = instrumentationData[rangeStart];
+            }
+        });
+    }
+
+    if (hasGritData) {
+        tree.comments.forEach(function(token) {
+            var rangeStart = token.range[0];
+            if (gritData.hasOwnProperty(rangeStart)) {
+                token.type = 'GritTag';
+                token.value = gritData[rangeStart];
             }
         });
     }

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -94,6 +94,41 @@ describe('modules/js-file', function() {
             assert.equal(parseError.lineNumber, 2);
             assert.equal(parseError.column, 2);
         });
+
+        it('should ignore lines containing only <include> tag', function() {
+            var file = createJsFile('<include src="file.js">\n' +
+                '  <include src="file.js">\n' +
+                '< include src="file.js" >\n' +
+                '<include\n' +
+                ' src="file.js">\n' +
+                'var a = 5;\n');
+            var comments = file._tree.comments;
+            var gritTags = comments.filter(function(comment) {
+                return comment.type === 'GritTag';
+            });
+
+            assert.equal(4, comments.length);
+            assert.equal(4, gritTags.length);
+        });
+
+        it('should ignore lines containing only <if> tag', function() {
+            var file = createJsFile('<if expr="false">\n' +
+                '  <if expr="false">\n' +
+                '< if expr="false" >\n' +
+                'var a = 5;\n' +
+                '</if>\n' +
+                '<if\n' +
+                ' expr="false">\n' +
+                'var b = 7;\n' +
+                '</ if>');
+            var comments = file._tree.comments;
+            var gritTags = comments.filter(function(comment) {
+                return comment.type === 'GritTag';
+            });
+
+            assert.equal(6, comments.length);
+            assert.equal(6, gritTags.length);
+        });
     });
 
     describe('isEnabledRule', function() {


### PR DESCRIPTION
Comment grit tags like `<include>` and `<if>` so esprima does not throw
parsing errors.

Fixes #1374