### PR TITLE
Preset: update Wordpress preset

### DIFF
--- a/presets/wordpress.json
+++ b/presets/wordpress.json
@@ -9,6 +9,6 @@
         "all": true,
         "except": [ "{", "}", "[", "]", "function" ]
     },
-    "requireYodaConditions": true,
+    "requireYodaConditions": ["==", "!=", "===", "!=="],
     "validateQuoteMarks": "'"
 }


### PR DESCRIPTION
Only disallow Yoda conditions for equality operators.

Closes #1452
Fixes #1188