### PR TITLE
requirePaddingNewlinesInBlocks: Add detail object to options

### DIFF
--- a/lib/rules/require-padding-newlines-in-blocks.js
+++ b/lib/rules/require-padding-newlines-in-blocks.js
@@ -10,9 +10,13 @@
  *
  * ```js
  * "requirePaddingNewlinesInBlocks": true
+ * "requirePaddingNewlinesInBlocks": 1
+ * "requirePaddingNewlinesInBlocks": { "open": true, "close": true }
+ * "requirePaddingNewlinesInBlocks": { "open": false, "close": true }
+ * "requirePaddingNewlinesInBlocks": { "open": true, "close": false }
  * ```
  *
- * ##### Valid for mode `true`
+ * ##### Valid for mode `true` or `{ "open": true, "close": true }`
  *
  * ```js
  * if (true) {
@@ -56,7 +60,54 @@
  *     doSomething();
  *     doSomethingElse();
  * }
+ *  ```
+ *
+ * ##### Valid for mode `{ "open": false, "close": true }`
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *
+ * }
+ * var abc = function() {};
  * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) {doSomething();}
+ * if (true) {
+ *     doSomething();
+ * }
+ * if (true) {
+ *
+ *     doSomething();
+ * }
+ * ```
+ *
+  * ##### Valid for mode `{ "open": true, "close": false }`
+ *
+ * ```js
+ * if (true) {
+ *
+ *     doSomething();
+ * }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) {doSomething();}
+ * if (true) {
+ *     doSomething();
+ * }
+ * if (true) {
+ *     doSomething();
+ *
+ * }
+ * ```
+ *
  */
 
 var assert = require('assert');
@@ -67,11 +118,27 @@ module.exports.prototype = {
 
     configure: function(options) {
         assert(
-            options === true || typeof options === 'number',
-            this.getOptionName() + ' option requires the value true or an Integer'
+            options === true || typeof options === 'number' || typeof options === 'object',
+            this.getOptionName() + ' option requires the value true, an Integer or an object'
         );
 
-        this._minStatements = options === true ? 0 : options;
+        this._checkOpen = true;
+        this._checkClose = true;
+        this._minStatements = 0;
+        if (typeof options === 'object') {
+            assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
+                this.getOptionName() + ' option requires the "open" and "close" ' +
+                 'properties to be booleans');
+
+            assert(options.open || options.close,
+                this.getOptionName() + ' option requires either one of  the "open" and "close" ' +
+                 'properties to be true');
+
+            this._checkOpen = options.open;
+            this._checkClose = options.close;
+        } else if (typeof options === 'number') {
+            this._minStatements = options;
+        }
     },
 
     getOptionName: function() {
@@ -80,30 +147,35 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var minStatements = this._minStatements;
+        var checkOpen = this._checkOpen;
+        var checkClose = this._checkClose;
 
         file.iterateNodesByType('BlockStatement', function(node) {
             if (node.body.length <= minStatements) {
                 return;
             }
 
-            var openingBracket = file.getFirstNodeToken(node);
+            if (checkOpen === true) {
+                var openingBracket = file.getFirstNodeToken(node);
 
-            errors.assert.linesBetween({
-                token: openingBracket,
-                nextToken: file.getNextToken(openingBracket, {includeComments: true}),
-                atLeast: 2,
-                message: 'Expected a padding newline after opening curly brace'
-            });
+                errors.assert.linesBetween({
+                    token: openingBracket,
+                    nextToken: file.getNextToken(openingBracket, {includeComments: true}),
+                    atLeast: 2,
+                    message: 'Expected a padding newline after opening curly brace'
+                });
+            }
 
-            var closingBracket = file.getLastNodeToken(node);
+            if (checkClose === true) {
+                var closingBracket = file.getLastNodeToken(node);
 
-            errors.assert.linesBetween({
-                token: file.getPrevToken(closingBracket, {includeComments: true}),
-                nextToken: closingBracket,
-                atLeast: 2,
-                message: 'Expected a padding newline before closing curly brace'
-            });
+                errors.assert.linesBetween({
+                    token: file.getPrevToken(closingBracket, {includeComments: true}),
+                    nextToken: closingBracket,
+                    atLeast: 2,
+                    message: 'Expected a padding newline before closing curly brace'
+                });
+            }
         });
     }
-
 };

--- a/test/specs/rules/require-padding-newlines-in-blocks.js
+++ b/test/specs/rules/require-padding-newlines-in-blocks.js
@@ -8,114 +8,178 @@ describe('rules/require-padding-newlines-in-blocks', function() {
         checker.registerDefaultRules();
     });
 
-    describe('option value true', function() {
-        beforeEach(function() {
-            checker.configure({ requirePaddingNewlinesInBlocks: true });
+    var scenarios = [
+        { option: true, statement: 'abc();' },
+        { option: 1, statement: 'abc();abc();' }
+    ];
+
+    describe('invalid options', function() {
+        it('should report configuration error if not boolean or integer', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewlinesInBlocks: 'string' });
+            });
         });
 
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {abc();\n\n}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {\nabc();\n\n}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newline before closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newline before closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();\n}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newlines in both cases', function() {
-            assert(checker.checkString('if (true) {abc();}').getErrorCount() === 2);
-        });
-
-        it('should report missing padding newlines in both cases', function() {
-            assert(checker.checkString('if (true) {\nabc();\n}').getErrorCount() === 2);
-        });
-
-        it('should not report with no spaces', function() {
-            assert(checker.checkString('if (true) {\n\nabc();\n\n}').isEmpty());
-        });
-
-        it('should not report empty function definitions', function() {
-            assert(checker.checkString('var a = function() {};').isEmpty());
-        });
-
-        it('should not report missing newlines after opening brace', function() {
-            assert(checker.checkString('if (true) {\n\n\nabc();\n\n}').isEmpty());
-        });
-
-        it('should not report missing newlines before closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();\nabc();\n\n\n}').isEmpty());
-        });
-
-        it('should not report missing newlines with comments inside block', function() {
-            assert(checker.checkString('if (true) {\n\n//bla\nabc();\nabc();\n\n}').isEmpty());
-        });
-
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {//bla\n\nabc();\n\n}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {\n/**/\nabc();\n\n}').getErrorCount() === 1);
-        });
-
-        it('should report missing padding newline between oneline comment and closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();\n\n//\n}').getErrorCount() === 1);
-        });
-
-        it('should fix missing padding newlines', function() {
-            assert.equal(
-                checker.fixString('if (true) {abc();abc();}').output,
-                'if (true) {\n\nabc();abc();\n\n}'
-            );
+        describe('option is boolean', function() {
+            it('should report configuration error if false', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: false });
+                });
+            });
         });
     });
 
-    describe('option value 1', function() {
-        beforeEach(function() {
-            checker.configure({ requirePaddingNewlinesInBlocks: 1 });
-        });
+    scenarios.forEach(function(scenario) {
+        describe('valid option: ' + JSON.stringify(scenario.option), function() {
+            it('should not report configuration error', function() {
+                assert.doesNotThrow(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
+            });
 
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {abc();abc();\n\n}').getErrorCount() === 1);
-        });
+            describe('tests for missing padding newline after opening brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
 
-        it('should report missing padding newline after opening brace', function() {
-            assert(checker.checkString('if (true) {\nabc();abc();\n\n}').getErrorCount() === 1);
-        });
+                it('should report error for no linebreak and no padding newline', function() {
+                    assert(checker.
+                        checkString('if (true) {' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
 
-        it('should report missing padding newline before closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();abc();}').getErrorCount() === 1);
-        });
+                it('should report error for linebreak but no padding newline', function() {
+                    assert(checker.
+                        checkString('if (true) {\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
 
-        it('should report missing padding newline before closing brace', function() {
-            assert(checker.checkString('if (true) {\n\nabc();abc();\n}').getErrorCount() === 1);
-        });
+                it('should report error for with no linebreak and no padding newline before single line comments',
+                    function() {
+                    assert(checker.
+                        checkString('if (true) {//bla\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
 
-        it('should report missing padding newlines in both cases', function() {
-            assert(checker.checkString('if (true) {abc();abc();}').getErrorCount() === 2);
-        });
+                it('should report error for linebreak but no padding newline before single line comments', function() {
+                    assert(checker.
+                        checkString('if (true) {\n//bla\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
 
-        it('should report missing padding newlines in both cases', function() {
-            assert(checker.checkString('if (true) {\nabc();abc();\n}').getErrorCount() === 2);
-        });
+                it('should report error for no linebreak and no padding newline before mulitiline comments',
+                    function() {
+                    assert(checker.
+                        checkString('if (true) {/**/\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
 
-        it('should not report with no spaces', function() {
-            assert(checker.checkString('if (true) {\n\nabc();abc();\n\n}').isEmpty());
-        });
+                it('should report error for linebreak but no padding newline before mulitiline comments', function() {
+                    assert(checker.
+                        checkString('if (true) {\n/**/\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                });
+            });
 
-        it('should not report empty function definitions', function() {
-            assert(checker.checkString('var a = function() {};').isEmpty());
-        });
+            describe('tests for missing padding newline before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
 
-        it('should not report single statement functions', function() {
-            assert(checker.checkString('var a = function() {abc();};').isEmpty());
+                it('should report error for no linebreak and no padding newline', function() {
+                    assert(checker
+                        .checkString('if (true) {\n\n' + scenario.statement + '}').getErrorCount() === 1);
+                });
+
+                it('should report error for with linebreak but no padding newline', function() {
+                    assert(checker
+                        .checkString('if (true) {\n\n' + scenario.statement + '\n}').getErrorCount() === 1);
+                });
+
+                it('should report error for no linebreak and no padding newline after single line comments',
+                    function() {
+                    assert(checker
+                        .checkString('if (true) {\n\n' + scenario.statement + '\n//bla}').getErrorCount() === 1);
+                });
+
+                it('should report error for linebreak but no padding newline after single line comments', function() {
+                    assert(checker.
+                        checkString('if (true) {\n\n' + scenario.statement + '\n//bla\n}').getErrorCount() === 1);
+                });
+
+                it('should report error for no linebreak and no padding newline after mulitiline comments', function() {
+                    assert(checker.
+                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/}').getErrorCount() === 1);
+                });
+
+                it('should report error for linebreak but no padding newline after mulitiline comments', function() {
+                    assert(checker.
+                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/\n}').getErrorCount() === 1);
+                });
+            });
+
+            describe('tests for missing padding newlines both after open brace and before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
+
+                it('should report 2 errors for no linebreak and no padding newline', function() {
+                    assert(checker
+                        .checkString('if (true) {' + scenario.statement + '}').getErrorCount() === 2);
+                });
+
+                it('should report 2 errors for linebreak but no padding newline', function() {
+                    assert(checker
+                        .checkString('if (true) {\n' + scenario.statement + '\n}').getErrorCount() === 2);
+                });
+            });
+
+            describe('tests for valid padding newlines after opening brace and before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
+
+                it('should not report error for single padding newline on both sides', function() {
+                    assert(checker.checkString('if (true) {\n\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+
+                it('should not report error for double padding newline after opening brace and single padding ' +
+                    'newline before closing brace', function() {
+                    assert(checker.checkString('if (true) {\n\n\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+
+                it('should not report error for single padding newline after opening brace and double padding  ' +
+                    'newline before closing brace', function() {
+                    assert(checker.checkString('if (true) {\n\n' + scenario.statement + '\n\n\n}').isEmpty());
+                });
+
+                it('should not report error for single padding newline on both sides with comments', function() {
+                    assert(checker.checkString('if (true) {\n\n//bla\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+            });
+
+            describe('tests for special valid rule exceptions', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
+
+                it('should not report empty function definitions', function() {
+                    assert(checker.checkString('var a = function() {};').isEmpty());
+                });
+
+                if (typeof scenario.option === 'number' && scenario.option === 1) {
+                    it('should not report single statement functions', function() {
+                        assert(checker.checkString('var a = function() {abc();};').isEmpty());
+                    });
+                }
+            });
+
+            describe('tests for fixString', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
+                });
+
+                it('should fix missing padding newlines', function() {
+                    assert.equal(
+                        checker.fixString('if (true) {abc();abc();}').output,
+                        'if (true) {\n\nabc();abc();\n\n}'
+                    );
+                });
+            });
         });
     });
 });

--- a/test/specs/rules/require-padding-newlines-in-blocks.js
+++ b/test/specs/rules/require-padding-newlines-in-blocks.js
@@ -10,11 +10,14 @@ describe('rules/require-padding-newlines-in-blocks', function() {
 
     var scenarios = [
         { option: true, statement: 'abc();' },
-        { option: 1, statement: 'abc();abc();' }
+        { option: 1, statement: 'abc();abc();' },
+        { option: { 'open': true, 'close': true }, statement: 'abc();' },
+        { option: { 'open': false, 'close': true }, statement: 'abc();' },
+        { option: { 'open': true, 'close': false }, statement: 'abc();' }
     ];
 
     describe('invalid options', function() {
-        it('should report configuration error if not boolean or integer', function() {
+        it('should report configuration error if not boolean, integer or object', function() {
             assert.throws(function() {
                 checker.configure({ requirePaddingNewlinesInBlocks: 'string' });
             });
@@ -24,6 +27,38 @@ describe('rules/require-padding-newlines-in-blocks', function() {
             it('should report configuration error if false', function() {
                 assert.throws(function() {
                     checker.configure({ requirePaddingNewlinesInBlocks: false });
+                });
+            });
+        });
+
+        describe('option is object', function() {
+            it('should report configuration error if options.open is not found', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: { 'close': true } });
+                });
+            });
+
+            it('should report configuration error if options.open is not a boolean', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: { 'open': 'true', 'close': true } });
+                });
+            });
+
+            it('should report configuration error if options.close is not found', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: { 'open': true } });
+                });
+            });
+
+            it('should report configuration error if options.close is not a boolean', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: { 'open': true, 'close': 'true' } });
+                });
+            });
+
+            it('should report configuration error if both options.open and options.close are false', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInBlocks: { open: false, close: false} });
                 });
             });
         });
@@ -42,36 +77,49 @@ describe('rules/require-padding-newlines-in-blocks', function() {
                     checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
                 });
 
-                it('should report error for no linebreak and no padding newline', function() {
+                var errorCount = 1;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.open === false) {
+                        errorCount = 0;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline', function() {
                     assert(checker.
-                        checkString('if (true) {' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {' + scenario.statement + '\n\n}').getErrorCount() === errorCount);
                 });
 
-                it('should report error for linebreak but no padding newline', function() {
+                it('should report ' + errorCount + ' error for linebreak but no padding newline', function() {
                     assert(checker.
-                        checkString('if (true) {\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {\n' + scenario.statement + '\n\n}').getErrorCount() === errorCount);
                 });
 
-                it('should report error for with no linebreak and no padding newline before single line comments',
-                    function() {
+                it('should report ' + errorCount + ' error for with no linebreak and no padding newline before ' +
+                    'single line comments', function() {
                     assert(checker.
-                        checkString('if (true) {//bla\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {//bla\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
                 });
 
-                it('should report error for linebreak but no padding newline before single line comments', function() {
+                it('should report ' + errorCount + ' error for linebreak but no padding newline before single line ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {\n//bla\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {\n//bla\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
                 });
 
-                it('should report error for no linebreak and no padding newline before mulitiline comments',
-                    function() {
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline before mulitiline ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {/**/\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {/**/\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
                 });
 
-                it('should report error for linebreak but no padding newline before mulitiline comments', function() {
+                it('should report ' + errorCount + ' error for linebreak but no padding newline before mulitiline ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {\n/**/\n' + scenario.statement + '\n\n}').getErrorCount() === 1);
+                        checkString('if (true) {\n/**/\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
                 });
             });
 
@@ -80,35 +128,41 @@ describe('rules/require-padding-newlines-in-blocks', function() {
                     checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
                 });
 
-                it('should report error for no linebreak and no padding newline', function() {
+                var errorCount = 1;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.close === false) {
+                        errorCount = 0;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline', function() {
                     assert(checker
-                        .checkString('if (true) {\n\n' + scenario.statement + '}').getErrorCount() === 1);
+                        .checkString('if (true) {\n\n' + scenario.statement + '}').getErrorCount() === errorCount);
                 });
 
-                it('should report error for with linebreak but no padding newline', function() {
+                it('should report ' + errorCount + ' error for with linebreak but no padding newline', function() {
                     assert(checker
-                        .checkString('if (true) {\n\n' + scenario.statement + '\n}').getErrorCount() === 1);
+                        .checkString('if (true) {\n\n' + scenario.statement + '\n}').getErrorCount() === errorCount);
                 });
 
-                it('should report error for no linebreak and no padding newline after single line comments',
-                    function() {
-                    assert(checker
-                        .checkString('if (true) {\n\n' + scenario.statement + '\n//bla}').getErrorCount() === 1);
-                });
-
-                it('should report error for linebreak but no padding newline after single line comments', function() {
+                it('should report ' + errorCount + ' error for linebreak but no padding newline after single line ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {\n\n' + scenario.statement + '\n//bla\n}').getErrorCount() === 1);
+                        checkString('if (true) {\n\n' + scenario.statement + '\n//bla\n}').
+                            getErrorCount() === errorCount);
                 });
 
-                it('should report error for no linebreak and no padding newline after mulitiline comments', function() {
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline after mulitiline ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/}').getErrorCount() === 1);
+                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/}').getErrorCount() === errorCount);
                 });
 
-                it('should report error for linebreak but no padding newline after mulitiline comments', function() {
+                it('should report ' + errorCount + ' error for linebreak but no padding newline after mulitiline ' +
+                    'comments', function() {
                     assert(checker.
-                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/\n}').getErrorCount() === 1);
+                        checkString('if (true) {\n\n' + scenario.statement + '\n/**/\n}').
+                            getErrorCount() === errorCount);
                 });
             });
 
@@ -117,14 +171,25 @@ describe('rules/require-padding-newlines-in-blocks', function() {
                     checker.configure({ requirePaddingNewlinesInBlocks: scenario.option });
                 });
 
-                it('should report 2 errors for no linebreak and no padding newline', function() {
+                var errorCount = 2;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.open === false) {
+                        errorCount -= 1;
+                    }
+
+                    if (scenario.option.close === false) {
+                        errorCount -= 1;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error(s) for no linebreak and no padding newline', function() {
                     assert(checker
-                        .checkString('if (true) {' + scenario.statement + '}').getErrorCount() === 2);
+                        .checkString('if (true) {' + scenario.statement + '}').getErrorCount() === errorCount);
                 });
 
-                it('should report 2 errors for linebreak but no padding newline', function() {
+                it('should report ' + errorCount + ' error(s) for linebreak but no padding newline', function() {
                     assert(checker
-                        .checkString('if (true) {\n' + scenario.statement + '\n}').getErrorCount() === 2);
+                        .checkString('if (true) {\n' + scenario.statement + '\n}').getErrorCount() === errorCount);
                 });
             });
 
@@ -174,10 +239,22 @@ describe('rules/require-padding-newlines-in-blocks', function() {
                 });
 
                 it('should fix missing padding newlines', function() {
-                    assert.equal(
-                        checker.fixString('if (true) {abc();abc();}').output,
-                        'if (true) {\n\nabc();abc();\n\n}'
-                    );
+                    if (typeof scenario.option === 'object' && scenario.option.open === false) {
+                        assert.equal(
+                            checker.fixString('if (true) {' + scenario.statement + '}').output,
+                            'if (true) {' + scenario.statement + '\n\n}'
+                        );
+                    } else if (typeof scenario.option === 'object' && scenario.option.close === false) {
+                        assert.equal(
+                            checker.fixString('if (true) {' + scenario.statement + '}').output,
+                            'if (true) {\n\n' + scenario.statement + '}'
+                        );
+                    } else {
+                        assert.equal(
+                            checker.fixString('if (true) {' + scenario.statement + '}').output,
+                            'if (true) {\n\n' + scenario.statement + '\n\n}'
+                        );
+                    }
                 });
             });
         });


### PR DESCRIPTION
Took a try to address this issue. Reviewers please take note that I did a fair amount of refactoring in the Test Suite to attempt to reuse test code and make the test more consistent throughout the various options that will be supported during configuration. I can always revert to the old way of testing hard code the individual tests for each supported option if that is the preferred practice.