### PR TITLE
Docs: Update documentation of disallowKeywordsOnNewLine, requirePaddingNewlinesBeforeKeywords, requirePaddingNewlinesInBlocks, requireVarDeclFirst

### DIFF
--- a/lib/rules/disallow-keywords-on-new-line.js
+++ b/lib/rules/disallow-keywords-on-new-line.js
@@ -1,9 +1,11 @@
 /**
  * Disallows placing keywords on a new line.
  *
- * Type: `Array`
+ * Types: `Array`
  *
- * Values: Array of quoted keywords
+ * Values:
+ *
+ * - `Array` specifies quoted keywords which are disallowed from being placed on a new line
  *
  * #### Example
  *

--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -1,9 +1,12 @@
 /**
  * Requires an empty line above the specified keywords unless the keyword is the first expression in a block.
  *
- * Types: `Array` or `Boolean`
+ * Types: `Boolean` or `Array`
  *
- * Values: Array of quoted types or `true` to require padding new lines before all of the keywords below.
+ * Values:
+ *
+ * - `true` specifies that the spacedKeywords found in the utils module require an empty line above it
+ * - `Array` specifies quoted keywords which require an empty line above it
  *
  * #### Example
  *
@@ -12,21 +15,12 @@
  *     "do",
  *     "for",
  *     "if",
- *     "else",
- *     "switch",
- *     "case",
- *     "try",
- *     "catch",
- *     "void",
- *     "while",
- *     "with",
- *     "return",
- *     "typeof",
- *     "function"
+ *     "else"
+ *     // etc
  * ]
  * ```
  *
- * ##### Valid
+ * ##### Valid for mode `true`
  *
  * ```js
  * function(a) {
@@ -40,6 +34,9 @@
  *         }
  *     }
  *
+ *     while (a) {
+ *         a = false;
+ *     }
  *     return true;
  * }
  * ```
@@ -56,9 +53,52 @@
  *             return false;
  *         }
  *     }
+ *     while (a) {
+ *         a = false;
+ *     }
  *     return true;
  * }
  * ```
+ *
+ * ##### Valid for mode `['if', for']`
+ *
+ * ```js
+ * function(a) {
+ *     if (!a) {
+ *         return false;
+ *     }
+ *
+ *     for (var i = 0; i < b; i++) {
+ *         if (!a[i]) {
+ *             return false;
+ *         }
+ *     }
+ *     while (a) {
+ *         a = false;
+ *     }
+ *     return true;
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function(a) {
+ *     if (!a) {
+ *         return false;
+ *     }
+ *     for (var i = 0; i < b; i++) {
+ *         if (!a[i]) {
+ *             return false;
+ *         }
+ *     }
+ *     while (a) {
+ *         a = false;
+ *     }
+ *     return true;
+ * }
+ * ```
+ *
  */
 
 var assert = require('assert');

--- a/lib/rules/require-padding-newlines-in-blocks.js
+++ b/lib/rules/require-padding-newlines-in-blocks.js
@@ -1,18 +1,22 @@
 /**
  * Requires blocks to begin and end with 2 newlines
  *
- * Types: `Boolean` or `Integer`
+ * Types: `Boolean`, `Integer`, `Object`
  *
- * Values: `true` validates all non-empty blocks,
- * `Integer` specifies a minimum number of statements in the block before validating.
+ * Values:
+ *  - `true` validates all non-empty blocks
+ *  - `Integer` specifies a minimum number of lines containing elements in the block before validating
+ *  - `Object` (at least one of properties must be true):
+ *      - `'open'`
+ *          - `true` validates that there is a newline after the opening brace in a block
+ *          - `false` ignores the newline validation after the opening brace in a block
+ *      - `'close'`
+ *          - `true` validates that there is a newline before the closing brace in a block
+ *          - `false` ignores the newline validation before the closing brace in a block
  *
  * #### Example
  *
  * ```js
- * "requirePaddingNewlinesInBlocks": true
- * "requirePaddingNewlinesInBlocks": 1
- * "requirePaddingNewlinesInBlocks": { "open": true, "close": true }
- * "requirePaddingNewlinesInBlocks": { "open": false, "close": true }
  * "requirePaddingNewlinesInBlocks": { "open": true, "close": false }
  * ```
  *

--- a/lib/rules/require-var-decl-first.js
+++ b/lib/rules/require-var-decl-first.js
@@ -3,10 +3,9 @@
  *
  * Types: `Boolean`
  *
- * Values: `true`
+ * Values:
  *
- * if `requireVarDeclFirst` defined as a `true` value, it will report errors of `var` declarations that
- * does not appear on the top of a function scope.
+ * - `true` specifies that `var` declarations must occur the top of a function scope.
  *
  * #### Example
  *
@@ -14,7 +13,7 @@
  * "requireVarDeclFirst": true
  * ```
  *
- * ##### Valid
+ * ##### Valid for mode `true`
  *
  * ```js
  * var x = 1,


### PR DESCRIPTION
Updating the type, value and example sections of the 4 rules stated in the subject to be consistent with other rule. I left it as 4 commits in the PR since I am modifying different rules. I can squash it if required.

It would be great to have some feedback on requirePaddingNewlinesBeforeKeywords as it has a default array list that is too big to fit into the value section. As I could not find an existing rule with a long list in the documentation. I left it in the example section and reference it in the description.

    * Values:
    *
    * - `true` specifies that the default keywords shown in the example require an empty line above it
    * - `Array` specifies quoted keywords which require an empty line above it
    *
    * #### Example
    *
    * ```js
    * "requirePaddingNewlinesBeforeKeywords": [
    *     "do",
    *     "for",
    *     "if",
    *     "else",
    *     "switch",
    *     "case",
    *     "try",
    *     "catch",
    *     "void",
    *     "while",
    *     "with",
    *     "return",
    *     "typeof",
    *     "function"
    * ]
    * ```