### PR TITLE
Add jscs-jsdoc plugin

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,6 +1,7 @@
 {
     "preset": "google",
     "fileExtensions": [".js", "jscs"],
+    "plugins": ["jscs-jsdoc"],
 
     "requireParenthesesAroundIIFE": true,
     "maximumLineLength": 120,


### PR DESCRIPTION
Fixes Sublime 3 SublimeLinter-jscs  *Error: Unsupported rule: jsDoc*
![error_unsupported-rule_jsdoc](https://cloud.githubusercontent.com/assets/1881059/8894965/f7fc2b96-33c0-11e5-9e1e-7947520d0327.PNG)