### PR TITLE
disallowSpacesInCallExpression: report only on a node's round brace

### DIFF
--- a/lib/rules/disallow-spaces-in-call-expression.js
+++ b/lib/rules/disallow-spaces-in-call-expression.js
@@ -42,16 +42,16 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType(['CallExpression', 'NewExpression'], function(node) {
+            function doesTokenBelongToNode(token, node) {
+                return token.range[1] <= node.range[1];
+            }
+
             var lastCalleeToken = file.getLastNodeToken(node.callee);
             var roundBraceToken = file.findNextToken(lastCalleeToken, 'Punctuator', '(');
 
+            // CallExpressions can't have missing parens, otherwise they're identifiers
             if (node.type === 'NewExpression') {
-                if (roundBraceToken === undefined) {
-                    return;
-                }
-
-                // Protect from the case like "new (SomeClass.extend())"(#1590)
-                if (node.callee.type === 'CallExpression') {
+                if (roundBraceToken === undefined || !doesTokenBelongToNode(roundBraceToken, node)) {
                     return;
                 }
             }

--- a/test/specs/rules/disallow-spaces-in-call-expression.js
+++ b/test/specs/rules/disallow-spaces-in-call-expression.js
@@ -19,6 +19,7 @@ describe('rules/disallow-spaces-in-call-expression', function() {
         assert(checker.checkString('var x = (function (){foobar();})();').isEmpty());
         assert(checker.checkString('(function(){ foobar(); })();').isEmpty());
         assert(checker.checkString('var x = function (){}();').isEmpty());
+        assert(checker.checkString('var x = foobar\n\n\n\n();').isEmpty());
     });
 
     it('should not report missing space before round brace in NewExpression', function() {
@@ -68,5 +69,10 @@ describe('rules/disallow-spaces-in-call-expression', function() {
 
     it('should not report NewExpression with fitting parentheses (#1590)', function() {
         assert(checker.checkString('new (SomeClass.extend()); function test () {}').isEmpty());
+    });
+
+    it('should not report on round braces that do not belong to a NewExpression #(1594)', function() {
+        checker.configure({ disallowSpacesInCallExpression: true, esnext: true });
+        assert(checker.checkString('const newObj = new data.constructor;\n\nif (dataIsMap) {\n\n}').isEmpty());
     });
 });


### PR DESCRIPTION
Fixes #1594