### PR TITLE
Allow string + string concatenation.

### DIFF
--- a/lib/rules/require-template-strings.js
+++ b/lib/rules/require-template-strings.js
@@ -1,9 +1,13 @@
 /**
  * Requires the use of template strings instead of string concatenation.
  *
- * Type: `Boolean`
+ * Types: `Boolean` or `Object`
  *
- * Value: `true`
+ * Values:
+ * - true
+ * - `Object`:
+ *      - `"allExcept"`: array of quoted exceptions:
+ *          - `"stringConcatenation"` ignores strings concatenated with other strings
  *
  * Version: `ES6`
  *
@@ -11,6 +15,7 @@
  *
  * ```js
  * "requireTemplateStrings": true
+ * "requireTemplateStrings": { "allExcept": ["stringConcatenation"] }
  * ```
  *
  * ##### Valid
@@ -21,6 +26,15 @@
  * }
  * `a ${b + c}`
  * `a ${a()}`
+ * ```
+ *
+ * ##### Valid for `{ "allExcept": ["stringConcatenation"] }`
+ *
+ * ```js
+ * function sayBye(name) {
+ *     return `It was good seeing you, ${name}! Let's hang out again sometime and` +
+ *         ' grab some chicken and waffles.';
+ * }
  * ```
  *
  * ##### Invalid
@@ -41,10 +55,28 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            options === true,
-            this.getOptionName() + ' option requires a true value or should be removed'
-        );
+        this._allowStringConcatenation = false;
+        var optionName = this.getOptionName();
+
+        if (typeof options === 'object') {
+            assert(Array.isArray(options.allExcept), optionName + ' option requires "allExcept" ' +
+                'to be an array');
+            assert(options.allExcept.length > 0, optionName + ' option requires "allExcept" ' +
+                'to have at least one item or be set to `true`');
+            options.allExcept.forEach(function(except) {
+                if (except === 'stringConcatenation') {
+                    this._allowStringConcatenation = true;
+                } else {
+                    assert(false, optionName + ' option requires "allExcept" to only have ' +
+                        '"stringConcatenation"');
+                }
+            }, this);
+        } else {
+            assert(
+                options === true,
+                optionName + ' option requires true value or object'
+            );
+        }
     },
 
     getOptionName: function() {
@@ -52,6 +84,8 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var allowStringConcatenation = this._allowStringConcatenation;
+
         function add(node) {
             errors.add(
                 'Illegal use of string concatenation. Use template strings instead.',
@@ -59,17 +93,25 @@ module.exports.prototype = {
             );
         }
 
-        function isString(value) {
-            return typeof value === 'string';
-        }
-
         file.iterateNodesByType('BinaryExpression', function(node) {
             if (node.operator !== '+') {
                 return;
             }
 
-            // Only one of the operands should be a string, otherwise this is not a concatenation
-            if (isString(node.left.value) || isString(node.right.value)) { add(node); }
+            var leftIsString = typeof node.left.value === 'string' ||
+                node.left.type === 'TemplateLiteral';
+            var rightIsString = typeof node.right.value === 'string' ||
+                node.right.type === 'TemplateLiteral';
+
+            if (allowStringConcatenation && leftIsString && rightIsString) {
+                return;
+            }
+
+            // At least one of the operands should be a string or template string,
+            // otherwise this is not a concatenation
+            if (leftIsString || rightIsString) {
+                add(node);
+            }
         });
     }
 };

--- a/test/specs/rules/require-template-strings.js
+++ b/test/specs/rules/require-template-strings.js
@@ -7,86 +7,155 @@ describe('rules/require-template-strings', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ esnext: true, requireTemplateStrings: true });
     });
 
-    it('should report the use of string concatenation with a identifier on the left', function() {
-        assert(checker.checkString('a + "a"').getErrorCount() === 1);
+    function errorChecks(string) {
+        it('should report the use of string concatenation with a identifier on the left', function() {
+            assert(checker.checkString('a + ' + string).getErrorCount() === 1);
+        });
+
+        it('should report the use of string concatenation with a identifier on the right', function() {
+            assert(checker.checkString(string + ' + a').getErrorCount() === 1);
+        });
+
+        it('should report the use of string concatenation with right handed binary expression',
+            function() {
+                assert(checker.checkString('"test" + (a + b)').getErrorCount() === 1);
+            }
+        );
+
+        it('should report the use of string concatenation with left handed binary expression',
+            function() {
+                assert(checker.checkString('(a + b) + "test"').getErrorCount() === 1);
+            }
+        );
+
+        it('should report for the use of string concatenation with a CallExpression',
+            function() {
+                assert(checker.checkString('a() + ' + string).getErrorCount() === 1);
+                assert(checker.checkString(string + ' + a()').getErrorCount() === 1);
+            }
+        );
+
+        it('should report for the use of string concatenation with a MemberExpression',
+            function() {
+                assert(checker.checkString('a.b + ' + string).getErrorCount() === 1);
+                assert(checker.checkString(string + ' + a.b').getErrorCount() === 1);
+            }
+        );
+
+        it('should report for the use of string concatenation with a TaggedTemplateExpression',
+            function() {
+                assert(checker.checkString('a`a` + ' + string).getErrorCount() === 1);
+                assert(checker.checkString(string + ' + a`a`').getErrorCount() === 1);
+            }
+        );
+    }
+
+    function validChecks() {
+        it('should not report the use of string concatenation with a identifier on the left and right', function() {
+            assert(checker.checkString('a + a').isEmpty());
+        });
+
+        it('should not report the use of template strings', function() {
+            assert(checker.checkString('`How are you, ${name}?`').isEmpty());
+        });
+
+        it('should not report for number literals', function() {
+            assert(checker.checkString('1 + a').isEmpty());
+            assert(checker.checkString('a + 1').isEmpty());
+        });
+
+        it('should not report for null literal', function() {
+            assert(checker.checkString('null + a').isEmpty());
+            assert(checker.checkString('a + null').isEmpty());
+        });
+
+        it('should not report for true literal', function() {
+            assert(checker.checkString('true + a').isEmpty());
+            assert(checker.checkString('a + false').isEmpty());
+        });
+
+        it('should not report for binary expression that isn\'t +', function() {
+            assert(checker.checkString('1 * 2').isEmpty());
+            assert(checker.checkString('a === b').isEmpty());
+        });
+    }
+
+    describe('true value', function() {
+        beforeEach(function() {
+            checker.configure({
+                esnext: true,
+                requireTemplateStrings: true
+            });
+        });
+
+        describe('for a string', function() {
+            errorChecks('"string"');
+
+            it('should report for the use of string concatenation with a TemplateLiteral',
+                function() {
+                    assert(checker.checkString('`a` + "string"').getErrorCount() === 1);
+                    assert(checker.checkString('"string" + `a`').getErrorCount() === 1);
+                }
+            );
+        });
+
+        describe('for a template string', function() {
+            errorChecks('`templateString`');
+        });
+
+        validChecks();
+
+        it('should report the use of string concatenation with two string literals', function() {
+            assert(checker.checkString('"a" + "a"').getErrorCount() === 1);
+        });
+
+        it('should report the use of string concatenation with two template strings', function() {
+            assert(checker.checkString('`a` + `a`').getErrorCount() === 1);
+        });
     });
 
-    it('should report the use of string concatenation with a identifier on the right', function() {
-        assert(checker.checkString('"a" + a').getErrorCount() === 1);
+    describe('allExcept: ["stringConcatenation"] value', function() {
+        beforeEach(function() {
+            checker.configure({
+                esnext: true,
+                requireTemplateStrings: {
+                    allExcept: ['stringConcatenation']
+                }
+            });
+        });
+
+        describe('for a string', function() {
+            errorChecks('"string"');
+        });
+
+        describe('for a template string', function() {
+            errorChecks('`templateString`');
+        });
+
+        validChecks();
+
+        it('should not report the use of string concatenation with two string literals', function() {
+            assert(checker.checkString('"a" + "a"').isEmpty());
+        });
+
+        it('should not report the use of string concatenation with two template strings', function() {
+            assert(checker.checkString('`a` + `a`').isEmpty());
+        });
     });
 
-    it('should report the use of string concatenation with right handed binary expression',
-        function() {
-            assert(checker.checkString('"test" + (a + b)').getErrorCount() === 1);
-        }
-    );
+    describe('invalid options', function() {
+        it('should throw if not allExcept object', function() {
+            assert.throws(function() {
+                checker.configure({requireTemplateStrings: {allBut: false}});
+            });
+        });
 
-    it('should report the use of string concatenation with left handed binary expression',
-        function() {
-            assert(checker.checkString('(a + b) + "test"').getErrorCount() === 1);
-        }
-    );
-
-    it('should report for the use of string concatenation with a CallExpression',
-        function() {
-            assert(checker.checkString('a() + "a"').getErrorCount() === 1);
-            assert(checker.checkString('"a" + a()').getErrorCount() === 1);
-        }
-    );
-
-    it('should report for the use of string concatenation with a MemberExpression',
-        function() {
-            assert(checker.checkString('a.b + "a"').getErrorCount() === 1);
-            assert(checker.checkString('"a" + a.b').getErrorCount() === 1);
-        }
-    );
-
-    it('should report for the use of string concatenation with a TemplateLiteral',
-        function() {
-            assert(checker.checkString('`a` + "a"').getErrorCount() === 1);
-            assert(checker.checkString('"a" + `a`').getErrorCount() === 1);
-        }
-    );
-
-    it('should report for the use of string concatenation with a TaggedTemplateExpression',
-        function() {
-            assert(checker.checkString('a`a` + "a"').getErrorCount() === 1);
-            assert(checker.checkString('"a" + a`a`').getErrorCount() === 1);
-        }
-    );
-
-    it('should report the use of string concatenation with two string literals', function() {
-        assert(checker.checkString('"a" + "a"').getErrorCount() === 1);
-    });
-
-    it('should not report the use of string concatenation with a identifier on the left and right', function() {
-        assert(checker.checkString('a + a').isEmpty());
-    });
-
-    it('should not report the use of template strings', function() {
-        assert(checker.checkString('`How are you, ${name}?`').isEmpty());
-    });
-
-    it('should not report for number literals', function() {
-        assert(checker.checkString('1 + a').isEmpty());
-        assert(checker.checkString('a + 1').isEmpty());
-    });
-
-    it('should not report for null literal', function() {
-        assert(checker.checkString('null + a').isEmpty());
-        assert(checker.checkString('a + null').isEmpty());
-    });
-
-    it('should not report for true literal', function() {
-        assert(checker.checkString('true + a').isEmpty());
-        assert(checker.checkString('a + false').isEmpty());
-    });
-
-    it('should not report for binary expression that isn\'t +', function() {
-        assert(checker.checkString('1 * 2').isEmpty());
-        assert(checker.checkString('a === b').isEmpty());
+        it('should throw if unknown allExcept value', function() {
+            assert.throws(function() {
+                checker.configure({requireTemplateStrings: {allExcept: ['badOptionName']}});
+            });
+        });
     });
 });


### PR DESCRIPTION
This also makes the logic match the comment.

Use case: single-line messages that are too long, like warnings or assertions or test descriptions.

```javascript
// Desired code:
it('should allow really long but peripheral strings to be concatenated, ' +
   'instead of forcing interpolation, which draws attention.', function() {
  if (someFailureCase) {
    console.error('This is a really really long error message that conveys a' +
                  'lot of information. A lot.');
  }
});

// The alternative, if we want to get past `requireTemplateStrings`:
it(`should allow really long but peripheral strings to be concatenated, \
instead of forcing interpolation, which draws attention.`, function() {
  if (someFailureCase) {
    console.error(`This is a really really long error message that conveys a \
lot of information. A lot.`);
  }
});
```
