### PR TITLE
yodaConditions: allow literals on the left side of comparison operators (<, >, <=, >=)

### DIFF
--- a/lib/rules/disallow-yoda-conditions.js
+++ b/lib/rules/disallow-yoda-conditions.js
@@ -43,11 +43,7 @@ module.exports.prototype = {
             '==': true,
             '===': true,
             '!=': true,
-            '!==': true,
-            '>': true,
-            '<': true,
-            '>=': true,
-            '<=': true
+            '!==': true
         };
     },
 


### PR DESCRIPTION
There are a number of reasons for disallowing `LITERAL === VARIABLE`
in code, however there is no similar reason to disallow `LITERAL <
VARIABLE` and, especially for array bounds or other limit checks, the version where the
constant (generally 0) comes first is more readable.

example code (which caused this pull request in the first place):

    if (0 <= index) {
      ...
    }
