### PR TITLE
requirePaddingNewLinesAfterBlocks: do not report arrow fn chaining

### DIFF
--- a/lib/rules/require-padding-newlines-after-blocks.js
+++ b/lib/rules/require-padding-newlines-after-blocks.js
@@ -123,7 +123,8 @@ var excludes = {
     'DoWhileStatement': ['while'],
     'TryStatement': ['catch', 'finally'],
     'CatchClause': ['finally'],
-    'FunctionExpression': ['.']
+    'FunctionExpression': ['.'],
+    'ArrowFunctionExpression': [')']
 };
 
 function isException(parent, exceptions) {
@@ -209,7 +210,8 @@ module.exports.prototype = {
                 if (nextToken.type === 'Punctuator' && (
                     nextToken.value === '}' ||
                     nextToken.value === ']' ||
-                    nextToken.value === ')')) {
+                    nextToken.value === ')')
+                ) {
                     return;
                 }
 

--- a/test/specs/rules/require-padding-newlines-after-blocks.js
+++ b/test/specs/rules/require-padding-newlines-after-blocks.js
@@ -263,4 +263,19 @@ describe('rules/require-padding-newlines-after-blocks', function() {
             assert(checker.checkString('[\n2,\n3,\nfunction() {\n},\nfunction() {\n}\n]').isEmpty());
         });
     });
+
+    describe('esnext', function() {
+        beforeEach(function() {
+            checker = new Checker();
+            checker.registerDefaultRules();
+            checker.configure({
+                requirePaddingNewLinesAfterBlocks: true,
+                esnext: true
+            });
+        });
+
+        it('should not report arrow chain (#1700)', function() {
+            assert(checker.checkString('a(res => {\n})\n.b();').isEmpty());
+        });
+    });
 });


### PR DESCRIPTION
Fixes #1700