### PR TITLE
New Rule: requireDefaultParameters (ES6)

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -785,6 +785,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/require-spread'));
     this.registerRule(require('../rules/require-template-strings'));
     this.registerRule(require('../rules/require-shorthand-arrow-functions'));
+    this.registerRule(require('../rules/require-default-parameters'));
     /* ES6 only (end) */
 
     this.registerRule(require('../rules/require-curly-braces'));

--- a/lib/rules/require-default-parameters.js
+++ b/lib/rules/require-default-parameters.js
@@ -1,0 +1,75 @@
+/**
+ * Requires use of default parameters instead of checking for undefined in the function body
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireDefaultParameters": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * function multiply(a, b = 1) {}
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function multiply(a, b) { b = b || 1; }
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireDefaultParameters';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('AssignmentExpression', function(node) {
+            var left = node.left;
+            var right = node.right;
+            if (
+                // b = b || 1
+                right.type === 'LogicalExpression' &&
+                left.type === 'Identifier' && right.left.type === 'Identifier' &&
+                left.name === right.left.name ||
+
+                // b = typeof b !== 'undefined' ? b : 1
+                right.type === 'ConditionalExpression' &&
+                right.test.type === 'BinaryExpression' &&
+                right.test.left.type === 'UnaryExpression' && right.test.left.operator === 'typeof' &&
+                right.test.right.type === 'Literal' && right.test.right.value === 'undefined' &&
+                left.type === 'Identifier' && right.consequent.type === 'Identifier' &&
+                right.test.left.argument.type === 'Identifier' &&
+                left.name === right.consequent.name &&
+                left.name === right.test.left.argument.name
+            ) {
+                errors.add(
+                    'Use default parameters instead of checking for undefined',
+                    node.loc.start.line,
+                    node.loc.start.column
+                );
+            }
+        });
+    }
+
+};

--- a/test/specs/rules/require-default-parameters.js
+++ b/test/specs/rules/require-default-parameters.js
@@ -1,0 +1,38 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-default-parameters', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ requireDefaultParameters: true, esnext: true });
+    });
+
+    it('should not report use of default parameters', function() {
+        assert(checker.checkString([
+            'function multiply(a, b = 1) {',
+                'return a * b;',
+            '}'
+        ].join('\n')).isEmpty());
+    });
+
+    it('should report use of checking for undefined parameters with the || operator', function() {
+        assert(checker.checkString([
+            'function multiply(a, b) {',
+                'b = b || 1;',
+                'return a * b;',
+            '}'
+        ].join('\n')).getErrorCount() === 1);
+    });
+
+    it('should report use of checking for undefined parameters with ternary and typeof', function() {
+        assert(checker.checkString([
+            'function multiply(a, b) {',
+                'b = typeof b !== \'undefined\' ?  b : 1;',
+                'return a * b;',
+            '}'
+        ].join('\n')).getErrorCount() === 1);
+    });
+});


### PR DESCRIPTION
Fixes #1387 

WIP - Kind of crazy to check for the other cases (not the `||` ones) but maybe it's required?

```js
// didn't do yet
function foo(a, b) {
   a = typeof a === 'undefined' ? 42 : a; // swap !== for ===
}

function pick(arg, def) {
   return (typeof arg == 'undefined' ? def : arg); // return instead of assignment
}
```