### PR TITLE
Refactor integration tests

### DIFF
--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -3,7 +3,6 @@ var chalk = require('chalk');
 var vow = require('vow');
 var vowFs = require('vow-fs');
 
-var Promise = vow.Promise;
 var SOURCES = ['lib', 'test/specs'];
 var MOCHA = 'node_modules/.bin/mocha';
 
@@ -36,8 +35,8 @@ vowFs.listDir('./presets').then(function(presetFilenames) {
         );
     });
 })
-.progress(function() {})
-.done();
+    .progress(function() {})
+    .done();
 
 /**
  * Creates log error handler to output error message and pass error further.
@@ -142,7 +141,6 @@ function runProcess(executable, args, successCodes) {
  * Exit handler. Restores file changes before exit.
  *
  * @param {Error} error
- * @returns {Promise}
  */
 function exit(error) {
     var errorCode = 0;

--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -8,7 +8,7 @@ var MOCHA = 'node_modules/.bin/mocha';
 
 /**
  * Applying every available preset to JSCS sources and tests, then executing tests.
- * It is
+ * So we can make sure nothing breaks during these reformatting actions.
  */
 vowFs.listDir('./presets').then(function(presetFilenames) {
     var presets = presetFilenames.map(function(presetFilename) {

--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -10,31 +10,32 @@ var MOCHA = 'node_modules/.bin/mocha';
  * Applying every available preset to JSCS sources and tests, then executing tests.
  * So we can make sure nothing breaks during these reformatting actions.
  */
-vowFs.listDir('./presets').then(function(presetFilenames) {
-    var presets = presetFilenames.map(function(presetFilename) {
-        return presetFilename.replace('.json', '');
-    });
-    console.log('\n' + chalk.green('> ') + 'Autofix ingeration tests');
-    return promiseQueue(presets, function(presetName) {
-        console.log('\nPreset "' + chalk.green(presetName) + '"');
-        logStep('Autofix execution');
-        return applyPreset(presetName).then(
-            function() {
-                logStep('Unit tests');
-                console.log('');
-                return runTests().then(
-                    function() {
-                        console.log('');
-                        logStep('Unit test on "' + chalk.green(presetName) + '" preset are finished');
-                    },
-                    logErrorHandler('Unit tests failure'),
-                    passthroughProgress
-                );
-            },
-            logErrorHandler('Autofix failure')
-        );
-    });
-})
+vowFs.listDir('./presets')
+    .then(function(presetFilenames) {
+        var presets = presetFilenames.map(function(presetFilename) {
+            return presetFilename.replace('.json', '');
+        });
+        console.log('\n' + chalk.green('> ') + 'Autofix ingeration tests');
+        return promiseQueue(presets, function(presetName) {
+            console.log('\nPreset "' + chalk.green(presetName) + '"');
+            logStep('Autofix execution');
+            return applyPreset(presetName).then(
+                function() {
+                    logStep('Unit tests');
+                    console.log('');
+                    return runTests().then(
+                        function() {
+                            console.log('');
+                            logStep('Unit test on "' + chalk.green(presetName) + '" preset are finished');
+                        },
+                        logErrorHandler('Unit tests failure'),
+                        passthroughProgress
+                    );
+                },
+                logErrorHandler('Autofix failure')
+            );
+        });
+    })
     .progress(function() {})
     .done();
 

--- a/test/scripts/integration.js
+++ b/test/scripts/integration.js
@@ -1,109 +1,168 @@
-var fs = require('fs');
 var spawn = require('child_process').spawn;
-
 var chalk = require('chalk');
-var presets = fs.readdirSync('./presets').map(function(preset) {
-    return preset.replace('.json', '');
-});
+var vow = require('vow');
+var vowFs = require('vow-fs');
 
-function exit() {
-    spawn('git', ('checkout lib test/specs').split(' '));
+var Promise = vow.Promise;
+var SOURCES = ['lib', 'test/specs'];
+var MOCHA = 'node_modules/.bin/mocha';
+
+/**
+ * Applying every available preset to JSCS sources and tests, then executing tests.
+ * It is
+ */
+vowFs.listDir('./presets').then(function(presetFilenames) {
+    var presets = presetFilenames.map(function(presetFilename) {
+        return presetFilename.replace('.json', '');
+    });
+    console.log('\n' + chalk.green('> ') + 'Autofix ingeration tests');
+    return promiseQueue(presets, function(presetName) {
+        console.log('\nPreset "' + chalk.green(presetName) + '"');
+        logStep('Autofix execution');
+        return applyPreset(presetName).then(
+            function() {
+                logStep('Unit tests');
+                console.log('');
+                return runTests().then(
+                    function() {
+                        console.log('');
+                        logStep('Unit test on "' + chalk.green(presetName) + '" preset are finished');
+                    },
+                    logErrorHandler('Unit tests failure'),
+                    passthroughProgress
+                );
+            },
+            logErrorHandler('Autofix failure')
+        );
+    });
+})
+.progress(function() {})
+.done();
+
+/**
+ * Creates log error handler to output error message and pass error further.
+ *
+ * @param {String} message
+ * @returns {Function}
+ */
+function logErrorHandler(message) {
+    return function(e) {
+        logStep(message);
+        throw e;
+    };
 }
 
-function execPresets(presets) {
-    var preset = presets.pop();
+/**
+ * Proxies progress into terminal (stdout).
+ *
+ * @param {String} data
+ */
+function passthroughProgress(data) {
+    process.stdout.write(data);
+}
 
-    if (!preset) {
-        exit();
-        console.log(
-            chalk.green('> ') + 'Autofix ingeration tests are ' + chalk.green('finished'),
-            '\n'
-        );
+/**
+ * Logs execution step.
+ *
+ * @param {String} step
+ */
+function logStep(step) {
+    console.log(chalk.magenta(' - ') + step);
+}
 
-        return;
+/**
+ * @param {String} presetName
+ * @returns {Promise}
+ */
+function applyPreset(presetName) {
+    return runProcess('node', ['./bin/jscs', '-x', '-p', presetName].concat(SOURCES), [0, 2]);
+}
+
+/**
+ * Runs JSCS Unit Tests.
+ *
+ * @returns {Promise}
+ */
+function runTests() {
+    return runProcess('node', [MOCHA, '--color']);
+}
+
+/**
+ * Creates a queue using promises.
+ *
+ * @param {Array[]} data
+ * @param {Function} promiseCreator
+ * @returns {Promise}
+ */
+function promiseQueue(data, promiseCreator) {
+    data = data.concat();
+    function keepWorking() {
+        if (data.length > 0) {
+            var item = data.shift();
+            return promiseCreator(item).then(keepWorking);
+        }
     }
 
-    var args = ('./bin/jscs lib test/specs -x -p ' + preset).split(' ');
-    var messages = {
-        start: 'Preset "' + chalk.green(preset) + '"',
-
-        fixStart: 'Autofix execution',
-        fixError: 'Autofix failure',
-
-        unitStart: 'Unit tests',
-        unitEnd: 'Unit test on "' + chalk.green(preset) + '" preset are finished',
-        unitError: 'Unit tests failure'
-    };
-
-    (function test(messages, args) {
-
-        // Execute jscs -x on jscs source code for the given presets
-        var child = spawn('node', args, { timeout: Infinity });
-
-        process.stdout.write(messages.start + '\n\n');
-        process.stdout.write(chalk.magenta(' - ') + messages.fixStart + '\n');
-
-        // For some reason this makes subprocess to be more effective
-        child.stdout.on('data', function() {});
-
-        // Wait until autofix process is done
-        child.on('close', function executeTests(code) {
-
-            // exit code == 2 means there is some unfixable style violations
-            if (code !== 0 && code !== 2) {
-                process.stderr.write(chalk.red(' ! ') + messages.fixError + '\n\n');
-                process.exit(code);
-
-                return;
-            }
-
-            // Execute jscs tests on modified source code
-            var sChild = spawn('mocha', ['--color']);
-            var counter = 1;
-
-            process.stdout.write(chalk.magenta(' - ') + messages.unitStart + '\n');
-
-            // Show output, basically show that something is going on
-            sChild.stdout.on('data', function log() {
-
-                // Do not be so verbose
-                if (counter % 5 === 0) {
-                    process.stdout.write(chalk.grey('.'));
-                }
-
-                if (counter % 400 === 0) {
-                    process.stdout.write('\n');
-                }
-
-                counter++;
-            });
-
-            // Wait until tests are finished
-            sChild.on('close', function(code) {
-
-                // exit code == 2 means there is pending tests
-                if (code !== 0 && code !== 2) {
-                    process.stderr.write('\n\n' + chalk.red(' ! ') + messages.unitError + '\n\n');
-                    process.exit(code);
-
-                // Show "OK" message and execute next presets
-                } else {
-                    process.stdout.write('\n\n' + chalk.magenta(' - ') + messages.unitEnd);
-                    process.stdout.write('\n' + chalk.black(new Array(80).join('-')) + '\n\n');
-                    execPresets(presets);
-                }
-            });
-
-        });
-    })(messages, args);
+    return vow.resolve().then(keepWorking);
 }
 
-console.log('\n' + chalk.green('> ') + 'Autofix ingeration tests', '\n');
+/**
+ * Runs a process, returns promise with data notifications.
+ *
+ * @param {String} executable
+ * @param {String[]} args
+ * @param {Number[]} [successCodes]
+ * @returns {Promise}
+ */
+function runProcess(executable, args, successCodes) {
+    successCodes = successCodes || [0];
+
+    var defer = vow.defer();
+    var subProcess = spawn(executable, args, {
+        stdio: [0, 'pipe', 'pipe'],
+        timeout: Infinity
+    });
+    var stderr = '';
+    subProcess.stderr.on('data', function(data) { stderr += data; });
+    subProcess.stdout.on('data', function(data) {
+        defer.notify(String(data));
+    });
+    subProcess.on('close', function(code) {
+        if (successCodes.indexOf(code) === -1) {
+            defer.reject(new Error('Command failed: ' + executable + ' ' + args.join(' ') + '\n' + stderr));
+        } else {
+            defer.resolve();
+        }
+    });
+
+    return defer.promise();
+}
+
+/**
+ * Exit handler. Restores file changes before exit.
+ *
+ * @param {Error} error
+ * @returns {Promise}
+ */
+function exit(error) {
+    var errorCode = 0;
+    if (error) {
+        console.error(error);
+        errorCode = 1;
+    }
+    console.log('\n\nRestoring files...');
+    runProcess('git', ['checkout'].concat(SOURCES)).then(
+        function() {
+            process.exit(errorCode);
+        },
+        function() {
+            process.exit(1);
+        },
+        function() {}
+    );
+}
 
 // Listen for all "exit" events so we could put everything back
 process.on('exit', exit);
 process.on('SIGINT', exit);
 process.on('uncaughtException', exit);
-
-// Run autofix process on all available presets
-execPresets(presets);


### PR DESCRIPTION
After integration tests silently failed, I decided to figure out why, and during that process, I made some refactoring:

* More human-readable integration tests code.
* Use promises instead of callbacks: bulletproof execution flow and readability.
* Show test output (currently output is hidden, it hides errors).
* Fix STDIO-error (the actual cause of the problem).

/cc @markelog