### PR TITLE
requireTrailingComma: typo

### DIFF
--- a/lib/rules/require-trailing-comma.js
+++ b/lib/rules/require-trailing-comma.js
@@ -103,7 +103,7 @@ module.exports.prototype = {
             errors.assert.tokenBefore({
                 token: closingToken,
                 expectedTokenBefore: {type: 'Punctuator', value: ','},
-                message: 'Missing comma before closing ' + (isObject ? ' curly brace' : ' bracket')
+                message: 'Missing comma before closing ' + (isObject ? 'curly brace' : 'bracket')
             });
         });
     }


### PR DESCRIPTION
Fixing a double space in error's message.