### PR TITLE
Reporters: add new summary reporter

### DIFF
--- a/bin/jscs
+++ b/bin/jscs
@@ -25,7 +25,8 @@ program
     .option('-v, --verbose', 'adds rule names to the error output')
     .option('-m, --max-errors <number>', 'maximum number of errors to report')
     .option('-f, --error-filter <path>', 'a module to filter errors')
-    .option('-r, --reporter <reporter>', 'error reporter, console - default, text, checkstyle, junit, inline, unix')
+    .option('-r, --reporter <reporter>',
+        'error reporter, console - default, text, checkstyle, junit, inline, unix, summary')
     .option('', 'Also accepts relative or absolute path to custom reporter')
     .option('', 'For instance:')
     .option('', '\t  ../some-dir/my-reporter.js\t(relative path with extension)')

--- a/lib/reporters/summary.js
+++ b/lib/reporters/summary.js
@@ -1,0 +1,77 @@
+var errorsByFileTable;
+var errorsByRuleTable;
+
+/**
+ * @param {Errors[]} errorsCollection
+ */
+module.exports = function(errorsCollection) {
+    var Table = require('cli-table');
+
+    var hasError = false;
+    var errorsByRule = {};
+    var style = {
+                'padding-left': 0,
+                'padding-right': 0,
+                'head': ['yellow'],
+                'border': ['green'],
+                'compact': false
+            };
+
+    errorsByFileTable = new Table({
+            'head': ['Path', 'Errors'],
+            'colAligns': [
+                'middle',
+                'middle',
+                'middle'
+            ],
+            'colWidths': [71, 6],
+            'style': style
+        });
+
+    errorsByRuleTable = new Table({
+            'head': ['Rule', 'Errors', 'No of Files'],
+            'colAligns': [
+                'middle',
+                'middle',
+                'middle'
+            ],
+            'colWidths': [59, 6, 11],
+            'style': style
+        });
+
+    errorsCollection.forEach(function(errors) {
+        var fileName = errors.getFilename();
+        if (!errors.isEmpty()) {
+            hasError = true;
+            errorsByFileTable.push([fileName, errors.getErrorCount()]);
+            errors.getErrorList().forEach(function(error) {
+                if (error.rule in errorsByRule) {
+                    errorsByRule[error.rule] .count += 1;
+                } else {
+                    errorsByRule[error.rule] = {
+                        count: 1,
+                        files: {}
+                    };
+                }
+                errorsByRule[error.rule].files[fileName] = 1;
+            });
+        }
+    });
+
+    var totalErrors = 0;
+    var totalFilesWithErrors = 0;
+    Object.getOwnPropertyNames(errorsByRule).forEach(function(ruleName) {
+        var fileCount = Object.getOwnPropertyNames(errorsByRule[ruleName].files).length;
+        errorsByRuleTable.push([ruleName, errorsByRule[ruleName].count, fileCount]);
+        totalErrors += errorsByRule[ruleName].count;
+        totalFilesWithErrors += fileCount;
+    });
+    errorsByRuleTable.push(['All', totalErrors, totalFilesWithErrors]);
+
+    if (hasError === false) {
+        console.log('No code style errors found.');
+    } else {
+        console.log(errorsByFileTable.toString());
+        console.log(errorsByRuleTable.toString());
+    }
+};

--- a/test/specs/reporters/summary.js
+++ b/test/specs/reporters/summary.js
@@ -1,0 +1,110 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var rewire = require('rewire');
+
+var Checker = require('../../../lib/checker');
+var summaryReporter = rewire('../../../lib/reporters/summary');
+
+describe('reporters/summary', function() {
+    var checker;
+
+    var scenarios = [
+        {
+            statement: 'with (x) {}',
+            results: {
+                byFile: {
+                    file: 'input',
+                    totalError: 1
+                },
+                byRule: [
+                    {
+                        name: 'disallowKeywords',
+                        totalError: 1,
+                        fileError: 1
+                    },
+                    {
+                        name: 'All',
+                        totalError: 1,
+                        fileError: 1
+                    }
+                ]
+            }
+        },
+        {
+            statement: 'with(x){} with(x){}',
+            results: {
+                byFile: {
+                    file: 'input',
+                    totalError: 2
+                },
+                byRule: [
+                    {
+                        name: 'disallowKeywords',
+                        totalError: 2,
+                        fileError: 1
+                    },
+                    {
+                        name: 'All',
+                        totalError: 2,
+                        fileError: 1
+                    }
+                ]
+            }
+        }
+    ];
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('valid code syntax', function() {
+        it('should correctly reports no errors', function() {
+            checker.configure({ disallowKeywords: ['with'] });
+            sinon.stub(console, 'log');
+            summaryReporter([checker.checkString('a++;')]);
+            assert.equal(console.log.getCall(0).args[0], 'No code style errors found.');
+            assert(console.log.calledOnce);
+            console.log.restore();
+        });
+    });
+
+    describe('invalid code syntax', function() {
+        scenarios.forEach(function(scenario) {
+            describe(JSON.stringify(scenario.statement), function() {
+                beforeEach(function() {
+                    checker.configure({ disallowKeywords: ['with'] });
+                    sinon.stub(console, 'log');
+                    summaryReporter([checker.checkString(scenario.statement)]);
+                });
+
+                afterEach(function() {
+                    console.log.restore();
+                });
+
+                it('should make 2 console.log calls', function() {
+                    assert.equal(console.log.callCount, 2);
+                });
+
+                it('should correctly report the number of errors by file name', function() {
+                    var actualError = summaryReporter.__get__('errorsByFileTable')[0];
+                    var expectedError = scenario.results.byFile;
+                    assert.strictEqual(actualError[0], expectedError.file);
+                    assert.strictEqual(actualError[1], expectedError.totalError);
+                });
+
+                it('should correctly report the number of errors by rule name', function() {
+                    var actualErrors = summaryReporter.__get__('errorsByRuleTable');
+                    var expectedErrors = scenario.results.byRule;
+
+                    assert.strictEqual(actualErrors.length, expectedErrors.length);
+                    for (var i = 0; i < actualErrors.length; i++) {
+                        assert.strictEqual(actualErrors[i][0], expectedErrors[i].name);
+                        assert.strictEqual(actualErrors[i][1], expectedErrors[i].totalError);
+                        assert.strictEqual(actualErrors[i][2], expectedErrors[i].fileError);
+                    }
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This reporter provides a summary of all files with errors found listing each filename against the error count. The following shows a sample of the output
    file.js: 1 error found.
    file2.js: 2 errors found.

Fixes #1047