### PR TITLE
add support for babel-jscs

### DIFF
--- a/lib/tree-iterator.js
+++ b/lib/tree-iterator.js
@@ -1,4 +1,7 @@
 var estraverse = require('estraverse');
+var assign     = require('lodash.assign');
+var types      = require('babel-core').types;
+assign(estraverse.VisitorKeys, types.VISITOR_KEYS);
 
 module.exports = {
     iterate: iterate

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "babel-jscs": "^1.0.1",
+    "babel-core": "^5.6.15",
+    "babel-jscs": "jscs-dev/babel-jscs#remove-monkeypatch",
     "chalk": "~1.0.0",
     "cli-table": "~0.3.1",
     "commander": "~2.8.1",


### PR DESCRIPTION
monkeypatch (specifically use of Module._resolveFilename) fails
on linux without symlink

removed monkeypatch method on babel-jscs and moved patching estraverse
to jscs itself.

Ref #1446

Pinning babel-jscs to PR to make it pass.