### PR TITLE
disallowSpacesInCallExpression: Extend rule to newExpression

### DIFF
--- a/lib/rules/disallow-spaces-in-call-expression.js
+++ b/lib/rules/disallow-spaces-in-call-expression.js
@@ -41,9 +41,14 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        file.iterateNodesByType('CallExpression', function(node) {
+        file.iterateNodesByType(['CallExpression', 'NewExpression'], function(node) {
+
             var lastCalleeToken = file.getLastNodeToken(node.callee);
             var roundBraceToken = file.findNextToken(lastCalleeToken, 'Punctuator', '(');
+
+            if (node.type === 'NewExpression' && roundBraceToken === undefined) {
+                return;
+            }
 
             errors.assert.noWhitespaceBetween({
                 token: file.getPrevToken(roundBraceToken),

--- a/test/specs/rules/disallow-spaces-in-call-expression.js
+++ b/test/specs/rules/disallow-spaces-in-call-expression.js
@@ -21,6 +21,17 @@ describe('rules/disallow-spaces-in-call-expression', function() {
         assert(checker.checkString('var x = function (){}();').isEmpty());
     });
 
+    it('should not report missing space before round brace in NewExpression', function() {
+        assert(checker.checkString('var x = new foobar();').isEmpty());
+        assert(checker.checkString('var x = new foo.bar();').isEmpty());
+        assert(checker.checkString('var x = new foo. bar();').isEmpty());
+        assert(checker.checkString('var x = new (foo .bar)();').isEmpty());
+        assert(checker.checkString('var x = new (function (){})();').isEmpty());
+        assert(checker.checkString('var x = new (function (){foobar();})();').isEmpty());
+        assert(checker.checkString('new (function(){ foobar(); })();').isEmpty());
+        assert(checker.checkString('var x = new function (){}();').isEmpty());
+    });
+
     it('should report space before round brace in CallExpression', function() {
         assert(checker.checkString('var x = foobar ();').getErrorCount() === 1);
         assert(checker.checkString('var x = foo.bar ();').getErrorCount() === 1);
@@ -31,4 +42,27 @@ describe('rules/disallow-spaces-in-call-expression', function() {
         assert(checker.checkString('(function(){foobar ();}) ();').getErrorCount() === 2);
         assert(checker.checkString('var x = function (){} ();').getErrorCount() === 1);
     });
+
+    it('should report space before round brace in NewExpression', function() {
+        assert(checker.checkString('var x = new foobar ();').getErrorCount() === 1);
+        assert(checker.checkString('var x = new foo.bar ();').getErrorCount() === 1);
+        assert(checker.checkString('var x = new foo. bar ();').getErrorCount() === 1);
+        assert(checker.checkString('var x = new (foor .bar) ();').getErrorCount() === 1);
+        assert(checker.checkString('var x = new (function(){}) ();').getErrorCount() === 1);
+        assert(checker.checkString('var x = new (function(){new foobar ();}) ();').getErrorCount() === 2);
+        assert(checker.checkString('new (function(){new foobar ();}) ();').getErrorCount() === 2);
+        assert(checker.checkString('var x = new function (){} ();').getErrorCount() === 1);
+    });
+
+    it('should ignore NewExpression without parentheses', function() {
+        assert(checker.checkString('var x = new foobar ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new foo.bar ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new foo. bar ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new (foor .bar) ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new (function(){}) ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new (function(){new foobar ;}) ;').getErrorCount() === 0);
+        assert(checker.checkString('new (function(){new foobar ;}) ;').getErrorCount() === 0);
+        assert(checker.checkString('var x = new function (){} ;').getErrorCount() === 0);
+    });
+
 });


### PR DESCRIPTION
Fixes #898  
New Expressions are also subjected to this rule, if it is enabled.  
It does not raise an error if new is used without any parentheses 
