### PR TITLE
Docs: Fix a typo in maximumNumberOfLines

### DIFF
--- a/lib/rules/maximum-number-of-lines.js
+++ b/lib/rules/maximum-number-of-lines.js
@@ -4,7 +4,7 @@
  * Type: `Integer`
  *
  * Values:
-*  - `Integer`: file should be at most the number of lines specified
+ * - `Integer`: file should be at most the number of lines specified
  *
  * #### Example
  *


### PR DESCRIPTION
See http://jscs.info/rule/maximumNumberOfLines.html (snapshot: https://github.com/jscs-dev/jscs-dev.github.io/blob/6d3018fd5940236c7ec306ee9e492415078563b2/rule/maximumNumberOfLines.html).