### PR TITLE
js-file: do not interpret html as grit instructions

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -936,7 +936,7 @@ function parseJavaScriptSource(source, esprima, esprimaOptions) {
     var hasGritData = false;
 
     // Process grit tags like `<if ...>` and `<include ...>`
-    source = source.replace(/^\s*<\/?\s*(if|include)(?!\w)[^]*?>/gm, function(str, p1, pos) {
+    source = source.replace(/^\s*<\/?\s*(if|include)(?!\w)[^]*?>/gim, function(str, p1, pos) {
         hasGritData = true;
         gritData[pos] = str.substring(0, str.length - 1);
 

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -936,7 +936,7 @@ function parseJavaScriptSource(source, esprima, esprimaOptions) {
     var hasGritData = false;
 
     // Process grit tags like `<if ...>` and `<include ...>`
-    source = source.replace(/^\s*<\/?\s*(if|include)[^]*?>/gm, function(str, p1, pos) {
+    source = source.replace(/^\s*<\/?\s*(if|include)(?!\w)[^]*?>/gm, function(str, p1, pos) {
         hasGritData = true;
         gritData[pos] = str.substring(0, str.length - 1);
 

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -95,39 +95,51 @@ describe('js-file', function() {
             assert.equal(parseError.column, 2);
         });
 
-        it('should ignore lines containing only <include> tag', function() {
-            var file = createJsFile('<include src="file.js">\n' +
-                '  <include src="file.js">\n' +
-                '< include src="file.js" >\n' +
-                '<include\n' +
-                ' src="file.js">\n' +
-                'var a = 5;\n');
-            var comments = file._tree.comments;
-            var gritTags = comments.filter(function(comment) {
-                return comment.type === 'GritTag';
+        describe('grit instructions', function() {
+            it('should ignore lines containing only <include> tag', function() {
+                var file = createJsFile('<include src="file.js">\n' +
+                    '  <include src="file.js">\n' +
+                    '< include src="file.js" >\n' +
+                    '<include\n' +
+                    ' src="file.js">');
+                var comments = file._tree.comments;
+                var gritTags = comments.filter(function(comment) {
+                    return comment.type === 'GritTag';
+                });
+
+                assert.equal(4, comments.length);
+                assert.equal(4, gritTags.length);
             });
 
-            assert.equal(4, comments.length);
-            assert.equal(4, gritTags.length);
-        });
+            it('should ignore lines containing only <if> tag', function() {
+                var file = createJsFile('<if expr="false">\n' +
+                    '  <if expr="false">\n' +
+                    '< if expr="false" >\n' +
+                    'var a = 5;\n' +
+                    '</if>\n' +
+                    '<if\n' +
+                    ' expr="false">\n' +
+                    'var b = 7;\n' +
+                    '</ if>');
+                var comments = file._tree.comments;
+                var gritTags = comments.filter(function(comment) {
+                    return comment.type === 'GritTag';
+                });
 
-        it('should ignore lines containing only <if> tag', function() {
-            var file = createJsFile('<if expr="false">\n' +
-                '  <if expr="false">\n' +
-                '< if expr="false" >\n' +
-                'var a = 5;\n' +
-                '</if>\n' +
-                '<if\n' +
-                ' expr="false">\n' +
-                'var b = 7;\n' +
-                '</ if>');
-            var comments = file._tree.comments;
-            var gritTags = comments.filter(function(comment) {
-                return comment.type === 'GritTag';
+                assert.equal(6, comments.length);
+                assert.equal(6, gritTags.length);
             });
 
-            assert.equal(6, comments.length);
-            assert.equal(6, gritTags.length);
+            it('should not interpret html tags as grit instructions', function() {
+                var file = createJsFile('<iframe src="file.js">');
+                var comments = file._tree.comments;
+                var gritTags = comments.filter(function(comment) {
+                    return comment.type === 'GritTag';
+                });
+
+                assert.equal(0, comments.length);
+                assert.equal(0, gritTags.length);
+            });
         });
     });
 

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -140,6 +140,40 @@ describe('js-file', function() {
                 assert.equal(0, comments.length);
                 assert.equal(0, gritTags.length);
             });
+
+            it('should ignore lines containing only <include> case-insensitive tag', function() {
+                var file = createJsFile('<includE src="file.js">\n' +
+                    '  <includE src="file.js">\n' +
+                    '< includE src="file.js" >\n' +
+                    '<includE\n' +
+                    ' src="file.js">');
+                var comments = file._tree.comments;
+                var gritTags = comments.filter(function(comment) {
+                    return comment.type === 'GritTag';
+                });
+
+                assert.equal(4, comments.length);
+                assert.equal(4, gritTags.length);
+            });
+
+            it('should ignore lines containing only <if> case-insensitive tag', function() {
+                var file = createJsFile('<if expr="false">\n' +
+                    '  <iF expr="false">\n' +
+                    '< if expr="false" >\n' +
+                    'var a = 5;\n' +
+                    '</if>\n' +
+                    '<iF\n' +
+                    ' expr="false">\n' +
+                    'var b = 7;\n' +
+                    '</ If>');
+                var comments = file._tree.comments;
+                var gritTags = comments.filter(function(comment) {
+                    return comment.type === 'GritTag';
+                });
+
+                assert.equal(6, comments.length);
+                assert.equal(6, gritTags.length);
+            });
         });
     });
 


### PR DESCRIPTION
Nothing to do with autofixing or with `validateQuoteMark` rule, just
an error in regexp.

Also does not catch cases when tags are actually tags not grit.
Can't do nothing about it at the moment, until we can extend parser

Fixes #1578

/cc @tonyganch 