### PR TITLE
New Rule: requirePaddingNewlinesInFunctionExpressions

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -870,6 +870,7 @@ Configuration.prototype.registerDefaultRules = function() {
 
     this.registerRule(require('../rules/disallow-padding-newlines-in-blocks'));
     this.registerRule(require('../rules/require-padding-newlines-in-blocks'));
+    this.registerRule(require('../rules/require-padding-newlines-in-function-expressions'));
     this.registerRule(require('../rules/require-padding-newlines-in-objects'));
     this.registerRule(require('../rules/disallow-padding-newlines-in-objects'));
     this.registerRule(require('../rules/require-newline-before-block-statements'));

--- a/lib/rules/require-padding-newlines-in-function-expressions.js
+++ b/lib/rules/require-padding-newlines-in-function-expressions.js
@@ -1,0 +1,185 @@
+/**
+ * Requires function's expressions to begin and end with 2 newlines
+ *
+ * Types: `Boolean`, `Integer`, `Object`
+ *
+ * Values:
+ *  - `true` validates all non-empty function's expressions
+ *  - `Integer` specifies a minimum number of lines containing elements in the function's expression before validating
+ *  - `Object` (at least one of properties must be true):
+ *      - `'open'`
+ *          - `true` validates that there is a newline after the opening brace in a function's expression
+ *          - `false` ignores the newline validation after the opening brace in a function's expression
+ *      - `'close'`
+ *          - `true` validates that there is a newline before the closing brace in a function's expression
+ *          - `false` ignores the newline validation before the closing brace in a function's expression
+ *
+ * #### Example
+ *
+ * ```js
+ * "requirePaddingNewlinesInFunctionExpressions": { "open": true, "close": false }
+ * ```
+ *
+ * ##### Valid for mode `true` or `{ "open": true, "close": true }`
+ *
+ * ```js
+ * if (true) {
+ *
+ *     doSomething();
+ *
+ * }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) {doSomething();}
+ * if (true) {
+ *     doSomething();
+ * }
+ * ```
+ *
+ * ##### Valid for mode `1`
+ *
+ * ```js
+ * if (true) {
+ *
+ *     doSomething();
+ *     doSomethingElse();
+ *
+ * }
+ * if (true) {
+ *     doSomething();
+ * }
+ * if (true) { doSomething(); }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) { doSomething(); doSomethingElse(); }
+ * if (true) {
+ *     doSomething();
+ *     doSomethingElse();
+ * }
+ *  ```
+ *
+ * ##### Valid for mode `{ "open": false, "close": true }`
+ *
+ * ```js
+ * if (true) {
+ *     doSomething();
+ *
+ * }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) {doSomething();}
+ * if (true) {
+ *     doSomething();
+ * }
+ * if (true) {
+ *
+ *     doSomething();
+ * }
+ * ```
+ *
+  * ##### Valid for mode `{ "open": true, "close": false }`
+ *
+ * ```js
+ * if (true) {
+ *
+ *     doSomething();
+ * }
+ * var abc = function() {};
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * if (true) {doSomething();}
+ * if (true) {
+ *     doSomething();
+ * }
+ * if (true) {
+ *     doSomething();
+ *
+ * }
+ * ```
+ *
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true || typeof options === 'number' || typeof options === 'object',
+            this.getOptionName() + ' option requires the value true, an Integer or an object'
+        );
+
+        this._checkOpen = true;
+        this._checkClose = true;
+        this._minStatements = 0;
+        if (typeof options === 'object') {
+            assert(typeof options.open === 'boolean' && typeof options.close === 'boolean',
+                this.getOptionName() + ' option requires the "open" and "close" ' +
+                 'properties to be booleans');
+
+            assert(options.open || options.close,
+                this.getOptionName() + ' option requires either one of  the "open" and "close" ' +
+                 'properties to be true');
+
+            this._checkOpen = options.open;
+            this._checkClose = options.close;
+        } else if (typeof options === 'number') {
+            this._minStatements = options;
+        }
+    },
+
+    getOptionName: function() {
+        return 'requirePaddingNewlinesInFunctionExpressions';
+    },
+
+    check: function(file, errors) {
+        var minStatements = this._minStatements;
+        var checkOpen = this._checkOpen;
+        var checkClose = this._checkClose;
+
+        file.iterateNodesByType('FunctionExpression', function(node) {
+            if (node.body.length <= minStatements) {
+                return;
+            }
+
+            if (checkOpen === true) {
+                var openingBracket = file.getFirstNodeToken(node);
+
+                errors.assert.linesBetween({
+                    token: openingBracket,
+                    nextToken: file.getNextToken(openingBracket, {includeComments: true}),
+                    atLeast: 2,
+                    message: 'Expected a padding newline after opening curly brace'
+                });
+            }
+
+            if (checkClose === true) {
+                var closingBracket = file.getLastNodeToken(node);
+
+                errors.assert.linesBetween({
+                    token: file.getPrevToken(closingBracket, {includeComments: true}),
+                    nextToken: closingBracket,
+                    atLeast: 2,
+                    message: 'Expected a padding newline before closing curly brace'
+                });
+            }
+        });
+    }
+};

--- a/lib/rules/require-padding-newlines-in-function-expressions.js
+++ b/lib/rules/require-padding-newlines-in-function-expressions.js
@@ -23,7 +23,7 @@
  * ##### Valid for mode `true` or `{ "open": true, "close": true }`
  *
  * ```js
- * if (true) {
+ * function () {
  *
  *     doSomething();
  *
@@ -34,8 +34,8 @@
  * ##### Invalid
  *
  * ```js
- * if (true) {doSomething();}
- * if (true) {
+ * function () {doSomething();}
+ * function () {
  *     doSomething();
  * }
  * ```
@@ -43,24 +43,24 @@
  * ##### Valid for mode `1`
  *
  * ```js
- * if (true) {
+ * function () {
  *
  *     doSomething();
  *     doSomethingElse();
  *
  * }
- * if (true) {
+ * function () {
  *     doSomething();
  * }
- * if (true) { doSomething(); }
+ * function () { doSomething(); }
  * var abc = function() {};
  * ```
  *
  * ##### Invalid
  *
  * ```js
- * if (true) { doSomething(); doSomethingElse(); }
- * if (true) {
+ * function () { doSomething(); doSomethingElse(); }
+ * function () {
  *     doSomething();
  *     doSomethingElse();
  * }
@@ -69,7 +69,7 @@
  * ##### Valid for mode `{ "open": false, "close": true }`
  *
  * ```js
- * if (true) {
+ * function () {
  *     doSomething();
  *
  * }
@@ -79,11 +79,11 @@
  * ##### Invalid
  *
  * ```js
- * if (true) {doSomething();}
- * if (true) {
+ * function () {doSomething();}
+ * function () {
  *     doSomething();
  * }
- * if (true) {
+ * function () {
  *
  *     doSomething();
  * }
@@ -92,7 +92,7 @@
   * ##### Valid for mode `{ "open": true, "close": false }`
  *
  * ```js
- * if (true) {
+ * function () {
  *
  *     doSomething();
  * }
@@ -102,11 +102,11 @@
  * ##### Invalid
  *
  * ```js
- * if (true) {doSomething();}
- * if (true) {
+ * function () {doSomething();}
+ * function () {
  *     doSomething();
  * }
- * if (true) {
+ * function () {
  *     doSomething();
  *
  * }

--- a/test/specs/rules/require-padding-newlines-in-function-expressions.js
+++ b/test/specs/rules/require-padding-newlines-in-function-expressions.js
@@ -1,0 +1,267 @@
+var Checker = require('../../../lib/checker');
+var assert = require('assert');
+
+describe('rules/require-padding-newlines-in-function-expressions', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    var scenarios = [
+        { option: true, statement: 'abc();' },
+        { option: 1, statement: 'abc();abc();' },
+        { option: { 'open': true, 'close': true }, statement: 'abc();' },
+        { option: { 'open': false, 'close': true }, statement: 'abc();' },
+        { option: { 'open': true, 'close': false }, statement: 'abc();' }
+    ];
+
+    describe('invalid options', function() {
+        it('should report configuration error if not boolean, integer or object', function() {
+            assert.throws(function() {
+                checker.configure({ requirePaddingNewlinesInFunctionExpressions: 'string' });
+            });
+        });
+
+        describe('option is boolean', function() {
+            it('should report configuration error if false', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: false });
+                });
+            });
+        });
+
+        describe('option is object', function() {
+            it('should report configuration error if options.open is not found', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: { 'close': true } });
+                });
+            });
+
+            it('should report configuration error if options.open is not a boolean', function() {
+                assert.throws(function() {
+                    checker.configure({
+                        requirePaddingNewlinesInFunctionExpressions: { 'open': 'true', 'close': true }
+                    });
+                });
+            });
+
+            it('should report configuration error if options.close is not found', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: { 'open': true } });
+                });
+            });
+
+            it('should report configuration error if options.close is not a boolean', function() {
+                assert.throws(function() {
+                    checker.configure({
+                        requirePaddingNewlinesInFunctionExpressions: { 'open': true, 'close': 'true' }
+                    });
+                });
+            });
+
+            it('should report configuration error if both options.open and options.close are false', function() {
+                assert.throws(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: { open: false, close: false} });
+                });
+            });
+        });
+    });
+
+    scenarios.forEach(function(scenario) {
+        describe('valid option: ' + JSON.stringify(scenario.option), function() {
+            it('should not report configuration error', function() {
+                assert.doesNotThrow(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+            });
+
+            describe('tests for missing padding newline after opening brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                var errorCount = 1;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.open === false) {
+                        errorCount = 0;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline', function() {
+                    assert(checker.
+                        checkString('function () {' + scenario.statement + '\n\n}').getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for linebreak but no padding newline', function() {
+                    assert(checker.
+                        checkString('function () {\n' + scenario.statement + '\n\n}').getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for with no linebreak and no padding newline before ' +
+                    'single line comments', function() {
+                    assert(checker.
+                        checkString('function () {//bla\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for linebreak but no padding newline before single line ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {\n//bla\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline before mulitiline ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {/**/\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for linebreak but no padding newline before mulitiline ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {\n/**/\n' + scenario.statement + '\n\n}').
+                            getErrorCount() === errorCount);
+                });
+            });
+
+            describe('tests for missing padding newline before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                var errorCount = 1;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.close === false) {
+                        errorCount = 0;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline', function() {
+                    assert(checker
+                        .checkString('function () {\n\n' + scenario.statement + '}').getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for with linebreak but no padding newline', function() {
+                    assert(checker
+                        .checkString('function () {\n\n' + scenario.statement + '\n}').getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for linebreak but no padding newline after single line ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {\n\n' + scenario.statement + '\n//bla\n}').
+                            getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for no linebreak and no padding newline after mulitiline ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {\n\n' + scenario.statement + '\n/**/}')
+                            .getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error for linebreak but no padding newline after mulitiline ' +
+                    'comments', function() {
+                    assert(checker.
+                        checkString('function () {\n\n' + scenario.statement + '\n/**/\n}').
+                            getErrorCount() === errorCount);
+                });
+            });
+
+            describe('tests for missing padding newlines both after open brace and before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                var errorCount = 2;
+                if (typeof scenario.option === 'object') {
+                    if (scenario.option.open === false) {
+                        errorCount -= 1;
+                    }
+
+                    if (scenario.option.close === false) {
+                        errorCount -= 1;
+                    }
+                }
+
+                it('should report ' + errorCount + ' error(s) for no linebreak and no padding newline', function() {
+                    assert(checker
+                        .checkString('function () {' + scenario.statement + '}').getErrorCount() === errorCount);
+                });
+
+                it('should report ' + errorCount + ' error(s) for linebreak but no padding newline', function() {
+                    assert(checker
+                        .checkString('function () {\n' + scenario.statement + '\n}').getErrorCount() === errorCount);
+                });
+            });
+
+            describe('tests for valid padding newlines after opening brace and before closing brace', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                it('should not report error for single padding newline on both sides', function() {
+                    assert(checker.checkString('function () {\n\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+
+                it('should not report error for double padding newline after opening brace and single padding ' +
+                    'newline before closing brace', function() {
+                    assert(checker.checkString('function () {\n\n\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+
+                it('should not report error for single padding newline after opening brace and double padding  ' +
+                    'newline before closing brace', function() {
+                    assert(checker.checkString('function () {\n\n' + scenario.statement + '\n\n\n}').isEmpty());
+                });
+
+                it('should not report error for single padding newline on both sides with comments', function() {
+                    assert(checker.checkString('function () {\n\n//bla\n' + scenario.statement + '\n\n}').isEmpty());
+                });
+            });
+
+            describe('tests for special valid rule exceptions', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                it('should not report empty function definitions', function() {
+                    assert(checker.checkString('var a = function() {};').isEmpty());
+                });
+
+                if (typeof scenario.option === 'number' && scenario.option === 1) {
+                    it('should not report single statement functions', function() {
+                        assert(checker.checkString('var a = function() {abc();};').isEmpty());
+                    });
+                }
+            });
+
+            describe('tests for fixString', function() {
+                beforeEach(function() {
+                    checker.configure({ requirePaddingNewlinesInFunctionExpressions: scenario.option });
+                });
+
+                it('should fix missing padding newlines', function() {
+                    if (typeof scenario.option === 'object' && scenario.option.open === false) {
+                        assert.equal(
+                            checker.fixString('function () {' + scenario.statement + '}').output,
+                            'function () {' + scenario.statement + '\n\n}'
+                        );
+                    } else if (typeof scenario.option === 'object' && scenario.option.close === false) {
+                        assert.equal(
+                            checker.fixString('function () {' + scenario.statement + '}').output,
+                            'function () {\n\n' + scenario.statement + '}'
+                        );
+                    } else {
+                        assert.equal(
+                            checker.fixString('function () {' + scenario.statement + '}').output,
+                            'function () {\n\n' + scenario.statement + '\n\n}'
+                        );
+                    }
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
[Draft]

Set config, for example: `{ requirePaddingNewlinesInFunctionBodies: 3 }`

So, invalid code:
```js
function(){
    var foo = [];
    bar();
    baz();
    qux();
}
```
```
^--- Expected a padding newline after opening curly brace
^--- Expected a padding newline after closing curly brace
```

And see valid version below:

valid code:
```js
function(){
    foo();
    bar();
    baz();
}
```

valid code:
```js
function(){
    foo();
}
```
Another example:

valid code:
```js
function(){
    foo();
    var bar;
}
```

----

What i did already:

* cp  `./lib/rules/require-padding-newlines-in-blocks.js` into `./lib/rules/require-padding-newlines-in-function-expressions.js`
* replace `BlockStatement` to `FunctionExpression`
* update jsdoc
* update spec, but it, as i see, does not pass.

TODO:
* correct spec
* finish rule
* check rule working