### PR TITLE
Preset: Set jsDoc.checkTypes to "strictNativeCase" for Wikimedia

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -79,7 +79,7 @@
         "checkReturnTypes": true,
         "checkRedundantReturns": true,
         "requireReturnTypes": true,
-        "checkTypes": "capitalizedNativeCase",
+        "checkTypes": "strictNativeCase",
         "checkRedundantAccess": true,
         "requireNewlineAfterDescription": true
     }

--- a/test/data/options/preset/wikimedia.js
+++ b/test/data/options/preset/wikimedia.js
@@ -16,7 +16,7 @@
 	 * @class
 	 *
 	 * @constructor
-	 * @param {String} id
+	 * @param {string} id
 	 * @param {Object} options
 	 */
 	APP.Example = function ( id, options ) {
@@ -97,6 +97,9 @@
 		return ret;
 	};
 
+	/**
+	 * @param {boolean|number} code
+	 */
 	APP.fall = function ( code ) {
 		switch ( code ) {
 			case 200:


### PR DESCRIPTION
Follows-up 5f8c939. Per www.mediawiki.org documentation, Wikimedia
notates primitives in lower case. Only uppercase when referring
to the identifier of a constructor.

Ref <https://mediawiki.org/wiki/Manual:Coding_conventions/JavaScript#Types>.
Ref jscs-dev/jscs-jsdoc#137.

/cc @jdforrester 