### PR TITLE
Wikimedia preset: Add es3: true

### DIFF
--- a/presets/wikimedia.json
+++ b/presets/wikimedia.json
@@ -1,4 +1,5 @@
 {
+    "es3": true,
     "requireCurlyBraces": [
         "if",
         "else",


### PR DESCRIPTION
Our browser support matrix (https://www.mediawiki.org/wiki/Compatibility#Browser_support_matrix) covers IE8+ for JS, so we'll need to maintain ES3 compatibility (and stop jscs from thinking we're erring) for a while yet.

Follows-up #1759