### PR TITLE
Make requireAlignedObjectValues work with disallowSpaceAfterObjectKeys

### DIFF
--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -7,6 +7,7 @@
  *  - `true`
  *  - `"ignoreSingleLine"` ignores objects if the object only takes up a single line
  *  - `"ignoreMultiLine"` ignores objects if the object takes up multiple lines
+ *  - `"ignoreAligned"` ignores aligned object properties
  *
  * #### Example
  *
@@ -33,7 +34,8 @@ module.exports.prototype = {
     configure: function(disallow) {
         var modes = {
             'ignoreSingleLine': 'ignoreSingleLine',
-            'ignoreMultiLine': 'ignoreMultiLine'
+            'ignoreMultiLine': 'ignoreMultiLine',
+            'ignoreAligned': 'ignoreAligned'
         };
         assert(
             disallow === true || typeof disallow === 'string' && modes[disallow],
@@ -51,21 +53,38 @@ module.exports.prototype = {
     check: function(file, errors) {
         var mode = this._mode;
         file.iterateNodesByType('ObjectExpression', function(node) {
+            var multiline = node.loc.start.line !== node.loc.end.line;
+            if (mode === 'ignoreSingleLine' && !multiline) {
+                return;
+            }
+            if (mode === 'ignoreMultiLine' && multiline) {
+                return;
+            }
+
+            var maxKeyEndPos = 0;
+            var tokens = [];
             node.properties.forEach(function(property) {
                 if (property.shorthand || property.kind !== 'init') {
                     return;
                 }
-                if (mode === 'ignoreSingleLine' && node.loc.start.line === node.loc.end.line) {
-                    return;
-                }
-                if (mode === 'ignoreMultiLine' && node.loc.start.line !== node.loc.end.line) {
-                    return;
-                }
 
-                var token = file.getFirstNodeToken(property.key);
-                errors.assert.noWhitespaceBetween({
-                    token: token,
-                    nextToken: file.getNextToken(token),
+                var keyToken = file.getFirstNodeToken(property.key);
+                if (mode === 'ignoreAligned') {
+                    maxKeyEndPos = Math.max(maxKeyEndPos, keyToken.loc.end.column);
+                }
+                tokens.push(keyToken);
+            });
+
+            tokens.forEach(function(key) {
+                var colon = file.getNextToken(key);
+                var space = 0;
+                if (mode === 'ignoreAligned') {
+                    space = maxKeyEndPos - key.loc.end.column;
+                }
+                errors.assert.spacesBetween({
+                    token: key,
+                    nextToken: colon,
+                    exactly: space,
                     message: 'Illegal space after key',
                     disallowNewLine: true
                 });

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -5,11 +5,15 @@
  *
  * Values:
  *  - `true`
+ *  - `"ignoreSingleLine"` ignores objects if the object only takes up a single line
+ *    (*deprecated* use `"allExcept": [ "singleline" ]`)
+ *  - `"ignoreMultiLine"` ignores objects if the object takes up multiple lines
+ *    (*deprecated* use `"allExcept": [ "multiline" ]`)
  *  - `Object`:
- *     - `allExcept`: array of exceptions:
- *       - `"singleline"` ignores objects if the object only takes up a single line
- *       - `"multiline"` ignores objects if the object takes up multiple lines
- *       - `"aligned"` ignores aligned object properties
+ *     - `"allExcept"`: array of exceptions:
+ *        - `"singleline"` ignores objects if the object only takes up a single line
+ *        - `"multiline"` ignores objects if the object takes up multiple lines
+ *        - `"aligned"` ignores aligned object properties
  *
  * #### Example
  *
@@ -100,12 +104,12 @@ module.exports.prototype = {
         assert(
             !this._exceptMultiline || !this._exceptAligned,
             this.getOptionName() +
-            ' option allExcept property cannot contain "aligned" and "multiline" at the same time'
+            ' option allExcept property cannot contain `aligned` and `multiline` at the same time'
         );
         assert(
             !this._exceptMultiline || !this._exceptSingleline,
             this.getOptionName() +
-            ' option allExcept property cannot contain "singleline" and "multiline" at the same time'
+            ' option allExcept property cannot contain `singleline` and `multiline` at the same time'
         );
     },
 
@@ -143,11 +147,11 @@ module.exports.prototype = {
 
             tokens.forEach(function(key) {
                 var colon = file.getNextToken(key);
-                var space = exceptAligned ? maxKeyEndPos - key.loc.end.column : 0;
+                var spaces = exceptAligned ? maxKeyEndPos - key.loc.end.column : 0;
                 errors.assert.spacesBetween({
                     token: key,
                     nextToken: colon,
-                    exactly: space,
+                    exactly: spaces,
                     message: 'Illegal space after key',
                     disallowNewLine: true
                 });

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -67,14 +67,23 @@ module.exports.prototype = {
     configure: function(options) {
         if (typeof options !== 'object') {
             assert(
-                options === true,
+                options === true ||
+                options === 'ignoreSingleLine' ||
+                options === 'ignoreMultiLine',
                 this.getOptionName() +
-                ' option requires a true value or an object'
+                ' option requires a true value, "ignoreSingleLine", "ignoreMultiLine", or an object'
             );
 
             var _options = {
                 allExcept: []
             };
+
+            if (options === 'ignoreSingleLine') {
+                _options.allExcept.push('singleline');
+            }
+            if (options === 'ignoreMultiLine') {
+                _options.allExcept.push('multiline');
+            }
 
             return this.configure(_options);
         } else {

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -5,9 +5,11 @@
  *
  * Values:
  *  - `true`
- *  - `"ignoreSingleLine"` ignores objects if the object only takes up a single line
- *  - `"ignoreMultiLine"` ignores objects if the object takes up multiple lines
- *  - `"ignoreAligned"` ignores aligned object properties
+ *  - `Object`:
+ *     - `allExcept`: array of exceptions:
+ *       - `"singleline"` ignores objects if the object only takes up a single line
+ *       - `"multiline"` ignores objects if the object takes up multiple lines
+ *       - `"aligned"` ignores aligned object properties
  *
  * #### Example
  *
@@ -15,10 +17,41 @@
  * "disallowSpaceAfterObjectKeys": true
  * ```
  *
- * ##### Valid
+ * ##### Valid for `true`
  * ```js
  * var x = {a: 1};
+ * var y = {
+ *     a: 1,
+ *     b: 2
+ * }
  * ```
+ *
+ * ##### Valid for `{ allExcept: ['singleline'} }`
+ * ```js
+ * var x = {a : 1};
+ * var y = {
+ *     a: 1,
+ *     b: 2
+ * }
+ * ```
+ *
+ * ##### Valid for `{ allExcept: ['multiline'} }`
+ * ```js
+ * var x = {a: 1};
+ * var y = {
+ *     a  : 1,
+ *     b   : 2
+ * }
+ * ```
+ *
+ * ##### Valid for `{ allExcept: ['aligned'} }`
+ * ```js
+ * var y = {
+ *     abc: 1,
+ *     d  : 2
+ * }
+ * ```
+ *
  * ##### Invalid
  * ```js
  * var x = {a : 1};
@@ -31,19 +64,40 @@ module.exports = function() {};
 
 module.exports.prototype = {
 
-    configure: function(disallow) {
-        var modes = {
-            'ignoreSingleLine': 'ignoreSingleLine',
-            'ignoreMultiLine': 'ignoreMultiLine',
-            'ignoreAligned': 'ignoreAligned'
-        };
+    configure: function(options) {
+        if (typeof options !== 'object') {
+            assert(
+                options === true,
+                this.getOptionName() +
+                ' option requires a true value or an object'
+            );
+
+            var _options = {
+                allExcept: []
+            };
+
+            return this.configure(_options);
+        } else {
+            assert(
+                Array.isArray(options.allExcept),
+                this.getOptionName() +
+                ' option object requires allExcept array property'
+            );
+        }
+
+        this._exceptSingleline = options.allExcept.indexOf('singleline') > -1;
+        this._exceptMultiline = options.allExcept.indexOf('multiline') > -1;
+        this._exceptAligned = options.allExcept.indexOf('aligned') > -1;
         assert(
-            disallow === true || typeof disallow === 'string' && modes[disallow],
+            !this._exceptMultiline || !this._exceptAligned,
             this.getOptionName() +
-            ' option requires true value requires one of the following values: ' +
-            Object.keys(modes).join(', ')
+            ' option allExcept property cannot contain "aligned" and "multiline" at the same time'
         );
-        this._mode = disallow === true ? true : modes[disallow];
+        assert(
+            !this._exceptMultiline || !this._exceptSingleline,
+            this.getOptionName() +
+            ' option allExcept property cannot contain "singleline" and "multiline" at the same time'
+        );
     },
 
     getOptionName: function() {
@@ -51,13 +105,16 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var mode = this._mode;
+        var exceptSingleline = this._exceptSingleline;
+        var exceptMultiline = this._exceptMultiline;
+        var exceptAligned = this._exceptAligned;
+
         file.iterateNodesByType('ObjectExpression', function(node) {
             var multiline = node.loc.start.line !== node.loc.end.line;
-            if (mode === 'ignoreSingleLine' && !multiline) {
+            if (exceptSingleline && !multiline) {
                 return;
             }
-            if (mode === 'ignoreMultiLine' && multiline) {
+            if (exceptMultiline && multiline) {
                 return;
             }
 
@@ -69,7 +126,7 @@ module.exports.prototype = {
                 }
 
                 var keyToken = file.getFirstNodeToken(property.key);
-                if (mode === 'ignoreAligned') {
+                if (exceptAligned) {
                     maxKeyEndPos = Math.max(maxKeyEndPos, keyToken.loc.end.column);
                 }
                 tokens.push(keyToken);
@@ -77,10 +134,7 @@ module.exports.prototype = {
 
             tokens.forEach(function(key) {
                 var colon = file.getNextToken(key);
-                var space = 0;
-                if (mode === 'ignoreAligned') {
-                    space = maxKeyEndPos - key.loc.end.column;
-                }
+                var space = exceptAligned ? maxKeyEndPos - key.loc.end.column : 0;
                 errors.assert.spacesBetween({
                     token: key,
                     nextToken: colon,

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -66,12 +66,13 @@ module.exports.prototype = {
             }
 
             var maxKeyEndPos = 0;
+            var prevKeyEndPos = 0;
+            var minColonPos = 0;
+            var tokens = [];
             var skip = node.properties.some(function(property, index) {
                 if (property.shorthand || property.method || property.kind !== 'init') {
                     return true;
                 }
-
-                maxKeyEndPos = Math.max(maxKeyEndPos, property.key.loc.end.column);
 
                 if (mode === 'ignoreFunction' && property.value.type === 'FunctionExpression') {
                     return true;
@@ -81,23 +82,30 @@ module.exports.prototype = {
                      node.properties[index - 1].loc.end.line !== property.loc.start.line - 1) {
                     return true;
                 }
+
+                prevKeyEndPos = maxKeyEndPos;
+                maxKeyEndPos = Math.max(maxKeyEndPos, property.key.loc.end.column);
+                var keyToken = file.getFirstNodeToken(property.key);
+                if (property.computed === true) {
+                    keyToken = file.getNextToken(keyToken);
+                }
+                var colon = file.getNextToken(keyToken);
+                if (prevKeyEndPos < maxKeyEndPos) {
+                    minColonPos = colon.loc.start.column;
+                }
+                tokens.push({key: keyToken, colon: colon});
             });
 
             if (skip) {
                 return;
             }
 
-            node.properties.forEach(function(property) {
-                var keyToken = file.getFirstNodeToken(property.key);
-                if (property.computed === true) {
-                    keyToken = file.getNextToken(keyToken);
-                }
-                var colon = file.getNextToken(keyToken);
-
+            var space = minColonPos - maxKeyEndPos;
+            tokens.forEach(function(pair) {
                 errors.assert.spacesBetween({
-                    token: keyToken,
-                    nextToken: colon,
-                    exactly: maxKeyEndPos - keyToken.loc.end.column + 1,
+                    token: pair.key,
+                    nextToken: pair.colon,
+                    exactly: maxKeyEndPos - pair.key.loc.end.column + space,
                     message: 'Alignment required'
                 });
             });

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -45,67 +45,85 @@ describe('rules/disallow-space-after-object-keys', function() {
         });
     });
 
-    describe('ignoreSingleLine option', function() {
-        beforeEach(function() {
-            checker.configure({ disallowSpaceAfterObjectKeys: 'ignoreSingleLine' });
-        });
+    describe('options as object', function() {
+        describe('allExcept option', function() {
+            describe('with singleline value', function() {
+                beforeEach(function() {
+                    checker.configure({ disallowSpaceAfterObjectKeys: { allExcept: ['singleline'] } });
+                });
 
-        it('should not report with an object that takes up a single line', function() {
-            assert(checker.checkString('var x = {a : 1, bcd : 2};').isEmpty());
-        });
+                it('should not report with an object that takes up a single line', function() {
+                    assert(checker.checkString('var x = {a : 1, bcd : 2};').isEmpty());
+                });
 
-        it('should report with an object that takes up a multi line', function() {
-            assert(checker.checkString(
-                'var x = {\n' +
-                    'a : 1,\n' +
-                '};'
-            ).getErrorCount() === 1);
-        });
-    });
+                it('should report with an object that takes up a multi line', function() {
+                    assert(checker.checkString(
+                            'var x = {\n' +
+                            'a : 1,\n' +
+                            '};'
+                        ).getErrorCount() === 1);
+                });
+            });
 
-    describe('ignoreMultiLine option', function() {
-        beforeEach(function() {
-            checker.configure({ disallowSpaceAfterObjectKeys: 'ignoreMultiLine' });
-        });
+            describe('with multliline value', function() {
+                beforeEach(function() {
+                    checker.configure({ disallowSpaceAfterObjectKeys: { allExcept: ['multiline'] } });
+                });
 
-        it('should report with an object that takes up a single line', function() {
-            assert(checker.checkString('var x = {a : 1, bcd : 2};').getErrorCount() === 2);
-        });
+                it('should report with an object that takes up a single line', function() {
+                    assert(checker.checkString('var x = {a : 1, bcd : 2};').getErrorCount() === 2);
+                });
 
-        it('should not report with an object that takes up a multi line', function() {
-            assert(checker.checkString(
-                'var x = {\n' +
-                    'a : 1,\n' +
-                '};'
-            ).isEmpty());
-        });
-    });
+                it('should not report with an object that takes up a multi line', function() {
+                    assert(checker.checkString(
+                        'var x = {\n' +
+                        'a : 1,\n' +
+                        '};'
+                    ).isEmpty());
+                });
+            });
 
-    describe('ignoreAligned option', function() {
-        beforeEach(function() {
-            checker.configure({ disallowSpaceAfterObjectKeys: 'ignoreAligned' });
-        });
+            describe('with aligned value', function() {
+                beforeEach(function() {
+                    checker.configure({ disallowSpaceAfterObjectKeys: { allExcept: ['aligned'] } });
+                });
 
-        it('should report with an object that takes up a single line', function() {
-            assert(checker.checkString('var x = {a : 1, bcd : 2};').getErrorCount() === 2);
-        });
+                it('should report with an object that takes up a single line', function() {
+                    assert(checker.checkString('var x = {a : 1, bcd : 2};').getErrorCount() === 2);
+                });
 
-        it('should report with an aligned multiline object with space after keys', function() {
-            assert(checker.checkString(
-                'var x = {\n' +
-                    'bcd :2,\n' +
-                    'a   : 1,\n' +
-                '};'
-            ).getErrorCount() === 2);
-        });
+                it('should report with an aligned multiline object with space after keys', function() {
+                    assert(checker.checkString(
+                            'var x = {\n' +
+                            'bcd :2,\n' +
+                            'a   : 1,\n' +
+                            '};'
+                        ).getErrorCount() === 2);
+                });
 
-        it('should not report with an aligned multiline object without space after keys', function() {
-            assert(checker.checkString(
-                'var x = {\n' +
-                    'bcd:2,\n' +
-                    'a  : 1,\n' +
-                '};'
-            ).isEmpty());
+                it('should not report with an aligned multiline object without space after keys', function() {
+                    assert(checker.checkString(
+                        'var x = {\n' +
+                        'bcd:2,\n' +
+                        'a  : 1,\n' +
+                        '};'
+                    ).isEmpty());
+                });
+            });
+
+            it('should not accept multiline and aligned at the same time', function() {
+                var rules = {disallowSpaceAfterObjectKeys: {allExcept: ['multiline', 'aligned']}};
+                assert.throws(function() {
+                    checker.configure(rules);
+                }, assert.AssertionError);
+            });
+
+            it('should not accept multiline and singleline at the same time', function() {
+                var rules = {disallowSpaceAfterObjectKeys: {allExcept: ['singleline', 'multiline']}};
+                assert.throws(function() {
+                    checker.configure(rules);
+                }, assert.AssertionError);
+            });
         });
     });
 

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -81,6 +81,39 @@ describe('rules/disallow-space-after-object-keys', function() {
         });
     });
 
+    describe('ignoreAligned option', function() {
+        beforeEach(function() {
+            checker.configure({ disallowSpaceAfterObjectKeys: 'ignoreAligned' });
+        });
+
+        it('should report with an object that takes up a single line', function() {
+            assert(checker.checkString('var x = {a : 1, bcd : 2};').getErrorCount() === 2);
+        });
+
+        it('should report with an aligned multiline object with space after keys', function() {
+            assert(checker.checkString(
+                'var x = {\n' +
+                    'bcd :2,\n' +
+                    'a   : 1,\n' +
+                '};'
+            ).getErrorCount() === 2);
+        });
+
+        it('should not report with an aligned multiline object with no space after keys', function() {
+            assert(checker.checkString(
+                'var x = {\n' +
+                    'bcd:2,\n' +
+                    'a  : 1,\n' +
+                '};'
+            ).isEmpty());
+        });
+    });
+
+    it('should not report es6-methods. #1013', function() {
+        checker.configure({ esnext: true });
+        assert(checker.checkString('var x = { a() { } };').isEmpty());
+    });
+
     it('should not report es5 getters/setters #1037', function() {
         checker.configure({ disallowSpaceAfterObjectKeys: true });
         assert(checker.checkString('var x = { get a() { } };').isEmpty());

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -127,6 +127,22 @@ describe('rules/disallow-space-after-object-keys', function() {
         });
     });
 
+    describe('legacy options', function() {
+        it('should accept ignoreSingleLine as an option', function() {
+            checker.configure({disallowSpaceAfterObjectKeys: 'ignoreSingleLine'});
+            assert(checker.checkString('var x = {a : 1, bcd : 2};').isEmpty());
+        });
+
+        it('should accept ignoreMultiLine as an option', function() {
+            checker.configure({disallowSpaceAfterObjectKeys: 'ignoreMultiLine'});
+            assert(checker.checkString(
+                'var x = {\n' +
+                'a : 1,\n' +
+                '};'
+            ).isEmpty());
+        });
+    });
+
     it('should not report es5 getters/setters #1037', function() {
         checker.configure({ disallowSpaceAfterObjectKeys: true });
         assert(checker.checkString('var x = { get a() { } };').isEmpty());

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -99,7 +99,7 @@ describe('rules/disallow-space-after-object-keys', function() {
             ).getErrorCount() === 2);
         });
 
-        it('should not report with an aligned multiline object with no space after keys', function() {
+        it('should not report with an aligned multiline object without space after keys', function() {
             assert(checker.checkString(
                 'var x = {\n' +
                     'bcd:2,\n' +
@@ -107,11 +107,6 @@ describe('rules/disallow-space-after-object-keys', function() {
                 '};'
             ).isEmpty());
         });
-    });
-
-    it('should not report es6-methods. #1013', function() {
-        checker.configure({ esnext: true });
-        assert(checker.checkString('var x = { a() { } };').isEmpty());
     });
 
     it('should not report es5 getters/setters #1037', function() {

--- a/test/specs/rules/require-aligned-object-values.js
+++ b/test/specs/rules/require-aligned-object-values.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-aligned-object-values', function() {
     var checker;
@@ -10,8 +11,9 @@ describe('rules/require-aligned-object-values', function() {
     });
 
     describe('all option', function() {
+        var rules = { requireAlignedObjectValues: 'all' };
         beforeEach(function() {
-            checker.configure({ requireAlignedObjectValues: 'all' });
+            checker.configure(rules);
         });
 
         it('should not report for empty object', function() {
@@ -91,6 +93,62 @@ describe('rules/require-aligned-object-values', function() {
                     '};'
                 ].join('\n')).getErrorCount() === 1
             );
+        });
+
+        describe('alignment check for any number of spaces', function() {
+            reportAndFix({
+                name: 'illegal object values alignment',
+                rules: rules,
+                input: 'var x = {\n' +
+                    'a: 1,\n' +
+                    '\n' +
+                    'foo: function() {},\n' +
+                    'bcd: 2\n' +
+                '};',
+                output: 'var x = {\n' +
+                    'a  : 1,\n' +
+                    '\n' +
+                    'foo: function() {},\n' +
+                    'bcd: 2\n' +
+                '};'
+            });
+            reportAndFix({
+                name: 'illegal object values alignment',
+                rules: rules,
+                input: 'var x = {\n' +
+                    'a      : 1,\n' +
+                    '\n' +
+                    'foo   : function() {},\n' +
+                    'bcd   : 2\n' +
+                '};',
+                output: 'var x = {\n' +
+                    'a     : 1,\n' +
+                    '\n' +
+                    'foo   : function() {},\n' +
+                    'bcd   : 2\n' +
+                '};'
+            });
+        });
+
+        describe('in conjunction with disallowSpaceAfterObjectKeys', function() {
+            reportAndFix({
+                name: 'illegal object values alignment',
+                rules: {
+                    disallowSpaceAfterObjectKeys: 'ignoreAligned',
+                    requireAlignedObjectValues: 'all'
+                },
+                errors: 4,
+                input: 'var x = {\n' +
+                    'a : 1,\n' +
+                    'foo : function() {},\n' +
+                    'bcd : 2\n' +
+                '};',
+                output: 'var x = {\n' +
+                    'a  : 1,\n' +
+                    'foo: function() {},\n' +
+                    'bcd: 2\n' +
+                '};'
+            });
         });
     });
 

--- a/test/specs/rules/require-aligned-object-values.js
+++ b/test/specs/rules/require-aligned-object-values.js
@@ -134,7 +134,7 @@ describe('rules/require-aligned-object-values', function() {
             reportAndFix({
                 name: 'illegal object values alignment',
                 rules: {
-                    disallowSpaceAfterObjectKeys: 'ignoreAligned',
+                    disallowSpaceAfterObjectKeys: {allExcept: ['aligned']},
                     requireAlignedObjectValues: 'all'
                 },
                 errors: 4,


### PR DESCRIPTION
This is my attempt to address #1420:
* `requireAlignedObjectValues` modified to validate only alignment of the colons, not exact number of space between object key and colon
* Added new option `ignoreAligned` to `disallowSpaceAfterObjectKeys`. When set rule would only check space after longest key in multiline object expression

### Example for new behavior of `requireAlignedObjectValues`
```javascript
"requireAlignedObjectValues": "all"
```

#### Valid
```javascript
var x = {
    a   : 1,
    bcd : 2
};
var x = {
    a  : 1,
    bcd: 2
};
var x = {
    a    : 1,
    bcd  : 2
};
```

#### Invalid
```javascript
var x = {
    a    : 1,
    bcd     : 2
};
```

### Example for both rules

```javascript
"disallowSpaceAfterObjectKeys": "ignoreAligned",
"requireAlignedObjectValues": "all"
```

#### Valid
```javascript
var x = {
    a  : 1,
    foo: function() {},
    bcd: 2
};
```

#### Invalid
```javascript
var x = {
    a   : 1,
    foo : function() {},
    bcd : 2
};
var y = {
    a: 1,
    foo: function() {},
    bcd: 2
};
```