### PR TITLE
New Rule: disallowSpaceBeforeSemicolon

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -744,6 +744,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-not-operators-in-conditionals'));
 
     this.registerRule(require('../rules/require-matching-function-name'));
+
+    this.registerRule(require('../rules/disallow-space-before-semicolon'));
 };
 
 /**

--- a/lib/rules/disallow-space-before-semicolon.js
+++ b/lib/rules/disallow-space-before-semicolon.js
@@ -1,0 +1,56 @@
+/**
+ * Disallows spaces before semicolons.
+ *
+ * Types: `Boolean`
+ *
+ * Values: `true` to disallow any spaces before any semicolon.
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowSpaceBeforeSemicolon": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = 1;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = 1 ;
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(option) {
+        assert(
+          option === true,
+          this.getOptionName() + ' option requires true value'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowSpaceBeforeSemicolon';
+    },
+
+    check: function(file, errors) {
+        file.iterateTokensByTypeAndValue('Punctuator', ';', function(token) {
+            var prevToken = file.getPrevToken(token);
+
+            errors.assert.noWhitespaceBetween({
+                token: prevToken,
+                nextToken: token,
+                message: 'Illegal space before semicolon'
+            });
+        });
+    }
+
+};

--- a/test/specs/rules/disallow-space-before-semicolon.js
+++ b/test/specs/rules/disallow-space-before-semicolon.js
@@ -1,0 +1,31 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/disallow-space-before-semicolon', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    it('should not accept a false value as an option', function() {
+        assert.throws(function() {
+            checker.configure({ disallowSpaceBeforeSemicolon: false });
+        });
+    });
+
+    it('does not allow spaces before semicolons', function() {
+        checker.configure({ disallowSpaceBeforeSemicolon: true });
+
+        assert(checker.checkString('; ;').getErrorCount() === 1);
+        assert(checker.checkString('var a = 1 ;').getErrorCount() === 1);
+        assert(checker.checkString('var a = 2  ;').getErrorCount() === 1);
+    });
+
+    it('does allow semicolons with no spaces', function() {
+        checker.configure({ disallowSpaceBeforeSemicolon: true });
+
+        assert(checker.checkString('var a = 1;').isEmpty());
+    });
+});


### PR DESCRIPTION
Disallow any spaces before semicolons (related to #1447)

```js
// "disallowSpaceBeforeSemicolon": true

// bad
var a ;

// good
var b;
```

The tests probably need some work.