### PR TITLE
Object property rules: support spread in object literals

### DIFF
--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -63,6 +63,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() {};
 
@@ -134,7 +135,8 @@ module.exports.prototype = {
             var maxKeyEndPos = 0;
             var tokens = [];
             node.properties.forEach(function(property) {
-                if (property.shorthand || property.kind !== 'init' || property._babelType === 'SpreadProperty') {
+                if (property.shorthand || property.kind !== 'init' ||
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/rules/disallow-space-before-object-values.js
+++ b/lib/rules/disallow-space-before-object-values.js
@@ -41,7 +41,8 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                if (property.shorthand || property.method || property.kind !== 'init') {
+                if (property.shorthand || property.method || property.kind !== 'init' ||
+                    property._babelType === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/rules/disallow-space-before-object-values.js
+++ b/lib/rules/disallow-space-before-object-values.js
@@ -22,6 +22,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() {};
 
@@ -42,7 +43,7 @@ module.exports.prototype = {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
                 if (property.shorthand || property.method || property.kind !== 'init' ||
-                    property._babelType === 'SpreadProperty') {
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -33,6 +33,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() {};
 
@@ -71,7 +72,7 @@ module.exports.prototype = {
             var tokens = [];
             var skip = node.properties.some(function(property, index) {
                 if (property.shorthand || property.method || property.kind !== 'init' ||
-                    property._babelType === 'SpreadProperty') {
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return true;
                 }
 

--- a/lib/rules/require-aligned-object-values.js
+++ b/lib/rules/require-aligned-object-values.js
@@ -70,7 +70,8 @@ module.exports.prototype = {
             var minColonPos = 0;
             var tokens = [];
             var skip = node.properties.some(function(property, index) {
-                if (property.shorthand || property.method || property.kind !== 'init') {
+                if (property.shorthand || property.method || property.kind !== 'init' ||
+                    property._babelType === 'SpreadProperty') {
                     return true;
                 }
 

--- a/lib/rules/require-quoted-keys-in-objects.js
+++ b/lib/rules/require-quoted-keys-in-objects.js
@@ -44,7 +44,7 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(prop) {
-                if (prop.shorthand || prop.method || prop.kind !== 'init') {
+                if (prop.shorthand || prop.method || prop.kind !== 'init' || prop._babelType === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/rules/require-quoted-keys-in-objects.js
+++ b/lib/rules/require-quoted-keys-in-objects.js
@@ -25,6 +25,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() { };
 
@@ -43,14 +44,15 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
-            node.properties.forEach(function(prop) {
-                if (prop.shorthand || prop.method || prop.kind !== 'init' || prop._babelType === 'SpreadProperty') {
+            node.properties.forEach(function(property) {
+                if (property.shorthand || property.method || property.kind !== 'init' ||
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return;
                 }
 
-                var key = prop.key;
+                var key = property.key;
                 if (!(typeof key.value === 'string' && key.type === 'Literal')) {
-                    errors.add('Object key without surrounding quotes', prop.loc.start);
+                    errors.add('Object key without surrounding quotes', property.loc.start);
                 }
             });
         });

--- a/lib/rules/require-space-after-object-keys.js
+++ b/lib/rules/require-space-after-object-keys.js
@@ -22,6 +22,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() {};
 
@@ -41,7 +42,8 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
-                if (property.shorthand || property.kind !== 'init' || property._babelType === 'SpreadProperty') {
+                if (property.shorthand || property.kind !== 'init' ||
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/rules/require-space-before-object-values.js
+++ b/lib/rules/require-space-before-object-values.js
@@ -22,6 +22,7 @@
  */
 
 var assert = require('assert');
+var utils = require('../utils');
 
 module.exports = function() {};
 
@@ -42,7 +43,7 @@ module.exports.prototype = {
         file.iterateNodesByType('ObjectExpression', function(node) {
             node.properties.forEach(function(property) {
                 if (property.shorthand || property.method || property.kind !== 'init' ||
-                    property._babelType === 'SpreadProperty') {
+                    utils.getBabelType(property) === 'SpreadProperty') {
                     return;
                 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,6 +160,15 @@ exports.promisify = function(fn) {
 };
 
 /**
+ * Wrapper to encapsulate getting private property for babel type
+ *
+ * @returns {String}
+ */
+exports.getBabelType = function(property) {
+    return property._babelType;
+};
+
+/**
  * All possible binary operators supported by JSCS
  * @type {Array}
  */

--- a/test/specs/rules/disallow-space-before-object-values.js
+++ b/test/specs/rules/disallow-space-before-object-values.js
@@ -57,6 +57,11 @@ describe('rules/disallow-space-before-object-values', function() {
         assert(checker.checkString('var x = { a() { } };').isEmpty());
     });
 
+    it('should not report es7 object spread. Ref #1624', function() {
+        checker.configure({ esnext: true });
+        assert(checker.checkString('var x = { ...a };').isEmpty());
+    });
+
     it('should not report es5 getters/setters #1037', function() {
         assert(checker.checkString('var x = { get a() { } };').isEmpty());
         assert(checker.checkString('var x = { set a(val) { } };').isEmpty());

--- a/test/specs/rules/require-aligned-object-values.js
+++ b/test/specs/rules/require-aligned-object-values.js
@@ -109,6 +109,19 @@ describe('rules/require-aligned-object-values', function() {
             );
         });
 
+        it('should not report es7 object spread. Ref #1624', function() {
+            checker.configure({ esnext: true });
+            assert(
+                checker.checkString(
+                    'var x = {\n' +
+                        'bcd : 2,\n' +
+                        '...a,\n' +
+                        'efg : 2\n' +
+                    '};'
+                ).isEmpty()
+            );
+        });
+
         describe('alignment check for any number of spaces', function() {
             reportAndFix({
                 name: 'illegal object values alignment',

--- a/test/specs/rules/require-quoted-keys-in-objects.js
+++ b/test/specs/rules/require-quoted-keys-in-objects.js
@@ -72,6 +72,11 @@ describe('rules/require-quoted-keys-in-objects', function() {
         assert(checker.checkString('var x = { a() { } };').isEmpty());
     });
 
+    it('should not report es7 object spread. Ref #1624', function() {
+        checker.configure({ esnext: true });
+        assert(checker.checkString('var x = { ...a };').isEmpty());
+    });
+
     it('should not report es5 getters/setters #1037', function() {
         assert(checker.checkString('var x = { get a() { } };').isEmpty());
         assert(checker.checkString('var x = { set a(val) { } };').isEmpty());

--- a/test/specs/utils.js
+++ b/test/specs/utils.js
@@ -2,15 +2,16 @@ var utils = require('../../lib/utils');
 var assert = require('assert');
 var JsFile = require('../../lib/js-file');
 var esprima = require('esprima');
+var babelJscs = require('babel-jscs');
 var path = require('path');
 
 describe('utils', function() {
 
-    function createJsFile(source) {
+    function createJsFile(source, customEsprima) {
         return new JsFile({
             filename: 'example.js',
             source: source,
-            esprima: esprima,
+            esprima: customEsprima || esprima,
             esprimaOptions: {loc: true, range: true, comment: true, tokens: true}
         });
     }
@@ -152,6 +153,14 @@ describe('utils', function() {
                 assert.ok(err);
                 done();
             });
+        });
+    });
+
+    describe('getBabelType', function() {
+        it('returns private property `_babelType`', function() {
+            var file = createJsFile('var a = { ...a };', babelJscs);
+            var property = file.getNodesByType('ObjectExpression')[0].properties[0];
+            assert.equal(utils.getBabelType(property), 'SpreadProperty');
         });
     });
 });


### PR DESCRIPTION
Rules modified:

- disallowSpaceBeforeObjectValues
- requireAlignedObjectValues
- requireQuotedKeysInObjects

Ref #1624

Support the rest of the object property rules that would instead object spread (es7)