### PR TITLE
Docs: Fix a typo in requireVarDeclFirst

### DIFF
--- a/lib/rules/require-var-decl-first.js
+++ b/lib/rules/require-var-decl-first.js
@@ -98,7 +98,7 @@
  * var a;
  * for(var count=0;count < 10;count++){}
  * ```
-  * ```js
+ * ```js
  * var x;
  * for(var count=0;count < 10;count++){
  *  var y;


### PR DESCRIPTION
See http://jscs.info/rule/requireVarDeclFirst.html (snapshot: https://github.com/jscs-dev/jscs-dev.github.io/blob/6d3018fd5940236c7ec306ee9e492415078563b2/rule/requireVarDeclFirst.html).