### PR TITLE
requireAlignedObjectValues: fix usage with computed keys with MemberE…

### DIFF
--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -87,7 +87,9 @@ module.exports.prototype = {
                 maxKeyEndPos = Math.max(maxKeyEndPos, property.key.loc.end.column);
                 var keyToken = file.getFirstNodeToken(property.key);
                 if (property.computed === true) {
-                    keyToken = file.getNextToken(keyToken);
+                    while (keyToken.value !== ']') {
+                        keyToken = file.getNextToken(keyToken);
+                    }
                 }
                 var colon = file.getNextToken(keyToken);
                 if (prevKeyEndPos < maxKeyEndPos) {

--- a/test/specs/rules/require-aligned-object-values.js
+++ b/test/specs/rules/require-aligned-object-values.js
@@ -95,6 +95,20 @@ describe('rules/require-aligned-object-values', function() {
             );
         });
 
+        it('should not report on an import plus aligned computed property names (#1587)', function() {
+            checker.configure({ esnext: true });
+            assert(
+                checker.checkString([
+                    'import React, {PropTypes} from \'react\';\n',
+                    'import {ImmutableComponentPure} from \'common/ImmutableComponent.js\'',
+                    'let myObject = {',
+                      '[myKey]     : "myKeyValue",',
+                      '[$main.pod] : "myOtherValue"',
+                    '};'
+                ].join('\n')).isEmpty()
+            );
+        });
+
         describe('alignment check for any number of spaces', function() {
             reportAndFix({
                 name: 'illegal object values alignment',


### PR DESCRIPTION
…xpressions

Fixes #1587 

```js
if (property.computed === true) {
  keyToken = file.getNextToken(keyToken);
}
```

normally it's `myKey` and `]` but in the other case it's `$main` and `.`

Do we already have a helper for this?