### PR TITLE
requireParenthesesAroundArrowParam: account for a single rest parameter

### DIFF
--- a/lib/rules/require-parentheses-around-arrow-param.js
+++ b/lib/rules/require-parentheses-around-arrow-param.js
@@ -48,6 +48,9 @@ module.exports.prototype = {
     check: function(file, errors) {
         function isWrapped(node) {
             var openParensToken = file.getPrevToken(file.getFirstNodeToken(node));
+            if (openParensToken.value === '...') {
+                openParensToken = file.getPrevToken(openParensToken);
+            }
             var closingParensToken = file.getNextToken(file.getLastNodeToken(node));
             var closingTokenValue = closingParensToken ? closingParensToken.value : '';
 

--- a/test/specs/rules/require-parentheses-around-arrow-param.js
+++ b/test/specs/rules/require-parentheses-around-arrow-param.js
@@ -21,4 +21,8 @@ describe('rules/require-parentheses-around-arrow-param', function() {
     it('should not report an arrow function expression with parens around multiple parameters', function() {
         assert(checker.checkString('[1, 2].map((x, y) => x * x);').isEmpty());
     });
+
+    it('should not report an arrow function expression with a single rest param #1616', function() {
+        assert(checker.checkString('[1, 2].map((...x) => x);').isEmpty());
+    });
 });


### PR DESCRIPTION
Fixes #1616