### PR TITLE
SpacesIn*: fix for shorthand methods/class methods, update tests

### DIFF
--- a/lib/rules/disallow-spaces-in-function-expression.js
+++ b/lib/rules/disallow-spaces-in-function-expression.js
@@ -80,6 +80,8 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType('FunctionExpression', function(node) {
+            // for a named function, use node.id
+            var functionNode = node.id || node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
@@ -87,15 +89,12 @@ module.exports.prototype = {
                 return;
             }
 
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
+
             if (beforeOpeningRoundBrace) {
-                // for a named function, use node.id
-                var functionNode = node.id || node;
-
-                // for a class method
-                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
-                    functionNode = parent.key;
-                }
-
                 var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.noWhitespaceBetween({
                     token: functionToken,

--- a/lib/rules/disallow-spaces-in-function.js
+++ b/lib/rules/disallow-spaces-in-function.js
@@ -86,6 +86,8 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
+            // for a named function, use node.id
+            var functionNode = node.id || node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
@@ -93,15 +95,12 @@ module.exports.prototype = {
                 return;
             }
 
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
+
             if (beforeOpeningRoundBrace) {
-                // for a named function, use node.id
-                var functionNode = node.id || node;
-
-                // for a class method
-                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
-                    functionNode = parent.key;
-                }
-
                 var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.noWhitespaceBetween({
                     token: functionToken,

--- a/lib/rules/disallow-spaces-in-named-function-expression.js
+++ b/lib/rules/disallow-spaces-in-named-function-expression.js
@@ -76,12 +76,23 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var functionNode = node.id;
+            var parent = node.parentNode;
+
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
+
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
 
             // named function expressions only
             if (node.id) {
-
                 if (beforeOpeningRoundBrace) {
-                    var functionToken = file.getFirstNodeToken(node.id);
+                    var functionToken = file.getFirstNodeToken(functionNode);
                     errors.assert.noWhitespaceBetween({
                         token: functionToken,
                         nextToken: file.getNextToken(functionToken),

--- a/lib/rules/require-spaces-in-anonymous-function-expression.js
+++ b/lib/rules/require-spaces-in-anonymous-function-expression.js
@@ -102,7 +102,6 @@ module.exports.prototype = {
 
             if (beforeOpeningRoundBrace) {
                 var functionToken = file.getFirstNodeToken(functionNode);
-
                 errors.assert.whitespaceBetween({
                     token: functionToken,
                     nextToken: file.getNextToken(functionToken),

--- a/lib/rules/require-spaces-in-function-expression.js
+++ b/lib/rules/require-spaces-in-function-expression.js
@@ -80,6 +80,8 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType('FunctionExpression', function(node) {
+            // for a named function, use node.id
+            var functionNode = node.id || node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
@@ -87,15 +89,12 @@ module.exports.prototype = {
                 return;
             }
 
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
+
             if (beforeOpeningRoundBrace) {
-                // for a named function, use node.id
-                var functionNode = node.id || node;
-
-                // for a class method
-                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
-                    functionNode = parent.key;
-                }
-
                 var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.whitespaceBetween({
                     token: functionToken,

--- a/lib/rules/require-spaces-in-function.js
+++ b/lib/rules/require-spaces-in-function.js
@@ -86,6 +86,8 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionDeclaration', 'FunctionExpression'], function(node) {
+            // for a named function, use node.id
+            var functionNode = node.id || node;
             var parent = node.parentNode;
 
             // Ignore syntactic sugar for getters and setters.
@@ -93,15 +95,12 @@ module.exports.prototype = {
                 return;
             }
 
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
+
             if (beforeOpeningRoundBrace) {
-                // for a named function, use node.id
-                var functionNode = node.id || node;
-
-                // for a class method
-                if (parent.type === 'MethodDefinition' && parent.key.type === 'Identifier') {
-                    functionNode = parent.key;
-                }
-
                 var functionToken = file.getFirstNodeToken(functionNode);
                 errors.assert.whitespaceBetween({
                     token: functionToken,

--- a/lib/rules/require-spaces-in-named-function-expression.js
+++ b/lib/rules/require-spaces-in-named-function-expression.js
@@ -76,11 +76,23 @@ module.exports.prototype = {
         var beforeOpeningCurlyBrace = this._beforeOpeningCurlyBrace;
 
         file.iterateNodesByType(['FunctionExpression'], function(node) {
+            var functionNode = node.id;
+            var parent = node.parentNode;
 
+            // Ignore syntactic sugar for getters and setters.
+            if (parent.type === 'Property' && (parent.kind === 'get' || parent.kind === 'set')) {
+                return;
+            }
+
+            // shorthand or constructor methods
+            if (parent.method || parent.type === 'MethodDefinition') {
+                functionNode = parent.key;
+            }
+
+            // named function expressions only
             if (node.id) {
-
                 if (beforeOpeningRoundBrace) {
-                    var functionToken = file.getFirstNodeToken(node.id);
+                    var functionToken = file.getFirstNodeToken(functionNode);
                     errors.assert.whitespaceBetween({
                         token: functionToken,
                         nextToken: file.getNextToken(functionToken),

--- a/test/specs/rules/disallow-spaces-in-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-spaces-in-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/disallow-spaces-in-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before round brace in FunctionExpression', function() {
@@ -49,20 +55,47 @@ describe('rules/disallow-spaces-in-function-expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
 
+        it('should not report missing space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y() {} }').isEmpty());
+        });
+
+        it('should report space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
         it('should report space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render () { return 1; } };').getErrorCount() === 1);
         });
 
         it('should not report missing space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render() { return 1; } };').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'extra space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function (){}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'extra space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y (){} }',
+            output: 'var x = { y(){} }'
         });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before curly brace in FunctionExpression', function() {
@@ -91,6 +124,34 @@ describe('rules/disallow-spaces-in-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y(){} }').isEmpty());
+        });
+
+        it('should report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
+        it('should report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').getErrorCount() === 1);
+        });
+
+        reportAndFix({
+            name: 'extra space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function() {}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'extra space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y() {} }',
+            output: 'var x = { y(){} }'
         });
     });
 });

--- a/test/specs/rules/disallow-spaces-in-function.js
+++ b/test/specs/rules/disallow-spaces-in-function.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-spaces-in-function', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/disallow-spaces-in-function', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            disallowSpacesInFunction: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInFunction: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before round brace in Function', function() {
@@ -54,19 +60,46 @@ describe('rules/disallow-spaces-in-function', function() {
         });
 
         it('should report space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render () { return 1; } };').getErrorCount() === 1);
         });
 
         it('should not report missing space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render() { return 1; } };').isEmpty());
+        });
+
+        it('should not report missing space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y() {} }').isEmpty());
+        });
+
+        it('should report space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
+        reportAndFix({
+            name: 'extra space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function (){}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'extra space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y (){} }',
+            output: 'var x = { y(){} }'
         });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            disallowSpacesInFunction: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInFunction: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before curly brace in Function', function() {
@@ -95,6 +128,34 @@ describe('rules/disallow-spaces-in-function', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function (){}').isEmpty());
+        });
+
+        it('should not report missing space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y(){} }').isEmpty());
+        });
+
+        it('should report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').getErrorCount() === 1);
+        });
+
+        it('should report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor() {} }').getErrorCount() === 1);
+        });
+
+        reportAndFix({
+            name: 'extra space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function() {}',
+            output: 'var x = function(){}'
+        });
+
+        reportAndFix({
+            name: 'extra space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y() {} }',
+            output: 'var x = { y(){} }'
         });
     });
 });

--- a/test/specs/rules/disallow-spaces-in-named-function-expression.js
+++ b/test/specs/rules/disallow-spaces-in-named-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/disallow-spaces-in-named-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/disallow-spaces-in-named-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before round brace in named FunctionExpression', function() {
@@ -36,11 +42,32 @@ describe('rules/disallow-spaces-in-named-function-expression', function() {
         it('should not report missing space before round brace in setter expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should not report missing space before round brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y() {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor() {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'illegal space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function a (){}',
+            output: 'var x = function a(){}'
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ disallowSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should not report missing space before curly brace in named FunctionExpression', function() {
@@ -69,6 +96,22 @@ describe('rules/disallow-spaces-in-named-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function a (){}').isEmpty());
+        });
+
+        it('should not report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function a() {}',
+            output: 'var x = function a(){}'
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-function-expression.js
+++ b/test/specs/rules/require-spaces-in-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-spaces-in-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/require-spaces-in-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before round brace in FunctionExpression', function() {
@@ -49,20 +55,47 @@ describe('rules/require-spaces-in-function-expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
 
+        it('should report missing space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y() {} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
         it('should not report space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render () { return 1; } };').isEmpty());
         });
 
         it('should report missing space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render() { return 1; } };').getErrorCount() === 1);
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function (){}'
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y (){} }'
         });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before curly brace in FunctionExpression', function() {
@@ -91,6 +124,34 @@ describe('rules/require-spaces-in-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function() {}').isEmpty());
+        });
+
+        it('should report missing space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y(){} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function() {}'
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y() {} }'
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-function.js
+++ b/test/specs/rules/require-spaces-in-function.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-spaces-in-function', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/require-spaces-in-function', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            requireSpacesInFunction: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInFunction: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before round brace in Function', function() {
@@ -54,19 +60,46 @@ describe('rules/require-spaces-in-function', function() {
         });
 
         it('should not report space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render () { return 1; } };').isEmpty());
         });
 
         it('should report missing space before round brace in class method', function() {
-            checker.configure({ esnext: true });
             assert(checker.checkString('const Component = class { render() { return 1; } };').getErrorCount() === 1);
+        });
+
+        it('should report missing space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y() {} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function (){}'
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y (){} }'
         });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            requireSpacesInFunction: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInFunction: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before curly brace in Function', function() {
@@ -95,6 +128,34 @@ describe('rules/require-spaces-in-function', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function() {}').isEmpty());
+        });
+
+        it('should report missing space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y(){} }').getErrorCount() === 1);
+        });
+
+        it('should not report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function(){}',
+            output: 'var x = function() {}'
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in method shorthand',
+            rules: rules,
+            errors: 1,
+            input: 'var x = { y(){} }',
+            output: 'var x = { y() {} }'
         });
     });
 });

--- a/test/specs/rules/require-spaces-in-named-function-expression.js
+++ b/test/specs/rules/require-spaces-in-named-function-expression.js
@@ -1,5 +1,6 @@
 var Checker = require('../../../lib/checker');
 var assert = require('assert');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-spaces-in-named-function-expression', function() {
     var checker;
@@ -9,8 +10,13 @@ describe('rules/require-spaces-in-named-function-expression', function() {
     });
 
     describe('beforeOpeningRoundBrace', function() {
+        var rules = {
+            requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningRoundBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before round brace in named FunctionExpression', function() {
@@ -36,11 +42,28 @@ describe('rules/require-spaces-in-named-function-expression', function() {
         it('should not report missing space before round brace in setter expression', function() {
             assert(checker.checkString('var x = { set y(v) {} }').isEmpty());
         });
+
+        it('should not report space before round brace in method shorthand #1470', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before round brace in named FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function a(){}',
+            output: 'var x = function a (){}'
+        });
     });
 
     describe('beforeOpeningCurlyBrace', function() {
+        var rules = {
+            requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true },
+            esnext: true
+        };
+
         beforeEach(function() {
-            checker.configure({ requireSpacesInNamedFunctionExpression: { beforeOpeningCurlyBrace: true } });
+            checker.configure(rules);
         });
 
         it('should report missing space before curly brace in named FunctionExpression', function() {
@@ -69,6 +92,22 @@ describe('rules/require-spaces-in-named-function-expression', function() {
 
         it('should not report missing space before round brace without option', function() {
             assert(checker.checkString('var x = function a() {}').isEmpty());
+        });
+
+        it('should not report space before curly brace in method shorthand', function() {
+            assert(checker.checkString('var x = { y () {} }').isEmpty());
+        });
+
+        it('should not report special "constructor" method #1607', function() {
+            assert(checker.checkString('class test { constructor () {} }').isEmpty());
+        });
+
+        reportAndFix({
+            name: 'missing space before curly brace in named FunctionExpression',
+            rules: rules,
+            errors: 1,
+            input: 'var x = function a(){}',
+            output: 'var x = function a() {}'
         });
     });
 });


### PR DESCRIPTION
Fixes jscs-dev/babel-jscs#21

Just copied over the changes
```js
if (parent.method || parent.type === 'MethodDefinition') {
  var functionNode = node.id || node;	
  functionNode = parent.key;
}
```

and copied all the tests over.

~~Still need to do the disallow rules.~~ (Combing functionExpression, anonymousFunctionExpression, namedFunctionExpression as a single rule would be nice)