### PR TITLE
disallowEmptyBlocks: allow blocks with comments

### DIFF
--- a/lib/rules/disallow-empty-blocks.js
+++ b/lib/rules/disallow-empty-blocks.js
@@ -34,10 +34,21 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            options === true,
-            this.getOptionName() + ' option requires a true value or should be removed'
-        );
+        if (typeof options !== 'object') {
+            assert(
+                options === true,
+                this.getOptionName() + ' option requires a true value or should be removed'
+            );
+
+            var _options = {
+                allExcept: []
+            };
+            return this.configure(_options);
+        }
+
+        if (Array.isArray(options.allExcept)) {
+            this._exceptComments = options.allExcept.indexOf('comments') > -1;
+        }
     },
 
     getOptionName: function() {
@@ -45,14 +56,36 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var exceptComments = this._exceptComments;
+
+        function canSkip(token) {
+            if (!exceptComments) {
+                return false;
+            }
+            var canSkipToken = false;
+            file.getComments().forEach(function(comment) {
+                if (comment.loc.start.line >= token.loc.start.line &&
+                    comment.loc.end.line <= token.loc.end.line) {
+                    canSkipToken = true;
+                }
+            });
+            return canSkipToken;
+        }
+
         file.iterateNodesByType('BlockStatement', function(node) {
-            if (node.body.length === 0 &&
-                node.parentNode.type !== 'CatchClause' &&
+            if (node.body.length) {
+                return true;
+            }
+
+            if (canSkip(node)) {
+                return true;
+            }
+
+            if (node.parentNode.type !== 'CatchClause' &&
                 node.parentNode.type !== 'FunctionDeclaration' &&
                 node.parentNode.type !== 'FunctionExpression') {
                 errors.add('Empty block found', node.loc.end);
             }
         });
     }
-
 };

--- a/lib/rules/disallow-empty-blocks.js
+++ b/lib/rules/disallow-empty-blocks.js
@@ -3,7 +3,11 @@
  *
  * Type: `Boolean`
  *
- * Value: `true`
+ * Values:
+ *  - `true` for default behavior (strict mode, no empty blocks allowed)
+ *  - `Object`:
+ *    - `'allExcept'` array of exceptions:
+ *       - `'comments'` blocks containing only comments are not considered empty
  *
  * JSHint: [`noempty`](http://jshint.com/docs/options/#noempty)
  *

--- a/lib/rules/disallow-empty-blocks.js
+++ b/lib/rules/disallow-empty-blocks.js
@@ -37,7 +37,7 @@ module.exports.prototype = {
         if (typeof options !== 'object') {
             assert(
                 options === true,
-                this.getOptionName() + ' option requires a true value or should be removed'
+                this.getOptionName() + ' option requires a true value or an object like: { allExcept: [\'comments\'] }'
             );
 
             var _options = {

--- a/test/specs/rules/disallow-empty-blocks.js
+++ b/test/specs/rules/disallow-empty-blocks.js
@@ -125,4 +125,37 @@ describe('rules/disallow-empty-blocks', function() {
     it('should not report empty block for function expressions', function() {
         assert(checker.checkString('var a = function(){};').isEmpty());
     });
+
+    describe('options as object', function() {
+        describe('allExcept as option', function() {
+            describe('with value `comments`', function() {
+                beforeEach(function() {
+                    checker = new Checker();
+                    checker.registerDefaultRules();
+                    checker.configure({disallowEmptyBlocks: {allExcept: ['comments']}});
+                });
+                it('should not report empty blocks with comments', function() {
+                    assert(
+                        checker.checkString(
+                          'if (true) { /* comment */ }'
+                        ).isEmpty()
+                    );
+                    assert(
+                        checker.checkString(
+                          'if (true) { \n' +
+                          ' // another comment \n' +
+                          '}'
+                        ).isEmpty()
+                    );
+                    assert(
+                        checker.checkString(
+                          'if (true) { \n' +
+                          ' // another comment \n' +
+                          '} else {}'
+                        ).getErrorCount() === 1
+                    );
+                });
+            });
+        });
+    });
 });

--- a/test/specs/rules/disallow-empty-blocks.js
+++ b/test/specs/rules/disallow-empty-blocks.js
@@ -126,36 +126,32 @@ describe('rules/disallow-empty-blocks', function() {
         assert(checker.checkString('var a = function(){};').isEmpty());
     });
 
-    describe('options as object', function() {
-        describe('allExcept as option', function() {
-            describe('with value `comments`', function() {
-                beforeEach(function() {
-                    checker = new Checker();
-                    checker.registerDefaultRules();
-                    checker.configure({disallowEmptyBlocks: {allExcept: ['comments']}});
-                });
-                it('should not report empty blocks with comments', function() {
-                    assert(
-                        checker.checkString(
-                          'if (true) { /* comment */ }'
-                        ).isEmpty()
-                    );
-                    assert(
-                        checker.checkString(
-                          'if (true) { \n' +
-                          ' // another comment \n' +
-                          '}'
-                        ).isEmpty()
-                    );
-                    assert(
-                        checker.checkString(
-                          'if (true) { \n' +
-                          ' // another comment \n' +
-                          '} else {}'
-                        ).getErrorCount() === 1
-                    );
-                });
-            });
+    describe('allExcept: [\'comments\']', function() {
+        beforeEach(function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({disallowEmptyBlocks: {allExcept: ['comments']}});
+        });
+        it('should not report empty blocks with comments', function() {
+            assert(
+                checker.checkString(
+                  'if (true) { /* comment */ }'
+                ).isEmpty()
+            );
+            assert(
+                checker.checkString(
+                  'if (true) { \n' +
+                  ' // another comment \n' +
+                  '}'
+                ).isEmpty()
+            );
+            assert(
+                checker.checkString(
+                  'if (true) { \n' +
+                  ' // another comment \n' +
+                  '} else {}'
+                ).getErrorCount() === 1
+            );
         });
     });
 });


### PR DESCRIPTION
Requires rule to be configured with `allExcept: ['comments']`

Fixes #1611