### PR TITLE
disallowSpacesInAnonymousFunctionExpression: Remove excess assert

### DIFF
--- a/lib/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -63,12 +63,6 @@ module.exports.prototype = {
             );
         }
 
-        assert(
-            options.beforeOpeningCurlyBrace || options.beforeOpeningRoundBrace,
-            this.getOptionName() + ' must have beforeOpeningCurlyBrace ' +
-            ' or beforeOpeningRoundBrace property'
-        );
-
         this._beforeOpeningRoundBrace = Boolean(options.beforeOpeningRoundBrace);
         this._beforeOpeningCurlyBrace = Boolean(options.beforeOpeningCurlyBrace);
     },


### PR DESCRIPTION
I want to override preset settings, but can't, because of this assert.

Google pereset contain [disallow rule](https://github.com/jscs-dev/node-jscs/blob/master/presets/google.json#L54), and I can't disable `beforeOpeningRoundBrace` rule by removing it (because assert doesn't allow empty rules)