### PR TITLE
allExcept: inCallExpression should also include object instantiation

### DIFF
--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -7,7 +7,8 @@
  * - `true`: always require a newline after blocks
  * - `Object`:
  *      - `"allExcept"`: `Array`
- *          - `"inCallExpressions"` Blocks don't need a line of padding in argument lists
+ *          - `"inCallExpressions"` Blocks don't need a line of padding in function argument lists
+ *          - `"inNewsExpressions"` Blocks don't need a line of padding in constructor argument lists
  *          - `"inArrayExpressions"` Blocks don't need a line of padding in arrays
  *          - `"inProperties"` Blocks don't need a line of padding as object properties
  *
@@ -16,7 +17,7 @@
  * ```js
  * "requirePaddingNewLinesAfterBlocks": true
  * "requirePaddingNewLinesAfterBlocks": {
- *     "allExcept": ["inCallExpressions", "inArrayExpressions", "inProperties"]
+ *     "allExcept": ["inCallExpressions", "inNewExpressions", "inArrayExpressions", "inProperties"]
  * }
  * ```
  *
@@ -61,6 +62,17 @@
  *
  * ```js
  * func(
+ *     2,
+ *     3,
+ *     function() {
+ *     }
+ * );
+ * ```
+ *
+ * ##### Valid for `{ "allExcept": ["inNewExpressions"] }`
+ *
+ * ```js
+ * new SomeClass(
  *     2,
  *     3,
  *     function() {
@@ -135,6 +147,7 @@ module.exports.prototype = {
     configure: function(value) {
         this.exceptions = {
             'CallExpression': false,
+            'NewExpression': false,
             'ArrayExpression': false,
             'Property': false
         };
@@ -150,13 +163,15 @@ module.exports.prototype = {
             value.allExcept.forEach(function(except) {
                 if (except === 'inCallExpressions') {
                     this.exceptions.CallExpression = true;
+                } else if (except === 'inNewExpressions') {
+                    this.exceptions.NewExpression = true;
                 } else if (except === 'inArrayExpressions') {
                     this.exceptions.ArrayExpression = true;
                 } else if (except === 'inProperties') {
                     this.exceptions.Property = true;
                 } else {
                     assert(false, optionName + ' option requires "allExcept" to only have ' +
-                        '"inCallExpressions" or "inArrayExpressions"');
+                        'one of "inCallExpressions", "inNewExpressions", "inArrayExpressions" or "inProperties');
                 }
             }, this);
         } else {

--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -8,7 +8,7 @@
  * - `Object`:
  *      - `"allExcept"`: `Array`
  *          - `"inCallExpressions"` Blocks don't need a line of padding in function argument lists
- *          - `"inNewsExpressions"` Blocks don't need a line of padding in constructor argument lists
+ *          - `"inNewExpressions"` Blocks don't need a line of padding in constructor argument lists
  *          - `"inArrayExpressions"` Blocks don't need a line of padding in arrays
  *          - `"inProperties"` Blocks don't need a line of padding as object properties
  *

--- a/test/specs/rules/require-padding-newlines-after-blocks.js
+++ b/test/specs/rules/require-padding-newlines-after-blocks.js
@@ -178,6 +178,14 @@ describe('rules/require-padding-newlines-after-blocks', function() {
         it('should not report missing padding when function is middle argument', function() {
             assert(checker.checkString('func(\n3,\nfunction() {\n},\n2\n)').isEmpty());
         });
+
+        it('should not report missing padding when function is last argument in object instantiation', function() {
+            assert(checker.checkString('new Obj(\n2,\n3,\nfunction() {\n}\n)').isEmpty());
+        });
+
+        it('should not report missing padding when function is middle argument in object instantiation', function() {
+            assert(checker.checkString('new Obj(\n3,\nfunction() {\n},\n2\n)').isEmpty());
+        });
     });
 
     describe('value allExcept: inArrayExpressions', function() {

--- a/test/specs/rules/require-padding-newlines-after-blocks.js
+++ b/test/specs/rules/require-padding-newlines-after-blocks.js
@@ -178,12 +178,22 @@ describe('rules/require-padding-newlines-after-blocks', function() {
         it('should not report missing padding when function is middle argument', function() {
             assert(checker.checkString('func(\n3,\nfunction() {\n},\n2\n)').isEmpty());
         });
+    });
 
-        it('should not report missing padding when function is last argument in object instantiation', function() {
+    describe('value allExcept: inNewExpressions', function() {
+        beforeEach(function() {
+            checker.configure({
+                requirePaddingNewLinesAfterBlocks: {
+                    allExcept: ['inNewExpressions']
+                }
+            });
+        });
+
+        it('should not report missing padding when function is last argument', function() {
             assert(checker.checkString('new Obj(\n2,\n3,\nfunction() {\n}\n)').isEmpty());
         });
 
-        it('should not report missing padding when function is middle argument in object instantiation', function() {
+        it('should not report missing padding when function is middle argument', function() {
             assert(checker.checkString('new Obj(\n3,\nfunction() {\n},\n2\n)').isEmpty());
         });
     });


### PR DESCRIPTION
Currently when setting the inCallExpression exception for requirePaddingNewLinesAfterBlocks object instantiation is not included in that exception. In the end it's the same scenario. So, when setting the inCallExpression exception the following should also be valid.

```javascript
//should be valid
new MyClass(
    'param1',
    function() {
        //some code
    }
);
```

```javascript
//is already valid
myFunction(
    'param1',
    function() {
        //some code
    }
);
```