### PR TITLE
validateIndetation: reduce RegExp create count (optimization)

### DIFF
--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -246,7 +246,6 @@ module.exports.prototype = {
         }
 
         function getIndentationFromLine(line) {
-            var rNotIndentChar = new RegExp('[^' + indentChar + ']');
             var firstContent = line.search(rNotIndentChar);
             if (firstContent === -1) {
                 firstContent = line.length;
@@ -541,6 +540,7 @@ module.exports.prototype = {
 
         var indentChar = this._indentChar;
         var indentSize = this._indentSize;
+        var rNotIndentChar = new RegExp('[^' + indentChar + ']');
 
         var indentStack = [0];
         var linesToCheck = file.getLines().map(function(line) {


### PR DESCRIPTION
Originaly `validateIndetation` rule creates new RegExp for every single line to check.
PR fix it, rule creates one RegExp per file (it's 100 times less on our code base).
Not sure, but probably it will be better add new private property `_rNotIndentChar` and creates just one RegExp in `configure`.