### PR TITLE
requireBlocksOnNewline: Add object option to handle comments

### DIFF
--- a/lib/rules/require-blocks-on-newline.js
+++ b/lib/rules/require-blocks-on-newline.js
@@ -1,15 +1,35 @@
 /**
  * Requires blocks to begin and end with a newline
  *
- * Types: `Boolean` or `Integer`
+ * Types: `Boolean`, `Integer`, `Object`
  *
- * Values: `true` validates all non-empty blocks,
- * `Integer` specifies a minimum number of statements in the block before validating.
+ * Values:
+ *  - `true` validates all non-empty blocks
+ *  - `Integer` specifies a minimum number of lines containing elements in the block before validating
+ *  - `Object`:
+ *      - `'includeComments'`
+ *          - `true` includes comments as part of the validation
+ *      - `'minLines'`
+ *          - `Integer` specifies a minimum number of lines containing elements in the block before validating
  *
  * #### Example
  *
  * ```js
  * "requireBlocksOnNewline": true
+ * ```
+ * ```js
+ * "requireBlocksOnNewline": 1
+ * ```
+ * ```js
+ * "requireBlocksOnNewline": {
+ *      includeComments: true
+ * }
+ * ```
+ * ```js
+ * "requireBlocksOnNewline": {
+ *      includeComments: true,
+ *      minLines: 1
+ * }
  * ```
  *
  * ##### Valid for mode `true`
@@ -18,6 +38,18 @@
  * if (true) {
  *     doSomething();
  * }
+ * var abc = function() {};
+ * ```
+ * ```
+ * if (true) { //comments
+ *     doSomething();
+ * }
+ * var abc = function() {};
+ * ```
+ * ```
+ * if (true) {
+ *     doSomething();
+ * /** comments *\/}
  * var abc = function() {};
  * ```
  *
@@ -37,27 +69,161 @@
  * if (true) { doSomething(); }
  * var abc = function() {};
  * ```
+ * ```js
+ * if (true) { //comments
+ *     doSomething();
+ *     doSomethingElse();
+ * }
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *     doSomethingElse();
+ *     /** comments *\/}
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
  *
  * ##### Invalid
  *
  * ```js
  * if (true) { doSomething(); doSomethingElse(); }
  * ```
+ *
+ * ##### Valid for mode {
+ *      includeComments: true
+ * }
+ *
+ * ```
+ * if (true) {
+ *     //comments
+ *     doSomething();
+ * }
+ * var abc = function() {};
+ * ```
+  * ```
+ * if (true) {
+ *     doSomething();
+ *      //comments
+ * }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```
+ * if (true) { //comments
+ *     doSomething();
+ * }
+ * var abc = function() {};
+ * ```
+  * ```
+ * if (true) {
+ *     doSomething();
+ * /** comments *\/}
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Valid for mode {
+ *      includeComments: true,
+ *      minLines: `1`
+ * }
+ *
+ * ```js
+ * if (true) {
+ *     //comments
+ *     doSomething();
+ *     doSomethingElse();
+ * }
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *     doSomethingElse();
+ *     //comments
+ * }
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ * ```js
+ * if (true) { //comments
+ *     doSomething();
+ *     doSomethingElse();
+ * }
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *     doSomethingElse();
+ *     /** comments *\/}
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
  */
 
 var assert = require('assert');
+
+function hasCommentInBlock(block, commentTokens) {
+    var count;
+    var comment;
+
+    for (count = 0; count < commentTokens.length; count++) {
+        comment = commentTokens[count];
+        if (comment.range[0] >= block.range[0] &&
+            comment.range[1] <= block.range[1]) {
+            return true;
+        }
+    }
+    return false;
+}
 
 module.exports = function() {};
 
 module.exports.prototype = {
 
     configure: function(options) {
+        var optionType = typeof options;
         assert(
-            options === true || typeof options === 'number',
-            this.getOptionName() + ' option requires the value true or an Integer'
+            options === true || optionType === 'number' || optionType === 'object',
+            this.getOptionName() + ' option requires the value true, an Integer or an object'
         );
 
-        this._minStatements = options === true ? 0 : options;
+        this._minLines = 0;
+        this._includeComments = false;
+        if (optionType === 'number') {
+            this._minLines = options;
+        } else if (optionType === 'object') {
+            assert(
+                options.includeComments === true,
+                this.getOptionName() + ' option requires includeComments property to be true for object'
+            );
+            this._includeComments = options.includeComments;
+
+            if (options.hasOwnProperty('minLines')) {
+                assert(
+                    typeof options.minLines === 'number',
+                    this.getOptionName() + ' option requires minLines property to be an integer for object'
+                );
+                this._minLines = options.minLines;
+            }
+        }
+
+        assert(
+            this._minLines >= 0,
+            this.getOptionName() + ' option requires minimum statements setting to be >= 0'
+        );
     },
 
     getOptionName: function() {
@@ -65,15 +231,26 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var minStatements = this._minStatements;
+        var minLines = this._minLines;
+        var includeComments = this._includeComments;
+        var commentTokens = [];
+
+        file.iterateTokensByType(['Line', 'Block'], function(commentToken) {
+            commentTokens.push(commentToken);
+        });
 
         file.iterateNodesByType('BlockStatement', function(node) {
-            if (node.body.length <= minStatements) {
+            var hasComment = false;
+            if (includeComments === true) {
+                hasComment = hasCommentInBlock(node, commentTokens);
+            }
+
+            if (hasComment === false && node.body.length <= minLines) {
                 return;
             }
 
             var openingBracket = file.getFirstNodeToken(node);
-            var nextToken = file.getNextToken(openingBracket);
+            var nextToken = file.getNextToken(openingBracket, { includeComments: includeComments });
 
             errors.assert.differentLine({
                 token: openingBracket,
@@ -82,7 +259,7 @@ module.exports.prototype = {
             });
 
             var closingBracket = file.getLastNodeToken(node);
-            var prevToken = file.getPrevToken(closingBracket);
+            var prevToken = file.getPrevToken(closingBracket, { includeComments: includeComments });
 
             errors.assert.differentLine({
                 token: prevToken,

--- a/test/specs/rules/require-blocks-on-newline.js
+++ b/test/specs/rules/require-blocks-on-newline.js
@@ -8,6 +8,66 @@ describe('rules/require-blocks-on-newline', function() {
         checker.registerDefaultRules();
     });
 
+    describe('configure', function() {
+        it('should not report an error for value "true"', function() {
+            assert.doesNotThrow(function() {
+                checker.configure({ requireBlocksOnNewline: true });
+            });
+        });
+
+        it('should not report an error for number value 1', function() {
+            assert.doesNotThrow(function() {
+                checker.configure({ requireBlocksOnNewline: 1 });
+            });
+        });
+
+        it('should not report an error for object with property includeComments value true', function() {
+            assert.doesNotThrow(function() {
+                checker.configure({ requireBlocksOnNewline: {
+                    includeComments: true
+                }});
+            });
+        });
+
+        it('should not report an error for object with property includeComments value true and minLines 1',
+            function() {
+                assert.doesNotThrow(function() {
+                        checker.configure({ requireBlocksOnNewline: { includeComments: true, minLines: 1 } });
+                    }
+                );
+            }
+        );
+
+        it('should report an error for value "false"', function() {
+            assert.throws(function() {
+                checker.configure({ requireBlocksOnNewline: false });
+            });
+        });
+
+        it('should report an error for value "-1"', function() {
+            assert.throws(function() {
+                checker.configure({ requireBlocksOnNewline: -1 });
+            });
+        });
+
+        it('should report error for object with property includeComments value false', function() {
+            assert.throws(function() {
+                checker.configure({ requireBlocksOnNewline: {
+                    includeComments: false
+                }});
+            });
+        });
+    });
+
+    it('should report an error for object with property includeComments value true ' +
+        'and a non integer minLines value', function() {
+            assert.throws(function() {
+                    checker.configure({ requireBlocksOnNewline: { includeComments: true, minLines: true } });
+                }
+            );
+        }
+    );
+
     describe('option value true', function() {
         beforeEach(function() {
             checker.configure({ requireBlocksOnNewline: true });
@@ -16,8 +76,14 @@ describe('rules/require-blocks-on-newline', function() {
         it('should report missing newline after opening brace', function() {
             assert(checker.checkString('if (true) {abc();\n}').getErrorCount() === 1);
         });
+        it('should not report missing newline for comments after opening brace', function() {
+            assert(checker.checkString('if (true) {//comments\n}').isEmpty());
+        });
         it('should report missing newline before closing brace', function() {
             assert(checker.checkString('if (true) {\nabc();}').getErrorCount() === 1);
+        });
+        it('should not report missing newline for comments before closing brace', function() {
+            assert(checker.checkString('if (true) {\n/*comments*/}').isEmpty());
         });
         it('should report missing newlines in both cases', function() {
             assert(checker.checkString('if (true) {abc();}').getErrorCount() === 2);
@@ -27,6 +93,12 @@ describe('rules/require-blocks-on-newline', function() {
         });
         it('should not report empty function definitions', function() {
             assert(checker.checkString('var a = function() {};').isEmpty());
+        });
+        it('should not report missing newline for comments before block', function() {
+            assert(checker.checkString('function a() {\n//comments\nif (true) {\nabc();\n}\n};').isEmpty());
+        });
+        it('should not report missing newline for comments after block', function() {
+            assert(checker.checkString('function a() {\nif (true) {\nabc();\n}//comments\n};').isEmpty());
         });
     });
 
@@ -52,6 +124,24 @@ describe('rules/require-blocks-on-newline', function() {
         });
         it('should not report single statement functions', function() {
             assert(checker.checkString('var a = function() {abc();};').isEmpty());
+        });
+    });
+
+    describe('option object includeComments true', function() {
+        beforeEach(function() {
+            checker.configure({ requireBlocksOnNewline: {
+                includeComments: true
+            }});
+        });
+
+        it('should report missing newline for comments after opening brace', function() {
+            assert(checker.checkString('if (true) {//comments\n}').getErrorCount() === 1);
+        });
+        it('should report missing newline for comments before closing brace', function() {
+            assert(checker.checkString('if (true) {\n/*comments*/}').getErrorCount() === 1);
+        });
+        it('should not report comments before empty function definitions', function() {
+            assert(checker.checkString('if (true) {\n//comments\nvar a = function() {};\n}').isEmpty());
         });
     });
 });


### PR DESCRIPTION
Add object option { includeComments: true } and { includeComments: true,
minStatements: 1} that allows the rule to turn on or off the inclusion of
comments as part of the block being checked using exisitng rules. A new
config option is introduced to maintain compatability with existing code like
the crockford preset which ignores comments.

Fixes #1417