### PR TITLE
New Rule: requireSortedObjectKeys

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -953,6 +953,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-space-before-comma'));
 
     this.registerRule(require('../rules/require-space-before-comma'));
+
+    this.registerRule(require('../rules/validate-order-in-object-keys'));
 };
 
 /**

--- a/lib/rules/validate-order-in-object-keys.js
+++ b/lib/rules/validate-order-in-object-keys.js
@@ -1,0 +1,153 @@
+
+/**
+ * Validates the order in object keys.
+ *
+ * Types: `Boolean` or `String`
+ *
+ * Values:
+ *  - `true` (alias to `asc`)
+ *  - `"asc"`: requires sorting in ascending order
+ *  - `"asc-insensitive"`: requires sorting in ascending order (case-insensitive)
+ *  - `"asc-natural"`: requires sorting in ascending natural order
+ *  - `"desc"`: requires sorting in descending order
+ *  - `"desc-insensitive"`: requires sorting in descending order (case-insensitive)
+ *  - `"desc-natural"`: requires sorting in descending natural order
+ *
+ * #### Example
+ *
+ * ```js
+ * "validateOrderInObjectKeys": "asc"
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var x = {
+ *  x: 'foo',
+ *  y: 'bar'
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var x = {
+ *  y: 'foo',
+ *  x: 'bar'
+ * }
+ * ```
+ */
+
+var assert = require('assert');
+var naturalSort = require('natural-compare');
+
+/**
+ * Sort in ascending order.
+ */
+function asc(a, b) {
+    return String(a) < String(b) ? -1 : 1;
+}
+
+/**
+ * Sort in ascending order (case-insensitive).
+ */
+function ascInsensitive(a, b) {
+    var lowercaseA = String(a).toLowerCase();
+    var lowercaseB = String(b).toLowerCase();
+
+    if (lowercaseA < lowercaseB) {
+        return -1;
+    }
+
+    if (lowercaseA > lowercaseB) {
+        return 1;
+    }
+
+    return asc(a, b);
+}
+
+/**
+ * Natural sort in ascending order.
+ */
+function ascNatural(a, b) {
+    return naturalSort(a, b);
+}
+
+/**
+ * Native sort in descending order.
+ */
+function desc(a, b) {
+    return asc(a, b) * -1;
+}
+
+/**
+ * Sort in descending order (case-insensitive).
+ */
+function descInsensitive(a, b) {
+    return ascInsensitive(a, b) * -1;
+}
+
+/**
+ * Native sort in descending order.
+ */
+function descNatural(a, b) {
+    return naturalSort(a, b) * -1;
+}
+
+/**
+ * Available sort methods.
+ */
+var methods = {
+    asc: asc,
+    'asc-insensitive': ascInsensitive,
+    'asc-natural': ascNatural,
+    desc: desc,
+    'desc-insensitive': descInsensitive,
+    'desc-natural': descNatural
+};
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true || Object.keys(methods).indexOf(options) !== -1,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+
+        this._sort = methods[options] || methods.asc;
+    },
+
+    getOptionName: function() {
+        return 'validateOrderInObjectKeys';
+    },
+
+    check: function(file, errors) {
+        var sort = this._sort;
+
+        file.iterateNodesByType('ObjectExpression', function(node) {
+            var keys = node.properties.map(function(property) {
+                return (property.key.name || property.key.value);
+            });
+
+            var sorted = keys.slice(0).sort(sort);
+            var unsorted;
+
+            for (var i = 0; i < keys.length; i++) {
+                if (keys[i] !== sorted[i]) {
+                    unsorted = i;
+
+                    break;
+                }
+            }
+
+            if (undefined !== unsorted) {
+                errors.add(
+                    'Object keys must be in ' + (/asc/.test(sort.name) ? 'ascending' : 'descending') + ' order',
+                    node.properties[unsorted].loc.start
+                );
+            }
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jscs-jsdoc": "1.1.0",
     "lodash.assign": "~3.2.0",
     "minimatch": "~2.0.1",
+    "natural-compare": "~1.2.2",
     "pathval": "~0.1.1",
     "prompt": "~0.2.14",
     "reserved-words": "^0.1.1",

--- a/test/specs/rules/validate-order-in-object-keys.js
+++ b/test/specs/rules/validate-order-in-object-keys.js
@@ -1,0 +1,193 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/validate-order-in-object-keys', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('should alias option value true to asc', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'asc' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\n_:2,\na:1,\nb:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:1,\nb:3,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:2,\nb:3,\nb_:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nC:3,\nb_:1,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n$:1,\nA:3,\n_:2,\na:4\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n1:1,\n\'11\':2,\n2:4,\nA:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n\'#\':1,\n\'Z\':2,\nÀ:3,\nè:4\n}').isEmpty());
+        });
+    });
+
+    describe('option value asc', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'asc' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\n_:2,\na:1,\nb:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:1,\nb:3,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:2,\nb:3,\nb_:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nC:3,\nb_:1,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n$:1,\nA:3,\n_:2,\na:4\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n1:1,\n\'11\':2,\n2:4,\nA:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n\'#\':1,\n\'Z\':2,\nÀ:3,\nè:4\n}').isEmpty());
+        });
+    });
+
+    describe('option value asc-insensitive', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'asc-insensitive' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\nA:3,\n_:2,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\n_:2,\na:1,\nb:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:1,\nb:3,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:2,\nb:3,\nb_:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nb_:1,\nC:3,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n1:1,\n\'11\':2,\n2:4,\nA:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n\'#\':1,\n\'Z\':2,\nÀ:3,\nè:4\n}').isEmpty());
+        });
+    });
+
+    describe('option value asc-natural', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'asc-natural' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\nA:3,\n_:2,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\n_:2,\na:1,\nb:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:1,\nb:3,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:2,\nb:3,\nb_:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nC:3,\nb_:1,\nc:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\n\'11\':2,\nA:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\n\'#\':1,\n\'Z\':2,\nÀ:3,\nè:4\n}').isEmpty());
+        });
+    });
+
+    describe('option value desc', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'desc' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\nb:3,\na:1,\n_:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nb:3,\na:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nb_:1,\nb:3,\na:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nb_:1,\nC:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:4,\n_:2,\nA:3,\n$:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nA:3,\n2:4,\n\'11\':2,\n1:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nè:4,\nÀ:3,\n\'Z\':2,\n\'#\':1\n}').isEmpty());
+        });
+    });
+
+    describe('option value desc-insensitive', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'desc-insensitive' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\nb:3,\na:1,\n_:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nb:3,\na:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nb_:1,\nb:3,\na:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nC:3,\nb_:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:4,\nA:3,\n_:2,\n$:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nA:3,\n2:4,\n\'11\':2,\n1:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nè:4,\nÀ:3,\n\'Z\':2,\n\'#\':1\n}').isEmpty());
+        });
+    });
+
+    describe('option value desc-natural', function() {
+        beforeEach(function() {
+            checker.configure({ validateOrderInObjectKeys: 'desc-natural' });
+        });
+
+        it('should report unsorted object keys', function() {
+            assert(checker.checkString('var obj = {\na:1,\n_:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\na:1,\nc:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\na:2,\nb:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\nb_:1,\nc:2,\nC:3\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n$:1,\n_:2,\nA:3,\na:4\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n1:1,\n2:4,\nA:3,\n\'11\':2\n}').getErrorCount() === 1);
+            assert(checker.checkString('var obj = {\n\'#\':1,\nÀ:3,\n\'Z\':2,\nè:4\n}').getErrorCount() === 1);
+        });
+
+        it('should not report sorted object keys', function() {
+            assert(checker.checkString('var obj = {\nb:3,\na:1,\n_:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nb:3,\na:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nb_:1,\nb:3,\na:2\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nc:2,\nb_:1,\nC:3\n}').isEmpty());
+            assert(checker.checkString('var obj = {\na:4,\nA:3,\n_:2,\n$:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nA:3,\n\'11\':2,\n2:4,\n1:1\n}').isEmpty());
+            assert(checker.checkString('var obj = {\nè:4,\nÀ:3,\n\'Z\':2,\n\'#\':1\n}').isEmpty());
+        });
+    });
+});


### PR DESCRIPTION
Requires sorted object keys.

Types: `Boolean` or `String`

Values:
  - `true` (alias to `asc`)
  - `"asc"`: requires sorting in ascending order
  - `"desc"`: requires sorting in descending order

#### Example

```js
"requireSortedObjectKeys": "asc"
```

##### Valid

```js
var x = {
  x: 'foo',
  y: 'bar'
}
```

##### Invalid

```js
var x = {
  y: 'foo',
  x: 'bar'
}
```
