### PR TITLE
Errors: Ability to suppress a single line

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -344,6 +344,14 @@ if (x) y(); // all errors from requireCurlyBraces on this line will be ignored
 if (z) a(); // all errors, including from requireCurlyBraces, on this line will be reported
 ```
 
+#### Disabling Specific Rules For a Single Line
+
+Rules can be disabled for a single line with `// jscs:ignore ruleName`. For these trailing comments one or more rule names must be given.
+```js
+if (x) y(); // jscs:ignore requireCurlyBraces
+if (z) a();
+```
+
 You can enable all rules after disabling a specific rule, and that rule becomes re-enabled as well.
 ```js
 // jscs:disable requireCurlyBraces

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -346,7 +346,7 @@ if (z) a(); // all errors, including from requireCurlyBraces, on this line will 
 
 #### Disabling Specific Rules For a Single Line
 
-Rules can be disabled for a single line with `// jscs:ignore ruleName`. For these trailing comments one or more rule names must be given.
+Rules can be disabled for a single line with `// jscs:ignore`.
 ```js
 if (x) y(); // jscs:ignore requireCurlyBraces
 if (z) a();

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -79,7 +79,7 @@ JsFile.prototype = {
 
         var comments = this.getComments();
         var blockRe = /(jscs\s*:\s*(en|dis)able)(.*)/;
-        var lineRe = /(jscs\s*:\s*ignore)(.*)/;
+        var lineRe = /(jscs\s*:\s*ignore)(\s+\w.*)/;
 
         comments.forEach(function(comment) {
             var enabled;
@@ -93,16 +93,26 @@ JsFile.prototype = {
                 this._addToDisabledRuleIndex(enabled, blockParsed[3], line);
 
             } else if (lineParsed && lineParsed.index === 0) {
-
-                if (!this.isEnabledRule(lineParsed[2], line)) {
-                    return;
-                }
-
-                this._addToDisabledRuleIndex(false, lineParsed[2], line);
-                this._addToDisabledRuleIndex(true, lineParsed[2], line + 1);
+                this._disableRulesAt(lineParsed[2], line);
             }
 
         }, this);
+    },
+
+    /**
+     * Disables a rules for a single line, not re-enabling any disabled rules
+     *
+     * @private
+     */
+    _disableRulesAt: function(rules, line) {
+        rules = rules.split(/\s*,\s*/);
+        for (var i = 0; i < rules.length; i++) {
+            if (!this.isEnabledRule(rules[i], line)) {
+                continue;
+            }
+            this._addToDisabledRuleIndex(false, rules[i], line);
+            this._addToDisabledRuleIndex(true, rules[i], line + 1);
+        }
     },
 
     /**

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -78,7 +78,10 @@ JsFile.prototype = {
         this._disabledRuleIndex = [];
 
         var comments = this.getComments();
+        // Matches a comment enabling or disabling rules.
         var blockRe = /(jscs\s*:\s*(en|dis)able)(.*)/;
+        // Matches a comment disbling a rule for one line.
+        // A rule name must be given for it to match.
         var lineRe = /(jscs\s*:\s*ignore)(\s+\w.*)/;
 
         comments.forEach(function(comment) {

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -81,8 +81,7 @@ JsFile.prototype = {
         // Matches a comment enabling or disabling rules.
         var blockRe = /(jscs\s*:\s*(en|dis)able)(.*)/;
         // Matches a comment disbling a rule for one line.
-        // A rule name must be given for it to match.
-        var lineRe = /(jscs\s*:\s*ignore)(\s+\w.*)/;
+        var lineRe = /(jscs\s*:\s*ignore)(.*)/;
 
         comments.forEach(function(comment) {
             var enabled;

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -78,18 +78,25 @@ JsFile.prototype = {
         this._disabledRuleIndex = [];
 
         var comments = this.getComments();
-        var commentRe = /(jscs\s*:\s*(en|dis)able)(.*)/;
+        var blockRe = /(jscs\s*:\s*(en|dis)able)(.*)/;
+        var lineRe = /(jscs\s*:\s*ignore)(.*)/;
 
         comments.forEach(function(comment) {
             var enabled;
-            var parsed = commentRe.exec(comment.value.trim());
+            var value = comment.value.trim();
+            var blockParsed = blockRe.exec(value);
+            var lineParsed = lineRe.exec(value);
+            var line = comment.loc.start.line;
 
-            if (!parsed || parsed.index !== 0) {
-                return;
+            if (blockParsed && blockParsed.index === 0) {
+                enabled = blockParsed[2] === 'en';
+                this._addToDisabledRuleIndex(enabled, blockParsed[3], line);
+
+            } else if (lineParsed && lineParsed.index === 0) {
+                this._addToDisabledRuleIndex(false, lineParsed[2], line);
+                this._addToDisabledRuleIndex(true, lineParsed[2], line + 1);
             }
 
-            enabled = parsed[2] === 'en';
-            this._addToDisabledRuleIndex(enabled, parsed[3], comment.loc.start.line);
         }, this);
     },
 

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -93,6 +93,11 @@ JsFile.prototype = {
                 this._addToDisabledRuleIndex(enabled, blockParsed[3], line);
 
             } else if (lineParsed && lineParsed.index === 0) {
+
+                if (!this.isEnabledRule(lineParsed[2], line)) {
+                    return;
+                }
+
                 this._addToDisabledRuleIndex(false, lineParsed[2], line);
                 this._addToDisabledRuleIndex(true, lineParsed[2], line + 1);
             }
@@ -109,6 +114,8 @@ JsFile.prototype = {
      */
     isEnabledRule: function(ruleName, line) {
         var enabled = true;
+        ruleName = ruleName.trim();
+
         this._disabledRuleIndex.some(function(region) {
             // once the comment we're inspecting occurs after the location of the error,
             // no longer check for whether the state is enabled or disable

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -163,11 +163,33 @@ describe('modules/js-file', function() {
             assert(file.isEnabledRule('validateQuoteMarks', 7));
         });
 
+        it('should trim whitespace from the rule name', function() {
+            var file = createJsFile([
+                '// jscs: disable validateQuoteMarks',
+                'var x = "1";',
+            ].join('\n'));
+            assert(!file.isEnabledRule('validateQuoteMarks', 2));
+            assert(!file.isEnabledRule('validateQuoteMarks  ', 2));
+            assert(!file.isEnabledRule('    validateQuoteMarks', 2));
+            assert(!file.isEnabledRule('   validateQuoteMarks   ', 2));
+        });
+
         describe('single line trailing comment', function() {
             it('should ignore a single line', function() {
                 var file = createJsFile([
                     'var x = "1";',
                     'var y = "1"; // jscs: ignore validateQuoteMarks',
+                    'var z = "1";',
+                ].join('\n'));
+                assert(file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(file.isEnabledRule('validateQuoteMarks', 3));
+            });
+
+            it('should work without a space before `jscs`', function() {
+                var file = createJsFile([
+                    'var x = "1";',
+                    'var y = "1"; //jscs: ignore validateQuoteMarks',
                     'var z = "1";',
                 ].join('\n'));
                 assert(file.isEnabledRule('validateQuoteMarks', 1));

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -173,6 +173,21 @@ describe('modules/js-file', function() {
             assert(!file.isEnabledRule('validateQuoteMarks', 2));
             assert(file.isEnabledRule('validateQuoteMarks', 3));
         });
+
+        it('should should not enable rules with a trailing comment', function() {
+            var file = createJsFile([
+                'var a = "1";',
+                '// jscs: disable validateQuoteMarks',
+                'var b = "1";',
+                'var c = "1"; // jscs: ignore validateQuoteMarks',
+                'var d = "1";',
+            ].join('\n'));
+            assert(file.isEnabledRule('validateQuoteMarks', 1));
+            assert(!file.isEnabledRule('validateQuoteMarks', 2));
+            assert(!file.isEnabledRule('validateQuoteMarks', 3));
+            assert(!file.isEnabledRule('validateQuoteMarks', 4));
+            assert(!file.isEnabledRule('validateQuoteMarks', 5));
+        });
     });
 
     describe('iterateNodesByType', function() {

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -186,6 +186,17 @@ describe('modules/js-file', function() {
                 assert(file.isEnabledRule('validateQuoteMarks', 3));
             });
 
+            it('should work with no space before jscs:ignore', function() {
+                var file = createJsFile([
+                    'var x = "1";',
+                    'var y = "1"; //jscs: ignore validateQuoteMarks',
+                    'var z = "1";',
+                ].join('\n'));
+                assert(file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(file.isEnabledRule('validateQuoteMarks', 3));
+            });
+
             it('should work without a space before `jscs`', function() {
                 var file = createJsFile([
                     'var x = "1";',

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -162,6 +162,17 @@ describe('modules/js-file', function() {
             assert(!file.isEnabledRule('validateQuoteMarks', 4));
             assert(file.isEnabledRule('validateQuoteMarks', 7));
         });
+
+        it('should ignore a single line with a trailing comment', function() {
+            var file = createJsFile([
+                'var x = "1";',
+                'var y = "1"; // jscs: ignore validateQuoteMarks',
+                'var z = "1";',
+            ].join('\n'));
+            assert(file.isEnabledRule('validateQuoteMarks', 1));
+            assert(!file.isEnabledRule('validateQuoteMarks', 2));
+            assert(file.isEnabledRule('validateQuoteMarks', 3));
+        });
     });
 
     describe('iterateNodesByType', function() {

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -235,20 +235,14 @@ describe('modules/js-file', function() {
                 assert(file.isEnabledRule('anotherRule', 3));
             });
 
-            it('requires a rule to be specified', function() {
+            it('should be able to ignore all rules', function() {
                 var file = createJsFile([
-                    '// jscs: disable validateQuoteMarks',
-                    'var a = "1"; // jscs: ignore', // invalid
+                    'var a = "1"; // jscs: ignore',
                     'var b = "1";',
                 ].join('\n'));
                 assert(!file.isEnabledRule('validateQuoteMarks', 1));
-                assert(!file.isEnabledRule('validateQuoteMarks', 2));
-                assert(!file.isEnabledRule('validateQuoteMarks', 3));
-                assert(file.isEnabledRule('anotherRule', 1));
-                assert(file.isEnabledRule('anotherRule', 2));
-                assert(file.isEnabledRule('anotherRule', 3));
+                assert(file.isEnabledRule('validateQuoteMarks', 2));
             });
-
         });
     });
 

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -163,30 +163,59 @@ describe('modules/js-file', function() {
             assert(file.isEnabledRule('validateQuoteMarks', 7));
         });
 
-        it('should ignore a single line with a trailing comment', function() {
-            var file = createJsFile([
-                'var x = "1";',
-                'var y = "1"; // jscs: ignore validateQuoteMarks',
-                'var z = "1";',
-            ].join('\n'));
-            assert(file.isEnabledRule('validateQuoteMarks', 1));
-            assert(!file.isEnabledRule('validateQuoteMarks', 2));
-            assert(file.isEnabledRule('validateQuoteMarks', 3));
-        });
+        describe('single line trailing comment', function() {
+            it('should ignore a single line', function() {
+                var file = createJsFile([
+                    'var x = "1";',
+                    'var y = "1"; // jscs: ignore validateQuoteMarks',
+                    'var z = "1";',
+                ].join('\n'));
+                assert(file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(file.isEnabledRule('validateQuoteMarks', 3));
+            });
 
-        it('should should not enable rules with a trailing comment', function() {
-            var file = createJsFile([
-                'var a = "1";',
-                '// jscs: disable validateQuoteMarks',
-                'var b = "1";',
-                'var c = "1"; // jscs: ignore validateQuoteMarks',
-                'var d = "1";',
-            ].join('\n'));
-            assert(file.isEnabledRule('validateQuoteMarks', 1));
-            assert(!file.isEnabledRule('validateQuoteMarks', 2));
-            assert(!file.isEnabledRule('validateQuoteMarks', 3));
-            assert(!file.isEnabledRule('validateQuoteMarks', 4));
-            assert(!file.isEnabledRule('validateQuoteMarks', 5));
+            it('should not re-enable rules', function() {
+                var file = createJsFile([
+                    'var a = "1";',
+                    '// jscs: disable validateQuoteMarks',
+                    'var b = "1"; // jscs: ignore validateQuoteMarks',
+                    'var c = "1";',
+                ].join('\n'));
+                assert(file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(!file.isEnabledRule('validateQuoteMarks', 3));
+                assert(!file.isEnabledRule('validateQuoteMarks', 4));
+            });
+
+            it('should also work with multiple rules', function() {
+                var file = createJsFile([
+                    '// jscs: disable validateQuoteMarks',
+                    'var a = "1"; // jscs: ignore validateQuoteMarks, anotherRule',
+                    'var b = "1";',
+                ].join('\n'));
+                assert(!file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(!file.isEnabledRule('validateQuoteMarks', 3));
+                assert(file.isEnabledRule('anotherRule', 1));
+                assert(!file.isEnabledRule('anotherRule', 2));
+                assert(file.isEnabledRule('anotherRule', 3));
+            });
+
+            it('requires a rule to be specified', function() {
+                var file = createJsFile([
+                    '// jscs: disable validateQuoteMarks',
+                    'var a = "1"; // jscs: ignore', // invalid
+                    'var b = "1";',
+                ].join('\n'));
+                assert(!file.isEnabledRule('validateQuoteMarks', 1));
+                assert(!file.isEnabledRule('validateQuoteMarks', 2));
+                assert(!file.isEnabledRule('validateQuoteMarks', 3));
+                assert(file.isEnabledRule('anotherRule', 1));
+                assert(file.isEnabledRule('anotherRule', 2));
+                assert(file.isEnabledRule('anotherRule', 3));
+            });
+
         });
     });
 


### PR DESCRIPTION
This allows the user to suppress errors on a single by appending a trailing comment in the format `// jscs: ignore requireSemicolons`

Fixes #1372 - issue

Possible edgecase that I've not handled:

```javascript
var a = 1
// jscs:disable requireSemicolons
var b = 2
var c = 3
var d = 4 // jscs:ignore requireSemicolons
var e = 5
var f = 6 // should it be enabled or disabled here?
```