### PR TITLE
Exclude common config comments in WordPress JS from requireCapitalizedComments

### DIFF
--- a/presets/wordpress.json
+++ b/presets/wordpress.json
@@ -14,5 +14,8 @@
         "except": [ "{", "}", "[", "]", "function" ]
     },
     "requireYodaConditions": ["==", "!=", "===", "!=="],
-    "validateQuoteMarks": "'"
+    "validateQuoteMarks": "'",
+    "requireCapitalizedComments": {
+        "allExcept": ["global", "exported", "jshint", "eslint", "jslint"]
+    }
 }

--- a/test/data/options/preset/wordpress.js
+++ b/test/data/options/preset/wordpress.js
@@ -1,3 +1,6 @@
+/* global foo */
+/* exported map */
+
 // Objects
 // Object declarations can be made on a single line if they are short (remember the line length guidelines).
 // When an object declaration is too long to fit on one line, there must be one property per line.


### PR DESCRIPTION
The JS coding standards for WordPress prescribes the use of the `/* global foo */` config comment: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#globals

Here are the instances of such config comments in the WordPress Core codebase:

```
  73 global
  35 eslint
  30 jshint
   3 jslint
   2 exported
```

These should be allowed when the `wordpress` preset is used.

Fixes #1627.