### PR TITLE
requirePaddingNewlinesAfterBlocks: arrays act like objects for the last item

### DIFF
--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -46,13 +46,14 @@
  *     func(
  *          function() {
  *          }
- *
  *     );
  *
  *     var a = [
  *         function() {
- *         }
+ *         },
  *
+ *         function() {
+ *         }
  *     ]
  *
  * }
@@ -205,7 +206,10 @@ module.exports.prototype = {
                     continue;
                 }
 
-                if (nextToken.type === 'Punctuator' && nextToken.value === '}') {
+                if (nextToken.type === 'Punctuator' && (
+                    nextToken.value === '}' ||
+                    nextToken.value === ']' ||
+                    nextToken.value === ')')) {
                     return;
                 }
 

--- a/test/data/options/preset/airbnb.js
+++ b/test/data/options/preset/airbnb.js
@@ -309,6 +309,37 @@
         .call(tron.led);
   })();
 
+  // https://github.com/airbnb/javascript#18.6
+  (function() {
+    if (foo) {
+      return bar;
+    }
+
+    return baz;
+  })();
+
+  (function() {
+    const obj = {
+      foo() {
+      },
+
+      bar() {
+      },
+    };
+  })();
+
+  (function() {
+    const arr = [
+      function foo() {
+      },
+
+      function bar() {
+      },
+    ];
+
+    return arr;
+  })();
+
   (function() {
     const story = [
       once,

--- a/test/specs/rules/require-padding-newlines-after-blocks.js
+++ b/test/specs/rules/require-padding-newlines-after-blocks.js
@@ -149,12 +149,12 @@ describe('rules/require-padding-newlines-after-blocks', function() {
             assert(checker.checkString('[].map(function() {})\n.filter(function(){})').isEmpty());
         });
 
-        it('should report missing padding when function is last arguments', function() {
-            assert(checker.checkString('func(\n2,\n3,\nfunction() {\n}\n)').getErrorCount() === 1);
+        it('should not report missing padding when function is last arguments', function() {
+            assert(checker.checkString('func(\n2,\n3,\nfunction() {\n}\n)').isEmpty());
         });
 
-        it('should report missing padding when function is last in array', function() {
-            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').getErrorCount() === 1);
+        it('should not report missing padding when function is last in array', function() {
+            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').isEmpty());
         });
 
         it('should report missing padding when function is middle in array', function() {
@@ -183,8 +183,8 @@ describe('rules/require-padding-newlines-after-blocks', function() {
             assert(checker.checkString('(function() {})\n(1,2,3)').isEmpty());
         });
 
-        it('should report missing padding when function is last in array', function() {
-            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').getErrorCount() === 1);
+        it('should not report missing padding when function is last in array', function() {
+            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').isEmpty());
         });
 
         it('should report missing padding when function is middle in array', function() {
@@ -252,7 +252,7 @@ describe('rules/require-padding-newlines-after-blocks', function() {
             checker.registerDefaultRules();
             checker.configure({ requirePaddingNewLinesAfterBlocks: true });
 
-            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').getErrorCount() === 1);
+            assert(checker.checkString('[\n2,\n3,\nfunction() {\n},\nfunction() {\n}\n]').getErrorCount() === 1);
 
             checker.configure({
                 requirePaddingNewLinesAfterBlocks: {
@@ -260,7 +260,7 @@ describe('rules/require-padding-newlines-after-blocks', function() {
                 }
             });
 
-            assert(checker.checkString('[\n2,\n3,\nfunction() {\n}\n]').isEmpty());
+            assert(checker.checkString('[\n2,\n3,\nfunction() {\n},\nfunction() {\n}\n]').isEmpty());
         });
     });
 });


### PR DESCRIPTION
And added the airbnb check for the section [18.6](https://github.com/airbnb/javascript#18.6)

```js
const arr = [
  function foo() {
  },

  function bar() {
  },
];

return arr;
```