### PR TITLE
requirePaddingNewLinesBeforeLineComments: fix for comment on 2nd line…

### DIFF
--- a/lib/rules/require-padding-newlines-before-line-comments.js
+++ b/lib/rules/require-padding-newlines-before-line-comments.js
@@ -97,7 +97,7 @@ module.exports.prototype = {
 
             var prevToken = file.getPrevToken(comment, {includeComments: true});
 
-            if (prevToken.type === 'Line') {
+            if (!prevToken || prevToken.type === 'Line') {
                 return;
             }
 

--- a/test/specs/rules/require-padding-newlines-before-line-comments.js
+++ b/test/specs/rules/require-padding-newlines-before-line-comments.js
@@ -66,6 +66,10 @@ describe('rules/require-padding-newlines-before-line-comments', function() {
             assert(checker.checkString('// comment\nvar a = 2;').isEmpty());
         });
 
+        it('should not report missing padding if newline is 1st line and the comment is 2nd line #1527', function() {
+            assert(checker.checkString('\n// comment\nvar a = 2;').isEmpty());
+        });
+
         it('should not report padding before line comment', function() {
             assert(checker.checkString('var a = 2;\n\n// comment').isEmpty());
         });


### PR DESCRIPTION
… with blank line on 1st line

Fixes #1527, #1444

I'm just returning if `prevToken` is undefined.