### PR TITLE
[preset] update airbnb

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -12,7 +12,6 @@
     "disallowSpacesInFunctionDeclaration": {
         "beforeOpeningRoundBrace": true
     },
-    "disallowEmptyBlocks": true,
     "disallowSpacesInCallExpression": true,
     "disallowSpacesInsideArrayBrackets": true,
     "disallowSpacesInsideParentheses": true,
@@ -32,6 +31,8 @@
     "disallowMultipleLineBreaks": true,
     "disallowMultipleLineStrings": true,
     "disallowMultipleVarDecl": true,
+    "disallowSpaceBeforeComma": true,
+    "disallowSpaceBeforeSemicolon": true,
     "requireSpaceBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
     "requireSpacesInConditionalExpression": true,


### PR DESCRIPTION
remove disallowEmptyBlocks: nothing about it [in the Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)

add new rules:
- disallowSpaceBeforeComma (https://github.com/airbnb/javascript#commas)
- disallowSpaceBeforeSemicolon (https://github.com/airbnb/javascript#semicolons)