### PR TITLE
maximumLineLength: Add exception for long require expressions

### DIFF
--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -13,6 +13,7 @@
  *        - `comments`: allows comments to break the rule
  *        - `urlComments`: allows comments with long urls to break the rule
  *        - `functionSignature`: allows function definitions to break the rule
+ *        - `require`: allows require expressions to break the rule
  *     - `allowRegex`: *deprecated* use `allExcept: ["regex"]` instead
  *     - `allowComments`: *deprecated* use `allExcept: ["comments"]` instead
  *     - `allowUrlComments`: *deprecated* use `allExcept: ["urlComments"]` instead
@@ -49,6 +50,7 @@ module.exports.prototype = {
         this._allowRegex = false;
         this._allowComments = false;
         this._allowUrlComments = false;
+        this._allowRequire = false;
 
         if (typeof maximumLineLength === 'object') {
             assert(
@@ -68,6 +70,7 @@ module.exports.prototype = {
             this._allowComments = (exceptions.indexOf('comments') !== -1);
             this._allowUrlComments = (exceptions.indexOf('urlComments') !== -1);
             this._allowFunctionSignature = (exceptions.indexOf('functionSignature') !== -1);
+            this._allowRequire = (exceptions.indexOf('require') !== -1);
 
             if (maximumLineLength.hasOwnProperty('allowRegex')) {
                 this._allowRegex = (maximumLineLength.allowRegex === true);
@@ -148,6 +151,16 @@ module.exports.prototype = {
             functionDeclarationLocs.forEach(function(loc) {
                 for (var i = loc.start.line; i <= loc.end.line; i++) {
                     lines[i - 1] = '';
+                }
+            });
+        }
+
+        if (this._allowRequire) {
+            file.iterateNodesByType('CallExpression', function(node) {
+                if (node.callee.name === 'require') {
+                    for (var i = node.loc.start.line; i <= node.loc.end.line; i++) {
+                        lines[i - 1] = '';
+                    }
                 }
             });
         }

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -218,7 +218,17 @@ describe('rules/maximum-line-length', function() {
         });
         it('should report require used as a variable', function() {
             var code = 'var require = "foobar"';
-            assert(checker.checkString(code).getErrorCount() === 1);
+            assert.equal(checker.checkString(code).getErrorCount(), 1);
+        });
+        it('should report require if the exception is disabled', function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                maximumLineLength: 15
+            });
+
+            var code = 'var foo = require("foo");';
+            assert.equal(checker.checkString(code).getErrorCount(), 1);
         });
     });
 });

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -191,4 +191,34 @@ describe('rules/maximum-line-length', function() {
             assert(checker.checkString(code).getErrorCount() === 1);
         });
     });
+
+    describe('allExcept["require"] option', function() {
+        beforeEach(function() {
+            checker.configure({
+                maximumLineLength: {
+                    value: 15,
+                    allExcept: ['require']
+                }
+            });
+        });
+
+        it('should not report require invocation', function() {
+            var code = 'var foo = require("foo");' +
+                       'var bar = require("bar");';
+            assert(checker.checkString(code).isEmpty());
+        });
+        it('should not report single-var require invocation', function() {
+            var code = 'var foo = require("foo")\n' +
+                       '  , bar = require("bar");';
+            assert(checker.checkString(code).isEmpty());
+        });
+        it('should not report require line shorter than minimum', function() {
+            var code = 'require("a");';
+            assert(checker.checkString(code).isEmpty());
+        });
+        it('should report require used as a variable', function() {
+            var code = 'var require = "foobar"';
+            assert(checker.checkString(code).getErrorCount() === 1);
+        });
+    });
 });


### PR DESCRIPTION
Some of our longer `require` expressions break our 80 character line limit. We'd like to keep this limit enforced everywhere, except on the lines that `require` modules.

This pull request adds an option to the `maximumLineLength` rule, in the `allExcept` array, with name `require`. If added, any line with a `require` call expression is ignored when checking for line-length violations.