### PR TITLE
requireArrowFunctions: only error for callbacks

### DIFF
--- a/lib/rules/require-arrow-functions.js
+++ b/lib/rules/require-arrow-functions.js
@@ -1,5 +1,5 @@
 /**
- * Requires that arrow functions are used instead of anonymous function expressions.
+ * Requires that arrow functions are used instead of anonymous function expressions in callbacks.
  *
  * Type: `Boolean`
  *
@@ -28,6 +28,12 @@
  * var x = { bar() {} }
  * // class method
  * class Foo { bar() {} }
+ * // function expression in a return statement
+ * function a(x) {
+ *     return function(x) { return x };
+ * };
+ * // function expression in a variable declaration
+ * var a = function(x) { return x };
  * ```
  *
  * ##### Invalid
@@ -37,12 +43,6 @@
  * [1, 2, 3].map(function (x) {
  *     return x * x;
  * });
- * // function expression in a return statement
- * function a(x) {
- *     return function(x) { return x };
- * };
- * // function expression in a variable declaration
- * var a = function(x) { return x };
  * ```
  */
 
@@ -64,25 +64,11 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType(['FunctionExpression'], function(node) {
-            var parent = node.parentNode;
-            if (parent && (
-                // exception for object shorthand methods
-                parent.method === true ||
-                // exception for getter
-                parent.kind === 'get' ||
-                // exception for setter
-                parent.kind === 'set' ||
-                // exception for class methods
-                parent.type === 'MethodDefinition' ||
-                // don't error due to possible use of 'this' #1413
-                parent.type === 'AssignmentExpression' ||
-                // don't error due to possible use of 'this' #1413
-                parent.type === 'Property')
-            ) {
-                return;
+            // only check call expressions
+            // due to issues with this in other cases
+            if (node.parentNode.type === 'CallExpression') {
+                errors.add('Use arrow functions instead of function expressions', node.loc.start);
             }
-
-            errors.add('Use arrow functions instead of function expressions', node.loc.start);
         });
     }
 };

--- a/test/specs/rules/require-arrow-functions.js
+++ b/test/specs/rules/require-arrow-functions.js
@@ -34,8 +34,8 @@ describe('rules/require-arrow-functions', function() {
         ].join('\n')).getErrorCount() === 1);
     });
 
-    it('should report use of function expression in a ReturnStatement', function() {
-        assert(checker.checkString('function a() { return function() {} }').getErrorCount() === 1);
+    it('should not report use of function expression in a ReturnStatement', function() {
+        assert(checker.checkString('function a() { return function() {} }').isEmpty());
     });
 
     it('should not report use of object property function expression #1413', function() {


### PR DESCRIPTION
Fixes #1483 

This ok - only checks callbacks since we can't be sure otherwise without a lot of other checks?