### PR TITLE
requirePaddingNewlinesBeforeKeywords: Modify special scenarios

### DIFF
--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -85,14 +85,16 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var excludedTokens = [':', ',', '(', '='];
-
+        var specialCases = { 'if': 'else' };
         file.iterateTokensByTypeAndValue('Keyword', this._keywords, function(token) {
             var prevToken = file.getPrevToken(token);
-
-            // Handle special case of 'else if' construct.
-            if (token.value === 'if' && prevToken && prevToken.value === 'else') {
+            // Handle special cases listed in specialCasesToken array
+            if (prevToken && prevToken.value === specialCases[token.value]) {
                 return;
-            // Handling for special cases.
+            } else if (prevToken  && token.value === 'while' &&
+                file.getNodesByFirstToken(token).length === 0) {
+                return;
+            // Handle excludedTokens
             } else if (prevToken && excludedTokens.indexOf(prevToken.value) > -1) {
                 return;
             }

--- a/test/specs/rules/require-padding-newlines-before-keywords.js
+++ b/test/specs/rules/require-padding-newlines-before-keywords.js
@@ -12,7 +12,9 @@ describe('rules/require-padding-newlines-before-keywords', function() {
     describe('array value', function() {
         beforeEach(function() {
             checker.configure({
-                requirePaddingNewlinesBeforeKeywords: ['if', 'for', 'return', 'switch', 'case', 'break', 'throw']
+                requirePaddingNewlinesBeforeKeywords: [
+                    'if', 'for', 'return', 'switch', 'case', 'break', 'throw', 'while', 'default'
+                ]
             });
         });
 
@@ -50,6 +52,14 @@ describe('rules/require-padding-newlines-before-keywords', function() {
             );
         });
 
+        it('should not report on do while construct', function() {
+            assert(
+                checker.checkString(
+                    'function x() { var a = true; do { a = !a; } while (a); }'
+                ).isEmpty()
+            );
+        });
+
         it('should not report on keyword following an if without curly braces', function() {
             assert(
                 checker.checkString(
@@ -59,7 +69,7 @@ describe('rules/require-padding-newlines-before-keywords', function() {
         });
 
         // Test case for 'for' statement
-        it('should report on matching if statement', function() {
+        it('should report on matching for statement', function() {
             assert(
                 checker.checkString(
                     'function x() { var a = true;' +
@@ -69,12 +79,21 @@ describe('rules/require-padding-newlines-before-keywords', function() {
         });
 
         // Test case for 'switch', 'case' and 'break' statement
-        it('should report on matching if statement', function() {
+        it('should report on matching switch, case, break, default statements', function() {
             assert(
                 checker.checkString(
                     'function x() { var y = true; switch ("Oranges")' + ' { case "Oranges": y = !y; break;' +
                     ' case "Apples": y = !y; break; default: y = !y; } }'
-                ).getErrorCount() === 4
+                ).getErrorCount() === 5
+            );
+        });
+
+        // Test cases for if statements
+        it('should report on matching while statement', function() {
+            assert(
+                checker.checkString(
+                    'function x() { var a = true; while (!a) { a = !a; }; }'
+                ).getErrorCount() === 1
             );
         });
 


### PR DESCRIPTION
Make special scenario for "elseif" perform index searching against a special case object.
Allow "while" that is part of a "dowhile" to succeed

Fixes #1092 

@mikesherov Please let me know if you think this is suitable.