### PR TITLE
Misc: set default value of maxErrors option to 50

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -226,7 +226,7 @@ Set the maximum number of errors to report
 
 Type: `Number`
 
-Default: Infinity
+Default: 50
 
 #### Example
 

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -111,7 +111,7 @@ function Configuration() {
      * @protected
      * @type {Number}
      */
-    this._maxErrors = Infinity;
+    this._maxErrors = 50;
 
     /**
      * JSCS CWD.
@@ -567,8 +567,8 @@ Configuration.prototype._loadMaxError = function(maxErrors) {
     maxErrors = maxErrors === null ? null : Number(maxErrors);
 
     assert(
-        maxErrors > 0 || isNaN(maxErrors) || maxErrors === null,
-        '`maxErrors` option requires number or null value'
+        maxErrors > 0 || maxErrors === null,
+        '`maxErrors` option requires positive number or null value'
     );
     this._maxErrors = maxErrors;
 };

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -248,10 +248,6 @@ StringChecker.prototype = {
      * @returns {{output: String, errors: Errors}}
      */
     fixString: function(source, filename) {
-        if (this._maxErrorsEnabled()) {
-            throw new Error('Cannot autofix when `maxError` option is enabled');
-        }
-
         filename = filename || 'input';
 
         var file = this._createJsFileInstance(filename, source);
@@ -300,7 +296,7 @@ StringChecker.prototype = {
      * @returns {Boolean}
      */
     _maxErrorsEnabled: function() {
-        return !isNaN(this._maxErrors) && this._maxErrors !== Infinity;
+        return this._maxErrors !== null;
     },
 
     /**

--- a/test/specs/checker.js
+++ b/test/specs/checker.js
@@ -3,7 +3,7 @@ var sinon = require('sinon');
 var Checker = require('../../lib/checker');
 var fs = require('fs');
 
-describe('modules/checker', function() {
+describe('checker', function() {
     var checker;
 
     beforeEach(function() {

--- a/test/specs/cli-config.js
+++ b/test/specs/cli-config.js
@@ -5,7 +5,7 @@ var rewire = require('rewire');
 
 var configFile = rewire('../../lib/cli-config');
 
-describe('modules/cli-config', function() {
+describe('cli-config', function() {
     describe('load method', function() {
         it('should load a config from a package.json file', function() {
             var config = configFile.load('package.json', './test/data/configs/package');

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -14,7 +14,7 @@ var startingDir = process.cwd();
 
 var Vow = require('vow');
 
-describe('modules/cli', function() {
+describe('cli', function() {
     var oldTTY;
 
     before(function() {
@@ -567,10 +567,12 @@ describe('modules/cli', function() {
     describe('maxErrors option', function() {
         beforeEach(function() {
             sinon.spy(console, 'log');
+            sinon.spy(console, 'error');
         });
 
         afterEach(function() {
             console.log.restore();
+            console.error.restore();
         });
 
         it('should limit the number of errors reported to the provided amount', function() {
@@ -585,14 +587,15 @@ describe('modules/cli', function() {
             });
         });
 
-        it('should not limit the number of errors reported if non numeric value provided', function() {
+        it('should throw a error when value is incorrect', function() {
             return cli({
                 maxErrors: '1a',
                 args: ['test/data/cli/error.js'],
                 config: 'test/data/cli/maxErrors.json'
             })
             .promise.always(function() {
-                assert(console.log.getCall(2).args[0].indexOf('2 code style errors found.') !== -1);
+                assert(console.error.getCall(0).args[0]
+                    .indexOf('`maxErrors` option requires positive number or null value') !== -1);
                 rAfter();
             });
         });

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 var Configuration = require('../../../lib/config/configuration');
 
-describe('modules/config/configuration', function() {
+describe('config/configuration', function() {
 
     var configuration;
     beforeEach(function() {
@@ -35,8 +35,8 @@ describe('modules/config/configuration', function() {
             assert(configuration.getExcludedFileMasks().length === 0);
         });
 
-        it('should have no default maximal error count', function() {
-            assert(configuration.getMaxErrors() === Infinity);
+        it('should have 50 default error count', function() {
+            assert(configuration.getMaxErrors() === 50);
         });
 
         it('should have no default preset', function() {

--- a/test/specs/errors.js
+++ b/test/specs/errors.js
@@ -1,7 +1,7 @@
 var Checker = require('../../lib/checker');
 var assert = require('assert');
 
-describe('modules/errors', function() {
+describe('errors', function() {
     var checker;
 
     beforeEach(function() {

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -6,7 +6,7 @@ var sinon = require('sinon');
 var fs = require('fs');
 var assign = require('lodash.assign');
 
-describe('modules/js-file', function() {
+describe('js-file', function() {
 
     function createJsFile(sources, options) {
         var params = {

--- a/test/specs/rules/validate-indentation.js
+++ b/test/specs/rules/validate-indentation.js
@@ -57,7 +57,7 @@ describe('rules/validate-indentation', function() {
 
     it('should validate 2 spaces indentation properly', function() {
         var fixture = readData('validate-indentation/check.js');
-        checker.configure({ validateIndentation: 2 });
+        checker.configure({ validateIndentation: 2, maxErrors: Infinity });
         checkErrors(fixture, [
             5,
             6,

--- a/test/specs/string-checker.js
+++ b/test/specs/string-checker.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 var fs = require('fs');
 
-describe('modules/string-checker', function() {
+describe('string-checker', function() {
     var checker;
     beforeEach(function() {
         checker = new StringChecker();
@@ -86,11 +86,11 @@ describe('modules/string-checker', function() {
                 assert(errors2.length === 0);
             });
 
-            it('should not be used when not a number', function() {
+            it('should not be used when it is nullified', function() {
                 var errors;
                 checker.configure({
                     requireSpaceBeforeBinaryOperators: ['='],
-                    maxErrors: NaN
+                    maxErrors: null
                 });
 
                 errors = checker.checkString('var foo=1;\n var bar=2;').getErrorList();

--- a/test/specs/token-assert.js
+++ b/test/specs/token-assert.js
@@ -4,7 +4,7 @@ var esprima = require('esprima');
 var JsFile = require('../../lib/js-file');
 var TokenAssert = require('../../lib/token-assert');
 
-describe('modules/token-assert', function() {
+describe('token-assert', function() {
 
     function createJsFile(sources) {
         return new JsFile({

--- a/test/specs/tree-iterator.js
+++ b/test/specs/tree-iterator.js
@@ -3,7 +3,7 @@ var esprima = require('esprima');
 var sinon = require('sinon');
 var iterate = require('../../lib/tree-iterator').iterate;
 
-describe('modules/tree-iterator', function() {
+describe('tree-iterator', function() {
 
     it('should pass parent and parentCollection', function() {
         var spy = sinon.spy();

--- a/test/specs/utils.js
+++ b/test/specs/utils.js
@@ -4,7 +4,7 @@ var JsFile = require('../../lib/js-file');
 var esprima = require('esprima');
 var path = require('path');
 
-describe('modules/utils', function() {
+describe('utils', function() {
 
     function createJsFile(source) {
         return new JsFile({


### PR DESCRIPTION
* Set default value of maxErrors option to 50
* Do not consider maxErrors value at autofix execution
* Rename testsuites of root modules
  (since they should point to the path of module their testing)

Fixes #681

/cc @mikesherov @mdevils 