### PR TITLE
remove capitalizedNativeCase from Google presets

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -83,7 +83,7 @@
         "checkReturnTypes": true,
         "checkRedundantReturns": true,
         "requireReturnTypes": true,
-        "checkTypes": "capitalizedNativeCase",
+        "checkTypes": true,
         "checkRedundantAccess": true,
         "requireNewlineAfterDescription": true
     }


### PR DESCRIPTION
This isn't the case, and in many cases can encourage incorrect type annotations. The canonical style guide (plus I'm writing this in my full capacity as a Google engineer), [allows both cases equally](https://google.github.io/styleguide/javascriptguide.xml?showone=JavaScript_Types#JavaScript_Types), see the types on "String object" versus "String value".

For a clearer example- `capitalizedNativeCase` enforces `String` over `string`. However, `String` is a nullable, object form of `string`. The Closure compiler will then allow `null`, which might not be what you want.