### PR TITLE
Preset: remove "requireCapitalizedComments" from jQuery preset

### DIFF
--- a/presets/jquery.json
+++ b/presets/jquery.json
@@ -67,7 +67,6 @@
         "beforeOpeningCurlyBrace": true
     },
     "requirePaddingNewLinesBeforeLineComments": true,
-    "requireCapitalizedComments": true,
     "validateLineBreaks": "LF",
 
     "disallowKeywords": [ "with" ],


### PR DESCRIPTION
It is not possible to validate this rule currently until edge cases are fixed

Ref #1686
Fixes #1724