### PR TITLE
validateIndentation: Add support for 'offset' switch cases

### DIFF
--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -32,7 +32,7 @@
  * }
  * ```
  *
- * ##### Invalid example for mode `2`
+ * ##### invalid example for mode `2`
  *
  * ```js
  * if (a) {
@@ -40,6 +40,45 @@
  * function(d) {
  *        e=f;
  * }
+ * }
+ * ```
+ *
+ * ##### valid example for mode `4`
+ *
+ * ```js
+ * switch (val) {
+ *   case '2':
+ *     a();
+ *     break;
+ *   default;
+ *     b();
+ *     break;
+ * }
+ * ```
+ *
+ * ##### valid example for mode `4`
+ *
+ * ```js
+ * switch (val) {
+ *     case '2':
+ *         a();
+ *         break;
+ *     default;
+ *         b();
+ *         break;
+ * }
+ * ```
+ *
+ * ##### invalid example for mode `4`
+ *
+ * ```js
+ * switch (val) {
+ *   case '2':
+ *     a();
+ *     break;
+ *   default;
+ *         b();
+ *         break;
  * }
  * ```
  *
@@ -155,6 +194,7 @@ module.exports.prototype = {
         }
 
         this._breakIndents = null;
+        this._caseOffset = null;
         this._moduleIndents = null;
     },
 
@@ -476,8 +516,15 @@ module.exports.prototype = {
                 var indents = 1;
                 var children = getChildren(node);
 
-                if (node.loc.start.column === children[0].loc.start.column) {
-                    indents = 0;
+                if (_this._caseOffset) {
+                    indents = 0.5;
+                } else {
+                    if (node.loc.start.column === children[0].loc.start.column) {
+                        indents = 0;
+                    } else if (children[0].loc.start.column - node.loc.start.column === indentSize / 2) {
+                        _this._caseOffset = 1;
+                        indents = 0.5;
+                    }
                 }
 
                 markChildren(node);
@@ -497,7 +544,13 @@ module.exports.prototype = {
                     return;
                 }
 
-                markPush(node, 1);
+                var indents = 1;
+
+                if (_this._caseOffset) {
+                    indents = 0.5;
+                }
+
+                markPush(node, indents);
                 markCheck(node);
                 markChildren(node);
 

--- a/test/specs/rules/validate-indentation.js
+++ b/test/specs/rules/validate-indentation.js
@@ -439,5 +439,62 @@ describe('rules/validate-indentation', function() {
                 ).getErrorCount() === 3
             );
         });
+
+        it('should report no errors when offset case statements are used', function() {
+            assert(
+                checker.checkString(
+                    'switch(value){\n' +
+                        '  case "1":\n' +
+                        '    a();\n' +
+                        '    break;\n' +
+                        '  case "2":\n' +
+                        '    break;\n' +
+                        '  default:\n' +
+                        '    break;\n' +
+                        '}'
+                ).getErrorCount() === 0
+            );
+        });
+
+        it('should report errors for indent when offset case statements are used', function() {
+            assert(
+                checker.checkString(
+                    'switch(value){\n' +
+                        '  case "1":\n' +
+                        '      a();\n' + // whole indent
+                        '    break;\n' +
+                        '  case "2":\n' +
+                        '    break;\n' +
+                        '  default:\n' +
+                        '    break;\n' +
+                        '}'
+                ).getErrorCount() === 1
+            );
+        });
+
+        it('should report errors when no offset case statements are used after previous use', function() {
+            assert(
+                checker.checkString(
+                    'switch(value){\n' +
+                        '  case "1":\n' +
+                        '    a();\n' +
+                        '    break;\n' +
+                        '  case "2":\n' +
+                        '    break;\n' +
+                        '  default:\n' +
+                        '    break;\n' +
+                        '}\n' +
+                        'switch(value){\n' +
+                        '    case "1":\n' +
+                        '        a();\n' +
+                        '        break;\n' +
+                        '    case "2":\n' +
+                        '        break;\n' +
+                        '    default:\n' +
+                        '        break;\n' +
+                        '}\n'
+                ).getErrorCount() === 7
+            );
+        });
     });
 });


### PR DESCRIPTION
'offset' switch cases are cases indented by a half indent. Example
(indentSize = 4):
```js
switch (val) {
  case "1":
    a();
    break;
  default:
    b();
    break;
}
```