### PR TITLE
(require|disallow)SpaceAfterObjectKeys: support computed properties

### DIFF
--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -139,6 +139,9 @@ module.exports.prototype = {
                 }
 
                 var keyToken = file.getFirstNodeToken(property.key);
+                if (property.computed === true) {
+                    keyToken = file.getNextToken(keyToken);
+                }
                 if (exceptAligned) {
                     maxKeyEndPos = Math.max(maxKeyEndPos, keyToken.loc.end.column);
                 }

--- a/lib/rules/require-space-after-object-keys.js
+++ b/lib/rules/require-space-after-object-keys.js
@@ -46,6 +46,11 @@ module.exports.prototype = {
                 }
 
                 var token = file.getFirstNodeToken(property.key);
+
+                if (property.computed === true) {
+                    token = file.getNextToken(token);
+                }
+
                 errors.assert.whitespaceBetween({
                     token: token,
                     nextToken: file.getNextToken(token),

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -39,6 +39,29 @@ describe('rules/disallow-space-after-object-keys', function() {
             assert(checker.checkString('var x = {a, b};').isEmpty());
         });
 
+        it('should not report if no space after computed property names #1406', function() {
+            checker.configure({ esnext: true });
+            assert(
+                checker.checkString([
+                    'var myObject = {',
+                      '[myKey]: "myKeyValue",',
+                      '[otherKey]: "myOtherValue"',
+                    '};'
+                ].join('\n')).isEmpty()
+            );
+        });
+
+        it('should report if space after computed property names #1406', function() {
+            checker.configure({ esnext: true });
+            assert(
+                checker.checkString([
+                    'var myObject = {',
+                      '[myKey] : "myKeyValue"',
+                    '};'
+                ].join('\n')).getErrorCount() === 1
+            );
+        });
+
         it('should report mixed shorthand and normal object propertis', function() {
             checker.configure({ esnext: true });
             assert.equal(checker.checkString('var x = { a : 1, b };').getErrorCount(), 1);

--- a/test/specs/rules/require-space-after-object-keys.js
+++ b/test/specs/rules/require-space-after-object-keys.js
@@ -47,6 +47,28 @@ describe('rules/require-space-after-object-keys', function() {
         it('should not report es6-methods with a space. #1013', function() {
             assert(checker.checkString('var x = { a () { } };').isEmpty());
         });
+
+        it('should report if no space after computed property names #1406', function() {
+            assert(
+                checker.checkString([
+                    'var myObject = {',
+                      '[myKey]: "myKeyValue"',
+                    '};'
+                ].join('\n')).getErrorCount() === 1
+            );
+        });
+
+        it('should not report if space after computed property names #1406', function() {
+            assert(
+                checker.checkString([
+                    'var myObject = {',
+                      '[myKey] : "myKeyValue",',
+                      '[otherKey] : "myOtherValue"',
+                    '};'
+                ].join('\n')).isEmpty()
+            );
+        });
+
     });
 
 });


### PR DESCRIPTION
Fixes #1406 

Same change as #1407 