### PR TITLE
Add "fix" field in rule declaration

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -220,6 +220,17 @@ Configuration.prototype.getConfiguredRules = function() {
 };
 
 /**
+ * Returns configured rule.
+ *
+ * @returns {Rule | null}
+ */
+Configuration.prototype.getConfiguredRule = function(name) {
+    return this._configuredRules.filter(function(rule) {
+        return rule.getOptionName() === name;
+    })[0] || null;
+};
+
+/**
  * Returns the list of unsupported rule names.
  *
  * @return {String[]}

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -690,7 +690,6 @@ Configuration.prototype._useRules = function() {
         var rule = this._rules[optionName];
         rule.configure(this._ruleSettings[optionName]);
         this._configuredRules.push(rule);
-
     }, this);
 };
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -37,17 +37,42 @@ Errors.prototype = {
             line = line.line;
         }
 
-        // line and column numbers should be explicit
-        assert(typeof line === 'number' && line > 0,
-            'Unable to add an error, `line` should be a number greater than 0 but ' + line + ' given');
-        assert(typeof column === 'number' && column >= 0,
-            'Unable to add an error, `column` should be a positive number but ' + column + ' given');
-
-        this._addError({
+        var errorInfo = {
             message: message,
             line: line,
             column: column
-        });
+        };
+
+        this._validateInput(errorInfo);
+        this._addError(errorInfo);
+    },
+
+    /**
+     * Adds style error to the list
+     *
+     * @param {Object} errorInfo
+     */
+    cast: function(errorInfo) {
+        var additional = errorInfo.additional;
+
+        assert(typeof additional !== undefined,
+               '`additional` argument should not be empty');
+
+        this._addError(errorInfo);
+    },
+
+    _validateInput: function(errorInfo) {
+        var line = errorInfo.line;
+        var column = errorInfo.column;
+
+        // line and column numbers should be explicit
+        assert(typeof line === 'number' && line > 0,
+            'Unable to add an error, `line` should be a number greater than 0 but ' +
+                line + ' given');
+
+        assert(typeof column === 'number' && column >= 0,
+            'Unable to add an error, `column` should be a positive number but ' +
+                column + ' given');
     },
 
     /**
@@ -61,12 +86,15 @@ Errors.prototype = {
             return;
         }
 
+        this._validateInput(errorInfo);
+
         this._errorList.push({
             filename: this._file.getFilename(),
             rule: this._currentRule,
             message: this._prepareMessage(errorInfo),
             line: errorInfo.line,
             column: errorInfo.column,
+            additional: errorInfo.additional,
             fixed: errorInfo.fixed
         });
     },

--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -106,13 +106,20 @@ module.exports.prototype = {
                     return;
                 }
 
-                errors.add(
-                    'Invalid quote mark found',
-                    token.loc.start.line,
-                    token.loc.start.column
-                );
+                errors.cast({
+                    message: 'Invalid quote mark found',
+                    line: token.loc.start.line,
+                    column: token.loc.start.column,
+                    additional: token
+                });
             }
         });
-    }
+    },
 
+    fix: function(error) {
+        var token = error.additional;
+        var fixer = require(this._quoteMark === '"' ? 'to-double-quotes' : 'to-single-quotes');
+
+        token.value = fixer(token.value);
+    }
 };

--- a/lib/rules/validate-quote-marks.js
+++ b/lib/rules/validate-quote-marks.js
@@ -116,7 +116,7 @@ module.exports.prototype = {
         });
     },
 
-    fix: function(error) {
+    _fix: function(error) {
         var token = error.additional;
         var fixer = require(this._quoteMark === '"' ? 'to-double-quotes' : 'to-single-quotes');
 

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -150,14 +150,14 @@ StringChecker.prototype = {
 
             var instance = configuration.getConfiguredRule(error.rule);
 
-            if (instance && instance.fix) {
+            if (instance && instance._fix) {
                 try {
 
                     // "error.fixed = true" should go first, so rule can
                     // decide for itself (with "error.fixed = false")
                     // if it can fix this particular error
                     error.fixed = true;
-                    instance.fix(error);
+                    instance._fix(error);
 
                 } catch (e) {
                     error.fixed = undefined;

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -6,6 +6,13 @@ var Configuration = require('./config/configuration');
 
 var MAX_FIX_ATTEMPTS = 5;
 
+function getErrorMessage(rule, e) {
+    return 'Error running rule ' + rule + ': ' +
+        'This is an issue with JSCS and not your codebase.\n' +
+        'Please file an issue (with the stack trace below) at: ' +
+        'https://github.com/jscs-dev/node-jscs/issues/new\n' + e;
+}
+
 /**
  * Starts Code Style checking process.
  * Params are deprecated, should be removed in 2.0
@@ -126,6 +133,41 @@ StringChecker.prototype = {
     },
 
     /**
+     * Fix provided error.
+     *
+     * @param {JsFile} file
+     * @param {Errors} errors
+     * @protected
+     */
+    _fixJsFile: function(file, errors) {
+        var list = errors.getErrorList();
+        var configuration = this.getConfiguration();
+
+        list.forEach(function(error) {
+            if (error.fixed) {
+                return;
+            }
+
+            var instance = configuration.getConfiguredRule(error.rule);
+
+            if (instance && instance.fix) {
+                try {
+
+                    // "error.fixed = true" should go first, so rule can
+                    // decide for itself (with "error.fixed = false")
+                    // if it can fix this particular error
+                    error.fixed = true;
+                    instance.fix(error);
+
+                } catch (e) {
+                    error.fixed = undefined;
+                    errors.add(getErrorMessage(error.rule, e), 1, 0);
+                }
+            }
+        });
+    },
+
+    /**
      * Checks a file specified using JsFile instance.
      * Fills Errors instance with validation errors.
      *
@@ -146,11 +188,7 @@ StringChecker.prototype = {
             try {
                 rule.check(file, errors);
             } catch (e) {
-                errors.add('Error running rule ' + rule.getOptionName() + ': ' +
-                    'This is an issue with JSCS and not your codebase.\n' +
-                    'Please file an issue (with the stack trace below) at: ' +
-                    'https://github.com/jscs-dev/node-jscs/issues/new\n' +
-                    e.stack, 1, 0);
+                errors.add(getErrorMessage(rule.getOptionName(), e.stack), 1, 0);
             }
         }, this);
 
@@ -249,6 +287,10 @@ StringChecker.prototype = {
 
                 // Changes to current sources are made in rules through assertions.
                 this._checkJsFile(file, errors);
+
+                // If assertions weren't used but rule has "fix" method,
+                // which we could use.
+                this._fixJsFile(file, errors);
 
                 var hasFixes = errors.getErrorList().some(function(err) {
                     return err.fixed;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "pathval": "~0.1.1",
     "prompt": "~0.2.14",
     "strip-json-comments": "~1.0.2",
+    "to-double-quotes": "^1.0.0",
+    "to-single-quotes": "^1.0.2",
     "vow": "~0.4.8",
     "vow-fs": "~0.3.4",
     "xmlbuilder": "^2.6.1"

--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -43,8 +43,15 @@ function execPresets(presets) {
         process.stdout.write(messages.start + '\n\n');
         process.stdout.write(chalk.magenta(' - ') + messages.fixStart + '\n');
 
+        child.stderr.setEncoding('utf8');
+
         // For some reason this makes subprocess to be more effective
         child.stdout.on('data', function() {});
+
+        child.stderr.on('data', function(data) {
+            process.stderr.write(chalk.red(' ! ') + 'Error:\n');
+            process.stderr.write(data);
+        });
 
         // Wait until autofix process is done
         child.on('close', function executeTests(code) {

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -297,6 +297,21 @@ describe('modules/config/configuration', function() {
         });
     });
 
+    describe('getConfiguredRule', function() {
+        it('should return configured rule after config load', function() {
+            assert(configuration.getConfiguredRule('ruleName') === null);
+            var rule = {
+                getOptionName: function() {
+                    return 'ruleName';
+                },
+                configure: function() {}
+            };
+            configuration.registerRule(rule);
+            configuration.load({ruleName: true});
+            assert(typeof configuration.getConfiguredRule('ruleName') === 'object');
+        });
+    });
+
     describe('isFileExcluded', function() {
         it('should return `false` if no `excludeFiles` are defined', function() {
             assert(!configuration.isFileExcluded('1.js'));

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -90,7 +90,7 @@ describe('modules/config/node-configuration', function() {
     });
 
     describe('load', function() {
-        it('should load existed preset', function() {
+        it('should load existing preset', function() {
             configuration.registerDefaultRules();
             configuration.registerPreset('test', {
                 disallowMultipleVarDecl: 'exceptUndefined'

--- a/test/specs/errors.js
+++ b/test/specs/errors.js
@@ -128,6 +128,78 @@ describe('modules/errors', function() {
         });
     });
 
+    describe('cast', function() {
+        var errors;
+        beforeEach(function() {
+            errors = checker.checkString('yay');
+        });
+
+        it('should throw an error on invalid line type', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: '0'
+                });
+            });
+        });
+
+        it('should throw an error on invalid line value', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 0
+                });
+            });
+        });
+
+        it('should throw an error on invalid column type', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: '2'
+                });
+            });
+        });
+
+        it('should throw an error on invalid column value', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: -1
+                });
+            });
+        });
+
+        it('should throw without "additional" argument', function() {
+            assert.throws(function() {
+                errors.cast({
+                    message: 'msg',
+                    line: 1,
+                    column: -1
+                });
+            });
+        });
+
+        it('should correctly set error', function() {
+            errors.setCurrentRule('anyRule');
+            errors.cast({
+                message: 'msg',
+                column: 0,
+                line: 1,
+                additional: 'test'
+            });
+
+            var error = errors.getErrorList()[0];
+
+            assert.equal(error.rule, 'anyRule');
+            assert.equal(error.line, 1);
+            assert.equal(error.column, 0);
+            assert.equal(error.additional, 'test');
+        });
+    });
+
     describe('add with verbose', function() {
         var errors;
         beforeEach(function() {

--- a/test/specs/rules/validate-quote-marks.js
+++ b/test/specs/rules/validate-quote-marks.js
@@ -1,4 +1,5 @@
 var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 var assert = require('assert');
 
 describe('rules/validate-quote-marks', function() {
@@ -180,5 +181,29 @@ describe('rules/validate-quote-marks', function() {
         it('should not report inconsistent quotes in comments', function() {
             assert(checker.checkString('var x = "x", y = "y"; /*\'y\'*/').isEmpty());
         });
+    });
+
+    reportAndFix({
+        name: 'should fix (simple case)',
+        rules: {
+            validateQuoteMarks: {
+                mark: '"',
+                escape: true
+            }
+        },
+        input: '\'\'',
+        output: '""'
+    });
+
+    reportAndFix({
+        name: 'should fix \'1\'2\'',
+        rules: {
+            validateQuoteMarks: '\''
+        },
+        errors: 1,
+        input: ' "1\'2" ',
+
+        // Check string in the string with same quotes, had to use "\\\"
+        output: ' \'1\\\'2\' '
     });
 });

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -204,8 +204,8 @@ describe('modules/string-checker', function() {
             });
         });
 
-        describe('rules with "fix" field', function() {
-            it('should call "fix" method', function() {
+        describe('rules with "_fix" field', function() {
+            it('should call "_fix" method', function() {
                 var err;
                 var called = false;
                 checker = new StringChecker();
@@ -220,7 +220,7 @@ describe('modules/string-checker', function() {
                             additional: 'test'
                         });
                     },
-                    fix: function(error) {
+                    _fix: function(error) {
                         called = true;
                         err = error;
                         assert.equal(error.additional, 'test');
@@ -233,7 +233,7 @@ describe('modules/string-checker', function() {
                 assert(called);
             });
 
-            it('should not try to call "fix" method if it does not exist', function() {
+            it('should not try to call "_fix" method if it does not exist', function() {
                 checker = new StringChecker();
 
                 checker.registerRule({
@@ -257,7 +257,7 @@ describe('modules/string-checker', function() {
                 }
             });
 
-            it('should add error if "fix" call field throws', function() {
+            it('should add error if "_fix" call field throws', function() {
                 var spy = sinon.spy(Errors.prototype, 'add');
 
                 checker = new StringChecker();
@@ -272,7 +272,7 @@ describe('modules/string-checker', function() {
                             additinal: 'test'
                         });
                     },
-                    fix: function() {
+                    _fix: function() {
                         throw new Error('test');
                     }
                 });
@@ -303,7 +303,7 @@ describe('modules/string-checker', function() {
                             additinal: 'test'
                         });
                     },
-                    fix: function(error) {
+                    _fix: function(error) {
                         err = error;
 
                         error.fixed = false;

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -1,4 +1,5 @@
 var StringChecker = require('../../lib/string-checker');
+var Errors = require('../../lib/errors');
 var assert = require('assert');
 var sinon = require('sinon');
 var fs = require('fs');
@@ -200,6 +201,119 @@ describe('modules/string-checker', function() {
                 var result = checker.fixString('x=1+2;');
                 assert(result.errors.isEmpty());
                 assert.equal(result.output, 'x = 1 + 2;');
+            });
+        });
+
+        describe('rules with "fix" field', function() {
+            it('should call "fix" method', function() {
+                var err;
+                var called = false;
+                checker = new StringChecker();
+
+                checker.registerRule({
+                    configure: function() {},
+                    getOptionName: function() { return 'fixRule'; },
+                    check: function(file, errors) {
+                        errors.cast({
+                            line: 1,
+                            column: 2,
+                            additional: 'test'
+                        });
+                    },
+                    fix: function(error) {
+                        called = true;
+                        err = error;
+                        assert.equal(error.additional, 'test');
+                    }
+                });
+                checker.configure({fixRule: true});
+
+                checker.fixString('test');
+                assert(err.fixed);
+                assert(called);
+            });
+
+            it('should not try to call "fix" method if it does not exist', function() {
+                checker = new StringChecker();
+
+                checker.registerRule({
+                    configure: function() {},
+                    getOptionName: function() { return 'fixRule'; },
+                    check: function(file, errors) {
+                        errors.cast({
+                            line: 1,
+                            column: 2,
+                            additinal: 'test'
+                        });
+                    }
+                });
+                checker.configure({fixRule: true});
+
+                try {
+                    checker.fixString('test');
+                    assert(true);
+                } catch (e) {
+                    assert(false);
+                }
+            });
+
+            it('should add error if "fix" call field throws', function() {
+                var spy = sinon.spy(Errors.prototype, 'add');
+
+                checker = new StringChecker();
+
+                checker.registerRule({
+                    configure: function() {},
+                    getOptionName: function() { return 'fixRule'; },
+                    check: function(file, errors) {
+                        errors.cast({
+                            line: 1,
+                            column: 2,
+                            additinal: 'test'
+                        });
+                    },
+                    fix: function() {
+                        throw new Error('test');
+                    }
+                });
+                checker.configure({fixRule: true});
+
+                try {
+                    checker.fixString('test');
+                    assert(true);
+                } catch (e) {
+                    assert(false);
+                }
+
+                assert(spy.called);
+                assert(spy.args[0][0].indexOf('Error running rule') > -1);
+            });
+
+            it('should allow rule to reset error.fixed property', function() {
+                var err;
+                checker = new StringChecker();
+
+                checker.registerRule({
+                    configure: function() {},
+                    getOptionName: function() { return 'fixRule'; },
+                    check: function(file, errors) {
+                        errors.cast({
+                            line: 1,
+                            column: 2,
+                            additinal: 'test'
+                        });
+                    },
+                    fix: function(error) {
+                        err = error;
+
+                        error.fixed = false;
+                    }
+                });
+                checker.configure({fixRule: true});
+
+                checker.fixString('test');
+
+                assert.ok(!err.fixed);
             });
         });
     });


### PR DESCRIPTION
Addresses https://github.com/jscs-dev/node-jscs/issues/1201 https://github.com/jscs-dev/node-jscs/pull/1202 https://github.com/jscs-dev/node-jscs/pull/1265, but most importantly #1113.

Example with `validateQuoteMarks` is just that, example.

This pull represents two different ideas for autofix infrastructure - "fix" field and assertion interface. 

Which is bad, we need to make them complimentary to each other or unite approaches, but we need to keep ball rolling need to release 2.0 soon, we can improve/refactor later. 