### PR TITLE
(require|disallow)AnonymousFunctionExpression: account for shorthand …

### DIFF
--- a/lib/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -82,11 +82,17 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var functionNode = node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
             if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
                 return;
+            }
+
+            // if shorthand method
+            if (parent.method) {
+                functionNode = parent.key;
             }
 
             // anonymous function expressions only
@@ -95,7 +101,7 @@ module.exports.prototype = {
             }
 
             if (beforeOpeningRoundBrace) {
-                var functionToken = file.getFirstNodeToken(node);
+                var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.noWhitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/lib/rules/require-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/require-spaces-in-anonymous-function-expression.js
@@ -82,6 +82,7 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var functionNode = node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
@@ -89,25 +90,33 @@ module.exports.prototype = {
                 return;
             }
 
-            if (!node.id) {
+            // if shorthand method
+            if (parent.method) {
+                functionNode = parent.key;
+            }
 
-                if (beforeOpeningRoundBrace) {
-                    var functionToken = file.getFirstNodeToken(node);
-                    errors.assert.whitespaceBetween({
-                        token: functionToken,
-                        nextToken: file.getNextToken(functionToken),
-                        message: 'Missing space before opening round brace'
-                    });
-                }
+            // anonymous function expressions only
+            if (node.id) {
+                return;
+            }
 
-                if (beforeOpeningCurlyBrace) {
-                    var bodyToken = file.getFirstNodeToken(node.body);
-                    errors.assert.whitespaceBetween({
-                        token: file.getPrevToken(bodyToken),
-                        nextToken: bodyToken,
-                        message: 'Missing space before opening curly brace'
-                    });
-                }
+            if (beforeOpeningRoundBrace) {
+                var functionToken = file.getFirstNodeToken(functionNode);
+
+                errors.assert.whitespaceBetween({
+                    token: functionToken,
+                    nextToken: file.getNextToken(functionToken),
+                    message: 'Missing space before opening round brace'
+                });
+            }
+
+            if (beforeOpeningCurlyBrace) {
+                var bodyToken = file.getFirstNodeToken(node.body);
+                errors.assert.whitespaceBetween({
+                    token: file.getPrevToken(bodyToken),
+                    nextToken: bodyToken,
+                    message: 'Missing space before opening curly brace'
+                });
             }
         });
     }

--- a/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before round brace in FunctionExpression', function() {
@@ -54,11 +60,32 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
             checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
         });
+
+        reportAndFix({
+            name: 'illegal space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function (){}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'illegal space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y (){} }',
+            output: 'var x = { y(){} }'
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before curly brace in FunctionExpression', function() {
@@ -101,6 +128,22 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
         it('should report space before curly brace in method shorthand', function() {
             checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
+        reportAndFix({
+            name: 'illegal space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function() {}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'illegal space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y() {} }',
+            output: 'var x = { y(){} }'
         });
     });
 });

--- a/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -44,6 +44,16 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
             assert(errors.getErrorCount() === 1);
             assert(error.column === 16);
         });
+
+        it('should not report missing space before round brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y() {} }').isEmpty());
+        });
+
+        it('should report space before round brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -81,6 +91,16 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y(){} }').isEmpty());
+        });
+
+        it('should report space before curly brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/require-spaces-in-anonymous-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-spaces-in-anonymous-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before round brace in FunctionExpression', function() {
@@ -19,6 +25,10 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
 
         it('should not report space before round brace in FunctionExpression', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
+        });
+
+        it('should not report named FunctionExpression', function() {
+            assert(checker.checkString('var x = function test() {}').isEmpty());
         });
 
         it('should not report space before round brace in getter expression', function() {
@@ -46,11 +56,32 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
             checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').isEmpty());
         });
+
+        reportAndFix({
+            name: 'missing space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function (){}'
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y (){} }'
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInAnonymousFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before curly brace in FunctionExpression', function() {
@@ -89,6 +120,22 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
         it('should not report space before curly brace in method shorthand', function() {
             checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function() {}'
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y() {} }'
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/require-spaces-in-anonymous-function-expression.js
@@ -37,6 +37,15 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
 
+        it('should report missing space before round brace in method shorthand #1470', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y() {} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before round brace in method shorthand #1470', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
@@ -70,6 +79,16 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function() {}').isEmpty());
+        });
+
+        it('should report missing space before curly brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y(){} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in method shorthand', function() {
+            checker.configure({ esnext: true });
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
         });
     });
 });


### PR DESCRIPTION
…methods

Fixes #1470 

I think I still need to do this for the other types and other relevant rules. (Can just add to this PR)