### PR TITLE
disallowEmptyBlocks: should not report empty arrow blocks

### DIFF
--- a/lib/rules/disallow-empty-blocks.js
+++ b/lib/rules/disallow-empty-blocks.js
@@ -49,7 +49,8 @@ module.exports.prototype = {
             if (node.body.length === 0 &&
                 node.parentNode.type !== 'CatchClause' &&
                 node.parentNode.type !== 'FunctionDeclaration' &&
-                node.parentNode.type !== 'FunctionExpression') {
+                node.parentNode.type !== 'FunctionExpression' &&
+                node.parentNode.type !== 'ArrowFunctionExpression') {
                 errors.add('Empty block found', node.loc.end);
             }
         });

--- a/lib/rules/validate-aligned-function-parameters.js
+++ b/lib/rules/validate-aligned-function-parameters.js
@@ -74,7 +74,11 @@ module.exports.prototype = {
         var lineBreakAfterOpeningBrace = this._lineBreakAfterOpeningBrace;
         var lineBreakBeforeClosingBrace = this._lineBreakBeforeClosingBrace;
 
-        file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
+        file.iterateNodesByType([
+            'FunctionDeclaration',
+            'FunctionExpression',
+            'ArrowFunctionExpression'
+        ], function(node) {
 
             // ignore this rule if there are no parameters
             if (!(node.params && node.params.length > 0)) {

--- a/test/specs/rules/disallow-empty-blocks.js
+++ b/test/specs/rules/disallow-empty-blocks.js
@@ -125,4 +125,9 @@ describe('rules/disallow-empty-blocks', function() {
     it('should not report empty block for function expressions', function() {
         assert(checker.checkString('var a = function(){};').isEmpty());
     });
+
+    it('should not report empty arrow blocks', function() {
+        checker.configure({ esnext: true });
+        assert(checker.checkString('() => {}').isEmpty());
+    });
 });

--- a/test/specs/rules/validate-aligned-function-parameters.js
+++ b/test/specs/rules/validate-aligned-function-parameters.js
@@ -11,13 +11,19 @@ describe('rules/validate-aligned-function-parameters', function() {
 
     describe('no option', function() {
         beforeEach(function() {
-            checker.configure({ validateAlignedFunctionParameters: true });
+            checker.configure({ validateAlignedFunctionParameters: true, esnext: true });
         });
 
         it('should not report a function with no parameters', function() {
             assert(
                 checker.checkString(
                     'function a() {}'
+                ).isEmpty()
+            );
+
+            assert(
+                checker.checkString(
+                    '() => {}'
                 ).isEmpty()
             );
         });
@@ -28,6 +34,12 @@ describe('rules/validate-aligned-function-parameters', function() {
                     'function a(b, c) {}'
                 ).isEmpty()
             );
+
+            assert(
+                checker.checkString(
+                    '(b, c) => {}'
+                ).isEmpty()
+            );
         });
 
         it('should not report inline function parameters on a new line', function() {
@@ -36,6 +48,14 @@ describe('rules/validate-aligned-function-parameters', function() {
                     'function a(\n' +
                         '  b, c\n' +
                     ') {}'
+                ).isEmpty()
+            );
+
+            assert(
+                checker.checkString(
+                    '(\n' +
+                        '  b, c\n' +
+                    ') => {}'
                 ).isEmpty()
             );
         });
@@ -49,6 +69,15 @@ describe('rules/validate-aligned-function-parameters', function() {
                     ') {}'
                 ).getErrorCount() === 1
             );
+
+            assert(
+                checker.checkString(
+                    '(\n' +
+                        '  b,\n' +
+                        'c\n' +
+                    ') => {}'
+                ).getErrorCount() === 1
+            );
         });
 
         it('should not report aligned multi-line function parameters', function() {
@@ -56,6 +85,13 @@ describe('rules/validate-aligned-function-parameters', function() {
                 checker.checkString(
                     'function a(b,\n' +
                     '           c) {}'
+                ).isEmpty()
+            );
+
+            assert(
+                checker.checkString(
+                    '(b,\n' +
+                    ' c) => {}'
                 ).isEmpty()
             );
         });
@@ -66,7 +102,8 @@ describe('rules/validate-aligned-function-parameters', function() {
             checker.configure({
                 validateAlignedFunctionParameters: {
                     lineBreakAfterOpeningBrace: true
-                }
+                },
+                esnext: true
             });
         });
 
@@ -78,6 +115,14 @@ describe('rules/validate-aligned-function-parameters', function() {
                         '  c) {}'
                 ).isEmpty()
             );
+
+            assert(
+                checker.checkString(
+                    '(\n' +
+                        '  b,\n' +
+                        '  c) => {}'
+                ).isEmpty()
+            );
         });
 
         it('should report a missing line break after the opening brace', function() {
@@ -85,6 +130,13 @@ describe('rules/validate-aligned-function-parameters', function() {
                 checker.checkString(
                     'function a(b,\n' +
                     '           c) {}'
+                ).getErrorCount() === 1
+            );
+
+            assert(
+                checker.checkString(
+                    '(b,\n' +
+                    ' c) => {}'
                 ).getErrorCount() === 1
             );
         });
@@ -95,7 +147,8 @@ describe('rules/validate-aligned-function-parameters', function() {
             checker.configure({
                 validateAlignedFunctionParameters: {
                     lineBreakBeforeClosingBrace: true
-                }
+                },
+                esnext: true
             });
         });
 
@@ -108,6 +161,15 @@ describe('rules/validate-aligned-function-parameters', function() {
                     ') {}'
                 ).isEmpty()
             );
+
+            assert(
+                checker.checkString(
+                    '(\n' +
+                        '  b,\n' +
+                        '  c\n' +
+                    ') => {}'
+                ).isEmpty()
+            );
         });
 
         it('should report a missing line break before the closing brace', function() {
@@ -115,6 +177,13 @@ describe('rules/validate-aligned-function-parameters', function() {
                 checker.checkString(
                     'function a(b,\n' +
                     '           c)\n' + ' {}'
+                ).getErrorCount() === 1
+            );
+
+            assert(
+                checker.checkString(
+                    '(b,\n' +
+                    ' c) =>\n' + ' {}'
                 ).getErrorCount() === 1
             );
         });


### PR DESCRIPTION
Similar to #169 and #174, this just extends the logic to arrow functions.