### PR TITLE
Improve JsFile constructor for better encapsulation

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -12,24 +12,37 @@ var KEYWORD_OPERATORS = {
  * File representation for JSCS.
  *
  * @name JsFile
+ * @param {Object} params
+ * @param {String} params.filename
+ * @param {String} params.source
+ * @param {Object} params.esprima
+ * @param {Object} [params.esprimaOptions]
+ * @param {Boolean} [params.es3]
+ * @param {Boolean} [params.es6]
  */
-var JsFile = function(filename, source, tree, options) {
-    options = options || {};
+var JsFile = function(params) {
+    params = params || {};
+    this._parseErrors = [];
+    this._filename = params.filename;
+    this._source = params.source;
+    this._tree = {tokens: [], comments: []};
 
-    this._filename = filename;
-    this._source = source;
-    this._tree = tree || {tokens: [], comments: []};
-
-    this._es3 = options.es3 || false;
-    this._es6 = options.es6 || false;
+    this._es3 = params.es3 || false;
+    this._es6 = params.es6 || false;
 
     this._lineBreaks = null;
-    this._lines = source.split(/\r\n|\r|\n/);
+    this._lines = this._source.split(/\r\n|\r|\n/);
+
+    try {
+        this._tree = parseJavaScriptSource(this._source, params.esprima, params.esprimaOptions);
+    } catch (e) {
+        this._parseErrors.push(e);
+    }
 
     this._tree.tokens = this._fixEs6Tokens(this._tree.tokens);
     this._tokens = this._buildTokenList(this._tree.tokens, this._tree.comments);
     this._addEOFToken();
-    this._applyWhitespaceData(this._tokens, source);
+    this._applyWhitespaceData(this._tokens, this._source);
 
     var tokenIndexes = this._buildTokenIndex(this._tokens);
     this._tokenRangeStartIndex = tokenIndexes.tokenRangeStartIndex;
@@ -651,6 +664,15 @@ JsFile.prototype = {
     },
 
     /**
+     * Returns list of parse errors.
+     *
+     * @returns {Error[]}
+     */
+    getParseErrors: function() {
+        return this._parseErrors;
+    },
+
+    /**
      * Builds token list using both code tokens and comment-tokens.
      *
      * @returns {Object[]}
@@ -805,7 +827,7 @@ JsFile.prototype = {
  * @param {Object} [esprimaOptions]
  * @returns {Object}
  */
-JsFile.parse = function(source, esprima, esprimaOptions) {
+function parseJavaScriptSource(source, esprima, esprimaOptions) {
     var finalEsprimaOptions = {
         tolerant: true
     };
@@ -859,6 +881,6 @@ JsFile.parse = function(source, esprima, esprimaOptions) {
     }
 
     return tree;
-};
+}
 
 module.exports = JsFile;

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -93,27 +93,15 @@ StringChecker.prototype = {
     checkString: function(source, filename) {
         filename = filename || 'input';
 
-        var sourceTree;
-        var parseError;
-
-        try {
-            sourceTree = JsFile.parse(source, this._esprima, this._configuration.getEsprimaOptions());
-        } catch (e) {
-            parseError = e;
-        }
-
-        var file = this._createJsFileInstance(filename, source, sourceTree);
+        var file = this._createJsFileInstance(filename, source);
 
         var errors = new Errors(file, this._verbose);
 
-        if (this._maxErrorsExceeded) {
-            return errors;
-        }
-
-        if (parseError) {
-            this._addParseError(errors, parseError);
-            return errors;
-        }
+        file.getParseErrors().forEach(function(parseError) {
+            if (!this._maxErrorsExceeded) {
+                this._addParseError(errors, parseError);
+            }
+        }, this);
 
         // Do not check empty strings
         if (file.getFirstToken().type === 'EOF') {
@@ -201,11 +189,14 @@ StringChecker.prototype = {
      *
      * @param {String} filename
      * @param {String} source
-     * @param {Object} sourceTree
      * @private
      */
-    _createJsFileInstance: function(filename, source, sourceTree) {
-        return new JsFile(filename, source, sourceTree, {
+    _createJsFileInstance: function(filename, source) {
+        return new JsFile({
+            filename: filename,
+            source: source,
+            esprima: this._esprima,
+            esprimaOptions: this._configuration.getEsprimaOptions(),
             es3: this._configuration.isES3Enabled(),
             es6: this._configuration.isESNextEnabled()
         });
@@ -225,28 +216,21 @@ StringChecker.prototype = {
 
         filename = filename || 'input';
 
-        var sourceTree;
-        var parseError;
+        var file = this._createJsFileInstance(filename, source);
+        var errors = new Errors(file, this._verbose);
 
-        try {
-            sourceTree = JsFile.parse(source, this._esprima, this._configuration.getEsprimaOptions());
-        } catch (e) {
-            parseError = e;
-        }
+        var parseErrors = file.getParseErrors();
 
-        if (parseError) {
-            var parseErrors = new Errors(this._createJsFileInstance(filename, source, sourceTree), this._verbose);
-            this._addParseError(parseErrors, parseError);
-            return {output: source, errors: parseErrors};
+        if (parseErrors.length > 0) {
+            parseErrors.forEach(function(parseError) {
+                this._addParseError(errors, parseError);
+            }, this);
+
+            return {output: source, errors: errors};
         } else {
             var attempt = 0;
-            var errors;
-            var file;
 
             do {
-                file = this._createJsFileInstance(filename, source, sourceTree);
-                errors = new Errors(file, this._verbose);
-
                 // Changes to current sources are made in rules through assertions.
                 this._checkJsFile(file, errors);
 
@@ -258,13 +242,13 @@ StringChecker.prototype = {
                     break;
                 }
 
-                source = file.render();
-                sourceTree = JsFile.parse(source, this._esprima, this._configuration.getEsprimaOptions());
+                file = this._createJsFileInstance(filename, file.render());
+                errors = new Errors(file, this._verbose);
 
                 attempt++;
             } while (attempt < MAX_FIX_ATTEMPTS);
 
-            return {output: source, errors: errors};
+            return {output: file.getSource(), errors: errors};
         }
     },
 

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -274,7 +274,9 @@ describe('modules/string-checker', function() {
     describe('esprima options', function() {
         var code = 'import { foo } from "bar";';
         var customEsprima = {
-            parse: function() {}
+            parse: function() {
+                return {tokens: [], comments: []};
+            }
         };
 
         beforeEach(function() {

--- a/test/specs/token-assert.js
+++ b/test/specs/token-assert.js
@@ -7,11 +7,12 @@ var TokenAssert = require('../../lib/token-assert');
 describe('modules/token-assert', function() {
 
     function createJsFile(sources) {
-        return new JsFile(
-            'example.js',
-            sources,
-            esprima.parse(sources, {loc: true, range: true, comment: true, tokens: true})
-        );
+        return new JsFile({
+            filename: 'example.js',
+            source: sources,
+            esprima: esprima,
+            esprimaOptions: {loc: true, range: true, comment: true, tokens: true}
+        });
     }
 
     describe('whitespaceBetween', function() {

--- a/test/specs/utils.js
+++ b/test/specs/utils.js
@@ -7,11 +7,12 @@ var path = require('path');
 describe('modules/utils', function() {
 
     function createJsFile(source) {
-        return new JsFile(
-            'example.js',
-            source,
-            esprima.parse(source, {loc: true, range: true, comment: true, tokens: true})
-        );
+        return new JsFile({
+            filename: 'example.js',
+            source: source,
+            esprima: esprima,
+            esprimaOptions: {loc: true, range: true, comment: true, tokens: true}
+        });
     }
 
     describe('isEs3Keyword', function() {


### PR DESCRIPTION
* Removed `JsFile.parse`.
* Moved parse routines to `JsFile` constructor.
* Added `JsFile:: getParseErrors` method.
* Fixed tests.
* Added tests.

I need this to implement abstraction on top of different file formats and then implement processing `JS` inlined to `HTML` pages.

/cc @markelog @zxqfox @mikesherov @mrjoelkemp 