### PR TITLE
requirePaddingNewlinesInBlocks: Rename internal variable

### DIFF
--- a/lib/rules/require-padding-newlines-in-blocks.js
+++ b/lib/rules/require-padding-newlines-in-blocks.js
@@ -128,7 +128,7 @@ module.exports.prototype = {
 
         this._checkOpen = true;
         this._checkClose = true;
-        this._minStatements = 0;
+        this._minLines = 0;
         if (typeof options === 'object') {
             assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
                 this.getOptionName() + ' option requires the "open" and "close" ' +
@@ -141,7 +141,7 @@ module.exports.prototype = {
             this._checkOpen = options.open;
             this._checkClose = options.close;
         } else if (typeof options === 'number') {
-            this._minStatements = options;
+            this._minLines = options;
         }
     },
 
@@ -150,12 +150,12 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        var minStatements = this._minStatements;
+        var minLines = this._minLines;
         var checkOpen = this._checkOpen;
         var checkClose = this._checkClose;
 
         file.iterateNodesByType('BlockStatement', function(node) {
-            if (node.body.length <= minStatements) {
+            if (node.body.length <= minLines) {
                 return;
             }
 


### PR DESCRIPTION
Rename internal variables minStatements and _minStatements to
minLines and _minLines. This makes the variable reflect it's purpose better
and fit the explaination of its documentation

Fixes #1668