### PR TITLE
Fix documentation of 'disallowPaddingNewLinesInObjects' to reflect the currently implemented behaviour.

### DIFF
--- a/lib/rules/disallow-padding-newlines-in-objects.js
+++ b/lib/rules/disallow-padding-newlines-in-objects.js
@@ -1,5 +1,5 @@
 /**
- * Disallows newline inside curly braces of all objects.
+ * Disallows newlines adjacent to curly braces in all object literals.
  *
  * Type: `Boolean`
  *
@@ -15,6 +15,16 @@
  *
  * ```js
  * var x = { a: 1 };
+ * var y = { a: 1,
+ *           b: 2 };
+ * var z = { a: 2,
+ *           b: 2,
+ *
+ *           c: 3,
+ *
+ *
+ *
+ *           d: 4 };
  * foo({a: {b: 1}});
  * ```
  *


### PR DESCRIPTION
Presumably fixes #1487