### PR TITLE
Add exceptions for (require|disallow)PaddingNewlinesInBlocks and add open/close newline padding options

### DIFF
--- a/lib/rules/disallow-padding-newlines-in-blocks.js
+++ b/lib/rules/disallow-padding-newlines-in-blocks.js
@@ -1,17 +1,31 @@
 /**
  * Disallows blocks from beginning or ending with 2 newlines.
  *
- * Type: `Boolean`
+ * Type: `Boolean` or `Object`
  *
- * Value: `true` validates all non-empty blocks.
+ * Values:
+ *  - `true` validates all non-empty blocks.
+ *  - `Object`:
+ *     - `'open'`
+*          - `true` validates that there is a newline after the opening brace in a block
+*          - `false` ignores the newline validation after the opening brace in a block
+ *     - `'close'`
+ *          - `true` validates that there is a newline before the closing brace in a block
+ *          - `false` ignores the newline validation before the closing brace in a block
+ *     - `'allExcept'` array of exceptions:
+ *          - `'conditionals'` ignores conditional (if, else if, else) blocks
+ *          - `'functions'` ignores function blocks
  *
  * #### Example
  *
  * ```js
  * "disallowPaddingNewlinesInBlocks": true
+ * "disallowPaddingNewlinesInBlocks": { "open": true, "close": false }
+ * "disallowPaddingNewlinesInBlocks": { "allExcept": [ "conditionals" ] }
+ * "disallowPaddingNewlinesInBlocks": { "open": true, "close": false, allExcept: ['conditionals'] }
  * ```
  *
- * ##### Valid
+ * ##### Valid for `true`
  *
  * ```js
  * if (true) {
@@ -19,6 +33,44 @@
  * }
  * if (true) {doSomething();}
  * var abc = function() {};
+ * ```
+ *
+ * ##### Valid for mode `{ "open": true, "close": false }`
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *
+ * }
+ * ```
+ *
+ * ##### Valid for `{ allExcept: ['conditionals'] }`
+ *
+ * ```js
+ * if (true) {
+ *
+ *     doSomething();
+ *
+ * }
+ *
+ * function (foo) {
+ *     return bar;
+ * }
+ * ```
+ *
+ * ##### Valid for `{  "open": true, "close": false, allExcept: ['conditionals'] }`
+ *
+ * ```js
+ * function (foo) {
+ *     return bar;
+ *
+ * }
+ *
+ * if (true) {
+ *
+ *     doSomething();
+ *
+ * }
  * ```
  *
  * ##### Invalid
@@ -39,10 +91,34 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            options === true,
-            this.getOptionName() + ' option requires a true value or should be removed'
-        );
+        var optionName = this.getOptionName();
+
+        this._checkOpen = true;
+        this._checkClose = true;
+
+        if (typeof options === 'object') {
+            assert(options.allExcept || options.open || options.close,
+            optionName + 'option requires either "open", "close", "allExcept"');
+
+            if (options.allExcept) {
+                assert(Array.isArray(options.allExcept), optionName + ' option requires "allExcept" to be an array');
+                assert(options.allExcept.length > 0, optionName + ' option requires "allExcept" to have at least one ' +
+                'item or be set to `true`');
+                this._exceptConditionals = options.allExcept.indexOf('conditionals') > -1;
+                this._exceptFunctions = options.allExcept.indexOf('functions') > -1;
+            }
+
+            if (options.open || options.close) {
+                assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
+                  this.getOptionName() + ' option requires the "open" and "close" ' +
+                  'properties to be booleans');
+
+                this._checkOpen = options.open;
+                this._checkClose = options.close;
+            }
+        } else {
+            assert(options === true, this.getOptionName() + ' option requires either a true value, or an object');
+        }
     },
 
     getOptionName: function() {
@@ -50,24 +126,42 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var exceptConditionals = this._exceptConditionals;
+        var exceptFunctions = this._exceptFunctions;
+        var checkOpen = this._checkOpen;
+        var checkClose = this._checkClose;
+
         file.iterateNodesByType('BlockStatement', function(node) {
-            var openingBracket = file.getFirstNodeToken(node);
+            var openingBracket;
+            var closingBracket;
 
-            errors.assert.linesBetween({
-                token: openingBracket,
-                nextToken: file.getNextToken(openingBracket, {includeComments: true}),
-                atMost: 1,
-                message: 'Expected no padding newline after opening curly brace'
-            });
+            if (exceptConditionals && node.parentNode.type === 'IfStatement' ||
+                exceptFunctions && (node.parentNode.type === 'FunctionExpression' ||
+                node.parentNode.type === 'FunctionDeclaration')) {
+                return;
+            }
 
-            var closingBracket = file.getLastNodeToken(node);
+            if (checkOpen === true) {
+                openingBracket = file.getFirstNodeToken(node);
 
-            errors.assert.linesBetween({
-                token: file.getPrevToken(closingBracket, {includeComments: true}),
-                nextToken: closingBracket,
-                atMost: 1,
-                message: 'Expected no padding newline before closing curly brace'
-            });
+                errors.assert.linesBetween({
+                    token: openingBracket,
+                    nextToken: file.getNextToken(openingBracket, {includeComments: true}),
+                    atMost: 1,
+                    message: 'Expected no padding newline after opening curly brace'
+                });
+            }
+
+            if (checkClose === true) {
+                closingBracket = file.getLastNodeToken(node);
+
+                errors.assert.linesBetween({
+                    token: file.getPrevToken(closingBracket, {includeComments: true}),
+                    nextToken: closingBracket,
+                    atMost: 1,
+                    message: 'Expected no padding newline before closing curly brace'
+                });
+            }
         });
     }
 

--- a/lib/rules/require-padding-newlines-in-blocks.js
+++ b/lib/rules/require-padding-newlines-in-blocks.js
@@ -13,11 +13,18 @@
  *      - `'close'`
  *          - `true` validates that there is a newline before the closing brace in a block
  *          - `false` ignores the newline validation before the closing brace in a block
+ *      - `'allExcept'` array of exceptions:
+ *          - `'conditionals'` ignores conditional (if, else if, else) blocks
+ *          - `'functions'` ignores function blocks
  *
  * #### Example
  *
  * ```js
+ * "requirePaddingNewlinesInBlocks": true
+ * "requirePaddingNewlinesInBlocks": 1
  * "requirePaddingNewlinesInBlocks": { "open": true, "close": false }
+ * "requirePaddingNewlinesInBlocks": { "allExcept": [ "conditionals" ] }
+ * "requirePaddingNewlinesInBlocks": { "open": true, "close": false, allExcept: ['conditionals'] }
  * ```
  *
  * ##### Valid for mode `true` or `{ "open": true, "close": true }`
@@ -66,30 +73,7 @@
  * }
  *  ```
  *
- * ##### Valid for mode `{ "open": false, "close": true }`
- *
- * ```js
- * if (true) {
- *     doSomething();
- *
- * }
- * var abc = function() {};
- * ```
- *
- * ##### Invalid
- *
- * ```js
- * if (true) {doSomething();}
- * if (true) {
- *     doSomething();
- * }
- * if (true) {
- *
- *     doSomething();
- * }
- * ```
- *
-  * ##### Valid for mode `{ "open": true, "close": false }`
+ * ##### Valid for mode `{ "open": true, "close": false }`
  *
  * ```js
  * if (true) {
@@ -112,6 +96,49 @@
  * }
  * ```
  *
+ * ##### Valid for `{ allExcept: ['conditionals'] }`
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ * }
+ *
+ * function (foo) {
+ *
+ *     return bar;
+ *
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function (foo) {
+ *     return bar;
+ * }
+ * ```
+ *
+ * ##### Valid for `{  "open": true, "close": false, allExcept: ['conditionals'] }`
+ *
+ * ```js
+ * function (foo) {
+ *
+ *     return bar;
+ * }
+ *
+ * if (true) {
+ *     doSomething();
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function (foo) {
+ *     return bar;
+ *
+ * }
+ * ```
  */
 
 var assert = require('assert');
@@ -121,27 +148,41 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
+        var optionName = this.getOptionName();
+
         assert(
             options === true || typeof options === 'number' || typeof options === 'object',
-            this.getOptionName() + ' option requires the value true, an Integer or an object'
+            optionName + ' option requires the value true, an Integer or an object'
         );
 
         this._checkOpen = true;
         this._checkClose = true;
         this._minStatements = 0;
+
         if (typeof options === 'object') {
-            assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
-                this.getOptionName() + ' option requires the "open" and "close" ' +
-                 'properties to be booleans');
+            assert(options.allExcept || options.open || options.close,
+            optionName + 'option requires either "open", "close", "allExcept"');
 
-            assert(options.open || options.close,
-                this.getOptionName() + ' option requires either one of  the "open" and "close" ' +
-                 'properties to be true');
+            if (options.allExcept) {
+                assert(Array.isArray(options.allExcept), optionName + ' option requires "allExcept" to be an array');
+                assert(options.allExcept.length > 0, optionName + ' option requires "allExcept" to have at least one ' +
+                'item or be set to `true`');
+                this._exceptConditionals = options.allExcept.indexOf('conditionals') > -1;
+                this._exceptFunctions = options.allExcept.indexOf('functions') > -1;
+            }
 
-            this._checkOpen = options.open;
-            this._checkClose = options.close;
+            if (options.open || options.close) {
+                assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
+                  this.getOptionName() + ' option requires the "open" and "close" ' +
+                  'properties to be booleans');
+
+                this._checkOpen = options.open;
+                this._checkClose = options.close;
+            }
         } else if (typeof options === 'number') {
             this._minStatements = options;
+        } else {
+            assert(options === true, this.getOptionName() + ' option requires either a true value, or an object');
         }
     },
 
@@ -151,16 +192,27 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var minStatements = this._minStatements;
+        var exceptConditionals = this._exceptConditionals;
+        var exceptFunctions = this._exceptFunctions;
         var checkOpen = this._checkOpen;
         var checkClose = this._checkClose;
 
         file.iterateNodesByType('BlockStatement', function(node) {
+            var openingBracket;
+            var closingBracket;
+
             if (node.body.length <= minStatements) {
                 return;
             }
 
+            if (exceptConditionals && node.parentNode.type === 'IfStatement' ||
+                exceptFunctions && (node.parentNode.type === 'FunctionExpression' ||
+                node.parentNode.type === 'FunctionDeclaration')) {
+                return;
+            }
+
             if (checkOpen === true) {
-                var openingBracket = file.getFirstNodeToken(node);
+                openingBracket = file.getFirstNodeToken(node);
 
                 errors.assert.linesBetween({
                     token: openingBracket,
@@ -171,7 +223,7 @@ module.exports.prototype = {
             }
 
             if (checkClose === true) {
-                var closingBracket = file.getLastNodeToken(node);
+                closingBracket = file.getLastNodeToken(node);
 
                 errors.assert.linesBetween({
                     token: file.getPrevToken(closingBracket, {includeComments: true}),

--- a/test/specs/rules/disallow-padding-newlines-in-blocks.js
+++ b/test/specs/rules/disallow-padding-newlines-in-blocks.js
@@ -3,58 +3,317 @@ var assert = require('assert');
 
 describe('rules/disallow-padding-newlines-in-blocks', function() {
     var checker;
+    var trueConfig = [
+      true,
+      { open: true, close: true }
+    ];
+
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ disallowPaddingNewlinesInBlocks: true });
     });
 
-    it('should not report missing newline after opening brace', function() {
-        assert(checker.checkString('if (true) {abc();\n}').isEmpty());
+    trueConfig.forEach(function(config) {
+        describe(config, function() {
+            beforeEach(function() {
+                checker.configure({ disallowPaddingNewlinesInBlocks: config });
+            });
+
+            it('should not report missing newline after opening brace', function() {
+                assert(checker.checkString('if (true) {abc();\n}').isEmpty());
+            });
+
+            it('should not report missing newline before closing brace', function() {
+                assert(checker.checkString('if (true) {\nabc();}').isEmpty());
+            });
+
+            it('should report extra padding newline after opening brace', function() {
+                assert(checker.checkString('if (true) {\n\nabc();\n}').getErrorCount() === 1);
+            });
+
+            it('should report extra padding newline before closing brace', function() {
+                assert(checker.checkString('if (true) {\nabc();\n\n}').getErrorCount() === 1);
+            });
+
+            it('should report extra padding newlines in both cases', function() {
+                assert(checker.checkString('if (true) {\n\nabc();\n\n}').getErrorCount() === 2);
+            });
+
+            it('should not report with no spaces', function() {
+                assert(checker.checkString('if (true) {\nabc();\n}').isEmpty());
+            });
+
+            it('should not report with no spaces in allman style', function() {
+                assert(checker.checkString('if (true)\n{\nabc();\n}').isEmpty());
+            });
+
+            it('should not report with comment on first line', function() {
+                assert(checker.checkString('if (true) {\n//comment\nabc();\n}').isEmpty());
+            });
+
+            it('should not report with multi-line comment on first line', function() {
+                assert(checker.checkString('if (true) {\n/*\ncomment\n*/\nabc();\n}').isEmpty());
+            });
+
+            it('should not report single line empty function definitions', function() {
+                assert(checker.checkString('var a = function() {};').isEmpty());
+            });
+
+            it('should not report multiline empty function definitions', function() {
+                assert(checker.checkString('var a = function() {\n};').isEmpty());
+            });
+
+            it('should report extra padding newline followed by comments', function() {
+                assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n}').getErrorCount() === 1);
+            });
+
+            it('should report extra padding newline preceded by comments', function() {
+                assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n\n}').getErrorCount() === 1);
+            });
+
+            it('should report extra padding newlines in both cases with comments', function() {
+                assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n\n}').getErrorCount() === 2);
+            });
+
+            it('should not report leading nor trailing comments', function() {
+                assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n}').isEmpty());
+            });
+
+            it('should report padding newline even when there is newline after block', function() {
+                assert(checker.checkString('if (true) {\n\nvar x = 5;\n}\n\nif (true) {}').getErrorCount() === 1);
+            });
+        });
     });
-    it('should not report missing newline before closing brace', function() {
-        assert(checker.checkString('if (true) {\nabc();}').isEmpty());
+
+    describe('open: true, close: false', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: { open: true, close: false } });
+        });
+
+        it('should not report extra padding newline before closing brace', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n}').isEmpty());
+        });
+
+        it('should report extra padding newline after opening brace', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n}').getErrorCount() === 1);
+        });
     });
-    it('should report extra padding newline after opening brace', function() {
-        assert(checker.checkString('if (true) {\n\nabc();\n}').getErrorCount() === 1);
+
+    describe('open: false, close: true', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: { open: false, close: true } });
+        });
+
+        it('should report extra padding newline before closing brace', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n}').getErrorCount() === 1);
+        });
+
+        it('should not report extra padding newline after opening brace', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n}').isEmpty());
+        });
     });
-    it('should report extra padding newline before closing brace', function() {
-        assert(checker.checkString('if (true) {\nabc();\n\n}').getErrorCount() === 1);
+
+    describe('allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: { allExcept: ['conditionals'] } });
+        });
+
+        it('should not report extra padding newline after opening brace of if statement', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n}').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of if statement', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n}').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of else statement', function() {
+            assert(checker.checkString('if (true) {} else {\n\nabc();\n}').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of else statement', function() {
+            assert(checker.checkString('if (true) {} else {\nabc();\n\n}').isEmpty());
+        });
+
+        it('should report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').getErrorCount() === 1);
+        });
     });
-    it('should report extra padding newlines in both cases', function() {
-        assert(checker.checkString('if (true) {\n\nabc();\n\n}').getErrorCount() === 2);
+
+    describe('allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: { allExcept: ['functions'] } });
+        });
+
+        it('should not report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should report extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').getErrorCount() === 1);
+        });
     });
-    it('should not report with no spaces', function() {
-        assert(checker.checkString('if (true) {\nabc();\n}').isEmpty());
+
+    describe('open: true, close: false, allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: {
+              open: true,
+              close: false,
+              allExcept: ['functions'] }
+            });
+        });
+
+        it('should not report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should report extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').getErrorCount() === 1);
+        });
+
+        it('should not report extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
     });
-    it('should not report with no spaces in allman style', function() {
-        assert(checker.checkString('if (true)\n{\nabc();\n}').isEmpty());
+
+    describe('open: false, close: true, allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: {
+              open: false,
+              close: true,
+              allExcept: ['functions'] }
+            });
+        });
+
+        it('should not report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+
+        it('should report extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').getErrorCount() === 1);
+        });
     });
-    it('should not report with comment on first line', function() {
-        assert(checker.checkString('if (true) {\n//comment\nabc();\n}').isEmpty());
+
+    describe('open: true, close: false, allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: {
+              open: true,
+              close: false,
+              allExcept: ['conditionals'] }
+            });
+        });
+
+        it('should report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').getErrorCount() === 1);
+        });
+
+        it('should not report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
     });
-    it('should not report with multi-line comment on first line', function() {
-        assert(checker.checkString('if (true) {\n/*\ncomment\n*/\nabc();\n}').isEmpty());
-    });
-    it('should not report single line empty function definitions', function() {
-        assert(checker.checkString('var a = function() {};').isEmpty());
-    });
-    it('should not report multiline empty function definitions', function() {
-        assert(checker.checkString('var a = function() {\n};').isEmpty());
-    });
-    it('should report extra padding newline followed by comments', function() {
-        assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n}').getErrorCount() === 1);
-    });
-    it('should report extra padding newline preceded by comments', function() {
-        assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n\n}').getErrorCount() === 1);
-    });
-    it('should report extra padding newlines in both cases with comments', function() {
-        assert(checker.checkString('if (true) {\n\n//comment\n\n/* comments */\n\n}').getErrorCount() === 2);
-    });
-    it('should not report leading nor trailing comments', function() {
-        assert(checker.checkString('if (true) {\n//comment\n\n/* comments */\n}').isEmpty());
-    });
-    it('should report padding newline even when there is newline after block', function() {
-        assert(checker.checkString('if (true) {\n\nvar x = 5;\n}\n\nif (true) {}').getErrorCount() === 1);
+
+    describe('open: false, close: true, allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ disallowPaddingNewlinesInBlocks: {
+              open: false,
+              close: true,
+              allExcept: ['conditionals'] }
+            });
+        });
+
+        it('should not report extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should not report extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;}').isEmpty());
+        });
+
+        it('should report extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {return bar;\n\n};').getErrorCount() === 1);
+        });
+
+        it('should report extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {return bar;\n\n};').getErrorCount() === 1);
+        });
+
+        it('should not report extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+
+        it('should not report extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
     });
 });

--- a/test/specs/rules/require-padding-newlines-in-blocks.js
+++ b/test/specs/rules/require-padding-newlines-in-blocks.js
@@ -259,4 +259,209 @@ describe('rules/require-padding-newlines-in-blocks', function() {
             });
         });
     });
+
+    describe('allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: { allExcept: ['conditionals'] } });
+        });
+
+        it('should not report missing extra padding newline after opening brace of if statement', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after closing brace of if statement', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of else statement', function() {
+            assert(checker.checkString('if (true) {} else {\nabc();\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after closing brace of else statement', function() {
+            assert(checker.checkString('if (true) {} else {\n\nabc();\n}').isEmpty());
+        });
+
+        it('should report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nnreturn bar;\n\n}').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n}').getErrorCount() === 1);
+        });
+    });
+
+    describe('allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: { allExcept: ['functions'] } });
+        });
+
+        it('should not report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should report missing extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').getErrorCount() === 1);
+        });
+
+    });
+
+    describe('open: true, close: false, allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: {
+              open: true,
+              close: false,
+              allExcept: ['functions'] }
+            });
+        });
+
+        it('should not report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should report missing extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').getErrorCount() === 1);
+        });
+
+        it('should not report missing extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+    });
+
+    describe('open: false, close: true, allExcept: ["functions"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: {
+              open: false,
+              close: true,
+              allExcept: ['functions'] }
+            });
+        });
+
+        it('should not report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
+
+        it('should report missing extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').getErrorCount() === 1);
+        });
+    });
+
+    describe('open: true, close: false, allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: {
+              open: true,
+              close: false,
+              allExcept: ['conditionals'] }
+            });
+        });
+
+        it('should report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nreturn bar;\n\n}').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').getErrorCount() === 1);
+        });
+
+        it('should not report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+    });
+
+    describe('open: false, close: true, allExcept: ["conditionals"]', function() {
+        beforeEach(function() {
+            checker.configure({ requirePaddingNewlinesInBlocks: {
+              open: false,
+              close: true,
+              allExcept: ['conditionals'] }
+            });
+        });
+
+        it('should not report missing extra padding newline after opening brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should not report missing extra padding newline after opening brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\nreturn bar;\n\n}').isEmpty());
+        });
+
+        it('should report missing extra padding newline before closing brace of function declaration', function() {
+            assert(checker.checkString('function foo() {\n\nreturn bar;\n};').getErrorCount() === 1);
+        });
+
+        it('should report missing extra padding newline before closing brace of function expression', function() {
+            assert(checker.checkString('var foo = function() {\n\nreturn bar;\n};').getErrorCount() === 1);
+        });
+
+        it('should not report missing extra padding newline after opening brace of conditional', function() {
+            assert(checker.checkString('if (true) {\nabc();\n\n};').isEmpty());
+        });
+
+        it('should not report missing extra padding newline before closing brace of conditional', function() {
+            assert(checker.checkString('if (true) {\n\nabc();\n};').isEmpty());
+        });
+    });
 });


### PR DESCRIPTION
Fixes #1596

Adds exceptions to (require|disallow)PaddingNewlinesInBlocks for functions & conditionals to allow them to be set independently.

Added open/close newline padding options to disallowPaddingNewlinesInBlocks for better continuity with requirePaddingNewlinesInBlocks, but left out the minimum statements option because it doesn't make sense in the context of the disallowPaddingNewlinesInBlocks rule.