### PR TITLE
disallowKeywordsOnNewLine: Allow comments before keywords

### DIFF
--- a/lib/rules/disallow-keywords-on-new-line.js
+++ b/lib/rules/disallow-keywords-on-new-line.js
@@ -20,6 +20,38 @@
  *     x--;
  * }
  * ```
+ * ```js
+ * if (x < 0)
+ *     x++;
+ * else
+  *     x--;
+ * ```
+ * ```js
+ * if (x < 0) {
+ *     x++;
+ * }
+ * // comments
+ * else {
+ *     x--;
+ * }
+ * ```
+ * ```js
+ * do {
+ *     x++;
+ * } while(x < 0);
+ * ```
+ * ```js
+ * do
+ *     x++;
+ * while(x < 0);
+ * ```
+  * ```js
+ * do {
+ *     x++;
+ * }
+ * // comments
+ * while(x < 0);
+ * ```
  *
  * ##### Invalid
  *
@@ -34,6 +66,11 @@
  */
 
 var assert = require('assert');
+
+function isPreviousTokenAComment(token, file) {
+    var prevToken = file.getPrevToken(token, {includeComments: true});
+    return (prevToken.type === 'Line' || prevToken.type === 'Block');
+}
 
 module.exports = function() {};
 
@@ -52,10 +89,17 @@ module.exports.prototype = {
         file.iterateTokensByTypeAndValue('Keyword', this._keywords, function(token) {
             var prevToken = file.getPrevToken(token);
 
-            // Special case for #905, even though it contradicts rule meaning,
-            // it makes more sense that way.
-            if (token.value === 'else' && prevToken.value !== '}') {
-                return;
+            if (token.value === 'else') {
+                if (prevToken.value !== '}') {
+                    // Special case for #905, even though it contradicts rule meaning,
+                    // it makes more sense that way.
+                    return;
+                }
+
+                if (isPreviousTokenAComment(token, file)) {
+                    // Special case for #1421, to handle comments before the else
+                    return;
+                }
             }
 
             // Special cases for #885, using while as the keyword contradicts rule meaning
@@ -67,6 +111,11 @@ module.exports.prototype = {
                     // "while" that is part of a do will not return nodes as it is not a start token
                     if (prevToken.value !== '}') {
                         // allow "while" that is part of a "do while" with no braces to succeed
+                        return;
+                    }
+
+                    if (isPreviousTokenAComment(token, file)) {
+                        // Special case for #1421, to handle comments before the "while" of a "do while"
                         return;
                     }
                 } else {

--- a/test/specs/rules/disallow-keywords-on-new-line.js
+++ b/test/specs/rules/disallow-keywords-on-new-line.js
@@ -130,6 +130,68 @@ describe('rules/disallow-keywords-on-new-line', function() {
         );
     });
 
+    describe('legal block comments before key word (#1421)', function() {
+        it('should not report legal keyword placement for a "if else"',
+            function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['else'] });
+            assert(
+                checker.checkString(
+                    'if (x) {\n' +
+                        'x++;\n' +
+                    '}\n' +
+                    '/* comments */\n' +
+                    'else {\n' +
+                        'x--;\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report legal keyword for a "do while"', function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+            assert(
+                checker.checkString(
+                    'do {\n' +
+                        'x++;\n' +
+                    '}\n' +
+                    '/* comments */\n' +
+                    'while(x > 0)'
+                ).isEmpty()
+            );
+        });
+    });
+
+    describe('legal line comments before key word (#1421)', function() {
+        it('should not report legal keyword placement for a "if else"',
+            function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['else'] });
+            assert(
+                checker.checkString(
+                    'if (x) {\n' +
+                        'x++;\n' +
+                    '}\n' +
+                    '// comments\n' +
+                    'else {\n' +
+                        'x--;\n' +
+                    '}'
+                ).isEmpty()
+            );
+        });
+
+        it('should not report legal keyword for a "do while"', function() {
+            checker.configure({ disallowKeywordsOnNewLine: ['while'] });
+            assert(
+                checker.checkString(
+                    'do {\n' +
+                        'x++;\n' +
+                    '}\n' +
+                    '// comments\n' +
+                    'while(x > 0)'
+                ).isEmpty()
+            );
+        });
+    });
+
     describe('fix', function() {
         it('should not fix special case for "else" statement without braces (#905)', function() {
             checker.configure({ disallowKeywordsOnNewLine: ['else'] });


### PR DESCRIPTION
Allow a special case for the keywords 'else' in 'if else' and 'while' in 'do while' to go on a new line if it is preceded by a comment token

Fixes #1421