### PR TITLE
New Rule: requireComputedPropertyInObject (ES6)

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -785,6 +785,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/require-spread'));
     this.registerRule(require('../rules/require-template-strings'));
     this.registerRule(require('../rules/require-shorthand-arrow-functions'));
+    this.registerRule(require('../rules/require-computed-property-in-object'));
     /* ES6 only (end) */
 
     this.registerRule(require('../rules/require-curly-braces'));

--- a/lib/rules/require-computed-property-in-object.js
+++ b/lib/rules/require-computed-property-in-object.js
@@ -1,0 +1,63 @@
+/**
+ * Use computed property names when creating objects with dynamic property names
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireComputedPropertyInObject": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * const obj = {
+ *   id: 5,
+ *   [getKey('enabled')]: true, // computed property
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * const obj = {
+ *   id: 5
+ * };
+ * obj[getKey('enabled')] = true; // property created outside of object creation
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireComputedPropertyInObject';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('AssignmentExpression', function(node) {
+            if (node.left.type === 'MemberExpression' && node.left.computed) {
+                errors.add(
+                    'Use computed property names when creating objects with dynamic property names',
+                    node.loc.start
+                );
+            }
+        });
+    }
+
+};

--- a/test/specs/rules/require-computed-property-in-object.js
+++ b/test/specs/rules/require-computed-property-in-object.js
@@ -1,0 +1,20 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-computed-property-in-object', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure({ esnext: true, requireComputedPropertyInObject: true });
+    });
+
+    it('should report a dynamic property assignment not at object creation', function() {
+        assert(checker.checkString('const obj = {}; obj[getKey(\'enabled\')] = true;').getErrorCount() === 1);
+    });
+
+    it('should not report a computed property', function() {
+        assert(checker.checkString('const obj = { [getKey(\'enabled\')]: true };').isEmpty());
+    });
+});


### PR DESCRIPTION
Fixes #1384 

Although there's probably false positives for setting a dynamic property from somewhere else like a parameter? Then we'd have to check if the object was created previous or is a parameter?

```js
function a(b) {
  b[func()] = true;
}
```