### PR TITLE
(WIP) Misc: use babel-jscs for the esnext option

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -109,7 +109,7 @@ jscs path[ path[...]] --reporter=./some-dir/my-reporter.js
 ```
 
 ### `--esnext` (`-e`)
-Attempts to parse your code as ES6 using the harmony version of the esprima parser. Please note that this is currently experimental, and will improve over time.
+Attempts to parse your code as ES6+ using the babel-jscs package as the parser.Please note that this is currently experimental, and will improve over time.
 
 ### `--esprima` (`-s`)
 Attempts to parse your code with a custom Esprima version.
@@ -236,7 +236,7 @@ Default: Infinity
 
 ### esnext
 
-Attempts to parse your code as ES6 using the harmony version of the esprima parser.
+Attempts to parse your code as ES6+ using the babel-jscs package as the parser.Please note that this is currently experimental, and will improve over time.
 
 Type: `Boolean`
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -109,7 +109,7 @@ jscs path[ path[...]] --reporter=./some-dir/my-reporter.js
 ```
 
 ### `--esnext` (`-e`)
-Attempts to parse your code as ES6+ using the babel-jscs package as the parser.Please note that this is currently experimental, and will improve over time.
+Attempts to parse your code as ES6+, JSX, and Flow using the babel-jscs package as the parser. Please note that this is experimental, and will improve over time.
 
 ### `--esprima` (`-s`)
 Attempts to parse your code with a custom Esprima version.
@@ -236,7 +236,7 @@ Default: Infinity
 
 ### esnext
 
-Attempts to parse your code as ES6+ using the babel-jscs package as the parser.Please note that this is currently experimental, and will improve over time.
+Attempts to parse your code as ES6+, JSX, and Flow using the babel-jscs package as the parser. Please note that this is experimental, and will improve over time.
 
 Type: `Boolean`
 

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -1,5 +1,5 @@
 var defaultEsprima = require('esprima');
-var harmonyEsprima = require('esprima-harmony-jscs');
+var babelJscs = require('babel-jscs');
 var Errors = require('./errors');
 var JsFile = require('./js-file');
 var Configuration = require('./config/configuration');
@@ -31,7 +31,7 @@ var StringChecker = function(options) {
     } else {
         options = options || {};
         this._verbose = options.verbose || false;
-        this._esprima = options.esprima || (options.esnext ? harmonyEsprima : defaultEsprima);
+        this._esprima = options.esprima || (options.esnext ? babelJscs : defaultEsprima);
     }
 };
 
@@ -72,7 +72,7 @@ StringChecker.prototype = {
         if (this._configuration.hasCustomEsprima()) {
             this._esprima = this._configuration.getCustomEsprima();
         } else if (this._configuration.isESNextEnabled()) {
-            this._esprima = harmonyEsprima;
+            this._esprima = babelJscs;
         }
 
         if (this._verbose === false) {

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
+    "babel-jscs": "^1.0.1",
     "chalk": "~1.0.0",
     "cli-table": "~0.3.1",
     "commander": "~2.8.1",
     "esprima": "^1.2.5",
-    "esprima-harmony-jscs": "1.1.0-bin",
     "estraverse": "^1.9.3",
     "exit": "~0.1.2",
     "glob": "^5.0.1",

--- a/test/data/cli/esprima.json
+++ b/test/data/cli/esprima.json
@@ -1,4 +1,4 @@
 {
     "disallowKeywords": ["with"],
-    "esprima": "esprima-harmony-jscs"
+    "esprima": "babel-jscs"
 }

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -695,7 +695,7 @@ describe('modules/cli', function() {
         it('should use a custom esprima provided at CLI', function() {
             return assertNoCliErrors(cli({
                 args: ['test/data/cli/esnext.js'],
-                esprima: 'esprima-harmony-jscs',
+                esprima: 'babel-jscs',
                 config: 'test/data/cli/cli.json'
             }));
         });

--- a/test/specs/config/node-configuration.js
+++ b/test/specs/config/node-configuration.js
@@ -24,7 +24,7 @@ describe('modules/config/node-configuration', function() {
                 preset: 'jquery',
                 maxErrors: '2',
                 errorFilter: path.resolve(__dirname, '../../data/error-filter.js'),
-                esprima: 'esprima-harmony-jscs',
+                esprima: 'babel-jscs',
                 es3: true,
                 verbose: true,
                 esnext: true
@@ -86,7 +86,7 @@ describe('modules/config/node-configuration', function() {
 
         it('should accept `esprima` to register different esprima', function() {
             configuration.load({
-                esprima: 'esprima-harmony-jscs'
+                esprima: 'babel-jscs'
             });
 
             assert.equal(configuration.hasCustomEsprima(), true);

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var esprima = require('esprima');
-var harmonyEsprima = require('esprima-harmony-jscs');
+var babelJscs = require('babel-jscs');
 var JsFile = require('../../lib/js-file');
 var sinon = require('sinon');
 var fs = require('fs');
@@ -18,11 +18,11 @@ describe('modules/js-file', function() {
         return new JsFile(assign(params, options));
     }
 
-    function createHarmonyJsFile(sources) {
+    function createBabelJsFile(sources) {
         return new JsFile({
             filename: 'example.js',
             source: sources,
-            esprima: harmonyEsprima,
+            esprima: babelJscs,
             es6: true
         });
     }
@@ -194,7 +194,7 @@ describe('modules/js-file', function() {
     describe('iterateNodesByType', function() {
         it('should handle ES6 export keyword', function() {
             var spy = sinon.spy();
-            createHarmonyJsFile('export function foo() { var a = "b"; };')
+            createBabelJsFile('export function foo() { var a = "b"; };')
                 .iterateNodesByType('VariableDeclaration', spy);
             assert(spy.calledOnce);
         });
@@ -231,13 +231,13 @@ describe('modules/js-file', function() {
 
         it('should not have duplicate tokens in es6 export default statements', function() {
             var spy = sinon.spy();
-            createHarmonyJsFile('export default function() {}').iterateTokenByValue('(', spy);
+            createBabelJsFile('export default function() {}').iterateTokenByValue('(', spy);
             assert(spy.calledOnce);
         });
 
         it('should not have duplicate tokens in es6 export default statements', function() {
             var spy = sinon.spy();
-            createHarmonyJsFile('export default function init() {\n' +
+            createBabelJsFile('export default function init() {\n' +
             '  window.addEventListener(\'fb-flo-reload\', function(ev) {\n' +
             '  });\n' +
             '}').iterateTokenByValue('(', spy);
@@ -1036,7 +1036,7 @@ describe('modules/js-file', function() {
         fs.readdirSync(absDirPath).forEach(function(filename) {
             it('file ' + relativeDirPath + '/' + filename + ' should be rendered correctly', function() {
                 var source = fs.readFileSync(absDirPath + '/' + filename, 'utf8');
-                var file = createHarmonyJsFile(source);
+                var file = createBabelJsFile(source);
                 assert.equal(file.render(), source);
             });
         });

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -239,7 +239,7 @@ describe('modules/string-checker', function() {
             assert(error.message === customDescription);
         });
 
-        it('uses the harmony esprima when true is provided to the constructor', function() {
+        it('uses babel-jscs when true is provided to the constructor', function() {
             checker = new StringChecker({ esnext: true });
             checker.registerDefaultRules();
 
@@ -247,7 +247,7 @@ describe('modules/string-checker', function() {
             assert(errors.isEmpty());
         });
 
-        it('uses the harmony esprima when esnext is set to true in the config', function() {
+        it('uses babel-jscs when esnext is set to true in the config', function() {
             checker = new StringChecker();
             checker.registerDefaultRules();
             checker.configure({ esnext: true });


### PR DESCRIPTION
Fixes #1353 @markelog 

Don't know if we just want to replace the `esprima-harmony-jscs`?

Also since babel-jscs has babel-core as a dependency, adding babel-jscs would make jscs bigger. It's not a problem for people using babel already - just unneeded for everyone else?

---

I think the tests are failing because of the local/global npm issue? Not sure why.

All the tests with `esprima: 'babel-jscs',` like

```js
it('should use a custom esprima provided at CLI', function() {
            return assertNoCliErrors(cli({
                args: ['test/data/cli/esnext.js'],
                esprima: 'babel-jscs', // was fine with 'esprima-harmony-jscs'
                config: 'test/data/cli/cli.json'
            }));
        });
```