### PR TITLE
SpacesInAnonymousFunctionExpression: consider ES6 "constructor" method

### DIFF
--- a/lib/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -90,8 +90,8 @@ module.exports.prototype = {
                 return;
             }
 
-            // if shorthand method
-            if (parent.method) {
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
                 functionNode = parent.key;
             }
 

--- a/lib/rules/require-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/require-spaces-in-anonymous-function-expression.js
@@ -90,8 +90,8 @@ module.exports.prototype = {
                 return;
             }
 
-            // if shorthand method
-            if (parent.method) {
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
                 functionNode = parent.key;
             }
 

--- a/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-anonymous-function-expression.js
@@ -52,13 +52,15 @@ describe('rules/disallow-spaces-in-anonymous-function-expression', function() {
         });
 
         it('should not report missing space before round brace in method shorthand', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y() {} }').isEmpty());
         });
 
         it('should report space before round brace in method shorthand', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor() {} }').isEmpty());
         });
 
         reportAndFix({

--- a/test/specs/rules/require-spaces-in-anonymous-function-expression.js
+++ b/test/specs/rules/require-spaces-in-anonymous-function-expression.js
@@ -48,12 +48,10 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
         });
 
         it('should report missing space before round brace in method shorthand #1470', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y() {} }').getErrorCount() === 1);
         });
 
         it('should not report space before round brace in method shorthand #1470', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').isEmpty());
         });
 
@@ -113,13 +111,15 @@ describe('rules/require-spaces-in-anonymous-function-expression', function() {
         });
 
         it('should report missing space before curly brace in method shorthand', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y(){} }').getErrorCount() === 1);
         });
 
         it('should not report space before curly brace in method shorthand', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').isEmpty());
         });
 
         reportAndFix({


### PR DESCRIPTION
Fixes #1607