### PR TITLE
Improve requireCapitalizedComments

### DIFF
--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -104,18 +104,21 @@ module.exports.prototype = {
             'jscs': true
         };
 
+        this._ignoreIfInTheMiddle = false;
+
         var optionName = this.getOptionName();
 
         var isObject = typeof options === 'object';
+        var error = optionName + ' option requires a true value ' +
+            'or an object with String[] `allExcept` property or true with `ignoreIfInTheMiddle`';
 
         assert(
             options === true ||
             isObject,
-            optionName + ' option requires a true value ' +
-            'or an object with String[] `allExcept` property'
+            error
         );
 
-        if (isObject) {
+        if (isObject && options.allExcept) {
             var exceptions = options.allExcept;
 
             // verify items in `allExcept` property in object are string values
@@ -128,6 +131,14 @@ module.exports.prototype = {
             for (var i = 0, l = exceptions.length; i < l; i++) {
                 this._exceptions[exceptions[i]] = true;
             }
+        }
+
+        if (isObject && options.ignoreIfInTheMiddle) {
+            this._ignoreIfInTheMiddle = true;
+        }
+
+        if (isObject && !options.allExcept && !options.ignoreIfInTheMiddle) {
+            assert(false, error);
         }
     },
 
@@ -181,6 +192,17 @@ module.exports.prototype = {
         return false;
     },
 
+    _shouldIgnoreIfInTheMiddle: function(file, comment) {
+        if (!this._ignoreIfInTheMiddle) {
+            return false;
+        }
+
+        var firstToken = file.getFirstNodeToken(comment);
+        var otherToken = file.getPrevToken(firstToken, { includeComments: true });
+
+        return otherToken.loc.start.line === firstToken.loc.start.line;
+    },
+
     check: function(file, errors) {
         var _this = this;
 
@@ -225,6 +247,10 @@ module.exports.prototype = {
             }
 
             if (!_this._isLetter(comment)) {
+                return;
+            }
+
+            if (_this._shouldIgnoreIfInTheMiddle(file, comment)) {
                 return;
             }
 

--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -207,10 +207,12 @@ module.exports.prototype = {
         var _this = this;
 
         function add(comment) {
-            errors.add(
-                'Comments must start with an uppercase letter, unless it is part of a textblock',
-                comment.loc.start
-            );
+            errors.cast({
+                message: 'Comments must start with an uppercase letter, unless it is part of a textblock',
+                line: comment.loc.start.line,
+                column: comment.loc.start.column,
+                additional: comment
+            });
         }
 
         file.iterateTokensByType('Line', function(comment, index, comments) {
@@ -260,5 +262,12 @@ module.exports.prototype = {
 
             add(comment);
         });
+    },
+
+    _fix: function(error) {
+        var comment = error.additional;
+        var first = this._getFirstChar(comment);
+
+        comment.value = comment.value.replace(first, first.toUpperCase());
     }
 };

--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -91,6 +91,9 @@
 
 var assert = require('assert');
 
+var letterPattern = require('../../patterns/L');
+var upperCasePattern = require('../../patterns/Lu');
+
 module.exports = function() {};
 
 module.exports.prototype = {
@@ -132,46 +135,104 @@ module.exports.prototype = {
         return 'requireCapitalizedComments';
     },
 
+    _isException: function(comment) {
+        // Strip leading whitespace and any asterisks
+        // split on whitespace and colons
+        var splitComment = comment.value.replace(/(^\s+|[\*])/g, '').split(/[\s\:]/g);
+
+        return this._exceptions[splitComment[0]];
+    },
+
+    _isUrl: function(comment) {
+        var protocolParts = comment.value.split('://');
+
+        if (protocolParts.length === 1) {
+            return false;
+        }
+
+        return comment.value.indexOf(protocolParts[0]) === 0;
+    },
+
+    _isValid: function(comment) {
+        var first = this._getFirstChar(comment);
+
+        return first && upperCasePattern.test(first);
+    },
+
+    _isLetter: function(comment) {
+        var first = this._getFirstChar(comment);
+
+        return first && letterPattern.test(first);
+    },
+
+    _getFirstChar: function(comment) {
+        return comment.value.replace(/[\n\s\*]/g, '')[0];
+    },
+
+    _isTextBlock: function(comment, comments, index) {
+        var prevComment = comments[index - 1];
+
+        if (prevComment) {
+            return prevComment.type === 'Line' &&
+                prevComment.loc.start.line + 1 === comment.loc.start.line &&
+                prevComment.value.trim().length > 0;
+        }
+
+        return false;
+    },
+
     check: function(file, errors) {
-        var inTextBlock = null;
-        var exceptions = this._exceptions;
+        var _this = this;
 
-        var letterPattern = require('../../patterns/L');
-        var upperCasePattern = require('../../patterns/Lu');
+        function add(comment) {
+            errors.add(
+                'Comments must start with an uppercase letter, unless it is part of a textblock',
+                comment.loc.start
+            );
+        }
 
-        file.iterateTokensByType(['Line', 'Block'], function(comment, index, comments) {
-            // strip leading whitespace and any asterisks
-            // split on whitespace and colons
-            var splitComment = comment.value.replace(/(^\s+|[\*])/g, '').split(/[\s\:]/g);
-
-            if (exceptions[splitComment[0]]) {
+        file.iterateTokensByType('Line', function(comment, index, comments) {
+            if (_this._isException(comment)) {
                 return;
             }
 
-            var stripped = comment.value.replace(/[\n\s\*]/g, '');
-            var firstChar = stripped[0];
-            var isLetter = firstChar && letterPattern.test(firstChar);
-
-            if (!isLetter) {
-                inTextBlock = false;
+            if (_this._isUrl(comment)) {
                 return;
             }
 
-            inTextBlock = inTextBlock &&
-                comments[index - 1].type === 'Line' &&
-                comments[index - 1].loc.start.line + 1 === comment.loc.start.line;
-
-            var isUpperCase = upperCasePattern.test(firstChar);
-            var isValid = isUpperCase || inTextBlock;
-
-            if (!isValid) {
-                errors.add(
-                    'Comments must start with an uppercase letter, unless it is part of a textblock',
-                    comment.loc.start
-                );
+            if (!_this._isLetter(comment)) {
+                return;
             }
 
-            inTextBlock = comment.type === 'Line';
+            if (_this._isTextBlock(comment, comments, index)) {
+                return;
+            }
+
+            if (_this._isValid(comment)) {
+                return;
+            }
+
+            add(comment);
+        });
+
+        file.iterateTokensByType('Block', function(comment, index, comments) {
+            if (_this._isException(comment)) {
+                return;
+            }
+
+            if (_this._isUrl(comment)) {
+                return;
+            }
+
+            if (!_this._isLetter(comment)) {
+                return;
+            }
+
+            if (_this._isValid(comment, index, comments)) {
+                return;
+            }
+
+            add(comment);
         });
     }
 };

--- a/test/lib/assertHelpers.js
+++ b/test/lib/assertHelpers.js
@@ -35,11 +35,11 @@ var AssertHelpers = {
                 checker.configure(options.rules);
             });
 
-            it('should report', function() {
+            it('report', function() {
                 assert(checker.checkString(options.input).getErrorCount() === options.errors);
             });
 
-            it('should fix', function() {
+            it('fix', function() {
                 var result = checker.fixString(options.input);
                 assert(result.errors.isEmpty());
                 assert.equal(result.output, options.output);

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -1,5 +1,7 @@
-var Checker = require('../../../lib/checker');
 var assert = require('assert');
+
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
+var Checker = require('../../../lib/checker');
 
 describe('rules/require-capitalized-comments', function() {
     var checker;
@@ -285,6 +287,17 @@ describe('rules/require-capitalized-comments', function() {
                 '// http://google.com\n' +
                 '// a'
             );
+        });
+    });
+
+    describe.only('autofixing', function() {
+        reportAndFix({
+            name: 'simple case',
+            rules: {
+                requireCapitalizedComments: true
+            },
+            input: '//invalid',
+            output: '//Invalid'
         });
     });
 });

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -290,7 +290,7 @@ describe('rules/require-capitalized-comments', function() {
         });
     });
 
-    describe.only('autofixing', function() {
+    describe('autofixing', function() {
         reportAndFix({
             name: 'simple case',
             rules: {

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -161,6 +161,76 @@ describe('rules/require-capitalized-comments', function() {
         });
     });
 
+    describe('allExcept: ["istanbul", "zombiecheckjs"]', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedComments: { allExcept: ['istanbul', 'zombiecheckjs'] } });
+        });
+
+        it('should report for anything else', function() {
+            assertOne('/* my comment: this is cool */');
+        });
+
+        it('should report for other comment directives', function() {
+            assertOne('/* jshint: -W071 */');
+        });
+
+        it('should not report for custom exceptions', function() {
+            assertEmpty('/* istanbul ignore next */');
+
+            assertEmpty('/* zombiecheckjs: ensurebrains */');
+        });
+
+        it('should not ignore comments if in the middle of a code', function() {
+            assertOne('function test( /* option */ ) {}');
+        });
+    });
+
+    describe('ignoreIfInTheMiddle: true', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireCapitalizedComments: {
+                    ignoreIfInTheMiddle: true
+                }
+            });
+        });
+
+        it('should ignore comment in the middle of code', function() {
+            assertEmpty('function test( /* option */ ) {}');
+        });
+
+        it('should ignore multiline comment in the middle of code', function() {
+            assertEmpty('function test( /* \n option */ ) {}');
+        });
+
+        it('should not ignore multiple comments if only in the middle of a code', function() {
+            assertOne('/* option */ function test( /* option */ ) {}');
+        });
+
+        it('should not ignore multiple comments if only in the middle of a code', function() {
+            assertOne('/* option */ function test( /* option */ ) {}');
+        });
+    });
+
+    describe('incorrect configuration', function() {
+        it('empty object', function() {
+            assert.throws(function() {
+                checker.configure({
+                    requireCapitalizedComments: {}
+                });
+            }, assert.AssertionError);
+        });
+
+        it('ignoreIfInTheMiddle: false', function() {
+            assert.throws(function() {
+                checker.configure({
+                    requireCapitalizedComments: {
+                        ignoreIfInTheMiddle: false
+                    }
+                });
+            }, assert.AssertionError);
+        });
+    });
+
     describe('ignore non-chars', function() {
         beforeEach(function() {
             checker.configure({ requireCapitalizedComments: true });

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -8,6 +8,10 @@ describe('rules/require-capitalized-comments', function() {
         assert(checker.checkString(str).isEmpty());
     }
 
+    function assertOne(str) {
+        assert(checker.checkString(str).getErrorCount() === 1);
+    }
+
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
@@ -19,15 +23,15 @@ describe('rules/require-capitalized-comments', function() {
         });
 
         it('should report on a lowercase start of a comment', function() {
-            assert(checker.checkString('//invalid').getErrorCount() === 1);
-            assert(checker.checkString('// invalid').getErrorCount() === 1);
-            assert(checker.checkString('/** invalid */').getErrorCount() === 1);
-            assert(checker.checkString('/* invalid */').getErrorCount() === 1);
-            assert(checker.checkString('/**\n * invalid\n*/').getErrorCount() === 1);
-            assert(checker.checkString('//\n// invalid\n//').getErrorCount() === 1);
-            assert(checker.checkString('/*\ninvalid\n*/').getErrorCount() === 1);
-            assert(checker.checkString('//\xFCber').getErrorCount() === 1);
-            assert(checker.checkString('//\u03C0').getErrorCount() === 1);
+            assertOne('//invalid');
+            assertOne('// invalid');
+            assertOne('/** invalid */');
+            assertOne('/* invalid */');
+            assertOne('/**\n * invalid\n*/');
+            assertOne('//\n// invalid\n//');
+            assertOne('/*\ninvalid\n*/');
+            assertOne('//\xFCber');
+            assertOne('//\u03C0');
         });
 
         it('should not report an uppercase start of a comment', function() {
@@ -59,75 +63,80 @@ describe('rules/require-capitalized-comments', function() {
             assert(checker.checkString('/* jscs:disable rule*/').isEmpty());
         });
 
-        it('should not report on multiple uppercase lines in a "textblock"', function() {
-            assertEmpty([
-                '// This is a textblock.',
-                '// That has two uppercase lines'
-            ].join('\n'));
+        describe('"textblock"', function() {
+            it('should not report on multiple uppercase lines in a "textblock"', function() {
+                assertEmpty([
+                    '// This is a textblock.',
+                    '// That has two uppercase lines'
+                ].join('\n'));
 
-            assertEmpty([
-                '// A textblock may also have multiple lines.',
-                '// Those lines can be uppercase as well to support',
-                '// sentense breaks in textblocks'
-            ].join('\n'));
-        });
+                assertEmpty([
+                    '// A textblock may also have multiple lines.',
+                    '// Those lines can be uppercase as well to support',
+                    '// sentense breaks in textblocks'
+                ].join('\n'));
+            });
 
-        it('should not report on multiple uppercase lines in multiple "textblocks"', function() {
-            assertEmpty([
-                '// This is a textblock',
-                '//',
-                '// That has two uppercase lines'
-            ].join('\n'));
-        });
+            it('should not report on multiple uppercase lines in multiple "textblocks"', function() {
+                assertEmpty([
+                    '// This is a textblock',
+                    '//',
+                    '// That has two uppercase lines'
+                ].join('\n'));
+            });
 
-        it('should not report on multiple lines that start with non-letters', function() {
-            assertEmpty([
-                '// 123 or any non-alphabetical starting character',
-                '// @are also valid anywhere'
-            ].join('\n'));
-        });
+            it('should not report on multiple lines that start with non-letters', function() {
+                assertEmpty([
+                    '// 123 or any non-alphabetical starting character',
+                    '// @are also valid anywhere'
+                ].join('\n'));
+            });
 
-        it('should not report on a lowercase start of a comment in a "textblock"', function() {
-            assertEmpty([
-                '// This is a comment',
-                '// that is part of a textblock'
-            ].join('\n'));
+            it('should not report on a lowercase start of a comment in a "textblock"', function() {
+                assertEmpty([
+                    '// This is a comment',
+                    '// that is part of a textblock'
+                ].join('\n'));
 
-            assertEmpty([
-                '// This is a comment',
-                '// that is part of a textblock',
-                '//',
-                '// So is this the beginning',
-                '// of a textblock that can be',
-                '// entered in and out of'
-            ].join('\n'));
+                assertEmpty([
+                    '// This is a comment',
+                    '// that is part of a textblock',
+                    '//',
+                    '// So is this the beginning',
+                    '// of a textblock that can be',
+                    '// entered in and out of'
+                ].join('\n'));
 
-            assertEmpty([
-                '// A textblock is a set of lines',
-                '// that starts with a capitalized letter',
-                '// and has one or more non-capitalized lines',
-                '// afterwards'
-            ].join('\n'));
-        });
+                assertEmpty([
+                    '// A textblock is a set of lines',
+                    '// that starts with a capitalized letter',
+                    '// and has one or more non-capitalized lines',
+                    '// afterwards'
+                ].join('\n'));
+            });
 
-        it('should handle "textblocks" correctly', function() {
-            assert(checker.checkString([
-                '// This is a comment',
-                '// that is part of a textblock',
-                'console.log(0)',
-                '// and this is another comment'
-            ].join('\n')).getErrorCount() === 1);
+            it('should handle "textblocks" correctly', function() {
+                assertOne(
+                    [
+                        '// This is a comment',
+                        '// that is part of a textblock',
+                        'console.log(0)',
+                        '// and this is another comment'
+                    ].join('\n')
+                );
 
-            assert(checker.checkString([
-                '/*',
-                ' * This is a comment',
-                ' * that is part of a textblock',
-                ' */',
-                '/*',
-                ' * and this is a another comment',
-                ' * that is part of a textblock',
-                ' */'
-            ].join('\n')).getErrorCount() === 1);
+                assertOne([
+                        '/*',
+                        ' * This is a comment',
+                        ' * that is part of a textblock',
+                        ' */',
+                        '/*',
+                        ' * and this is a another comment',
+                        ' * that is part of a textblock',
+                        ' */'
+                    ].join('\n')
+                );
+            });
         });
 
     });
@@ -138,17 +147,74 @@ describe('rules/require-capitalized-comments', function() {
         });
 
         it('should report for anything else', function() {
-            assert(checker.checkString('/* my comment: this is cool */').getErrorCount() === 1);
+            assertOne('/* my comment: this is cool */');
         });
 
         it('should report for other comment directives', function() {
-            assert(checker.checkString('/* jshint: -W071 */').getErrorCount() === 1);
+            assertOne('/* jshint: -W071 */');
         });
 
         it('should not report for custom exceptions', function() {
             assertEmpty('/* istanbul ignore next */');
 
             assertEmpty('/* zombiecheckjs: ensurebrains */');
+        });
+    });
+
+    describe('ignore non-chars', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedComments: true });
+        });
+
+        it('should ignore brackets', function() {
+            assertEmpty('// [When the key is not a string, or both a key and value');
+            assertEmpty('// ]when the key is not a string, or both a key and value');
+        });
+
+        it('should ignore parentheses', function() {
+            assertEmpty('// (When the key is not a string, or both a key and value');
+            assertEmpty('// )when the key is not a string, or both a key and value');
+        });
+
+        it('considers line with first non-letter char as continuation of the comment "(" case',
+            function() {
+                assertEmpty(
+                    '// Expose jQuery and $ identifiers, even in AMD\n' +
+                    '// (#7102#comment:10, https://github.com/jquery/jquery/pull/557)\n' +
+                    '// and CommonJS for browser emulators (#13566)'
+                );
+            }
+        );
+
+        it('considers line with first non-letter char as continuation of the comment "[" case',
+            function() {
+                assertEmpty(
+                    '// [*]When the key is not a string, or both a key and value\n' +
+                    '// are specified, set or extend (existing objects) with either:'
+                );
+            }
+        );
+
+        it('considers line with first non-letter char as continuation of the comment "#" case',
+            function() {
+                assertEmpty(
+                    '// #3456 this does xxx\n' +
+                    '// to yyy so that zzz.'
+                );
+            }
+        );
+
+        it('should ignore urls', function() {
+            assertEmpty(
+                '// http://google.com'
+            );
+        });
+
+        it('shoulds ignore urls', function() {
+            assertEmpty(
+                '// http://google.com\n' +
+                '// a'
+            );
         });
     });
 });


### PR DESCRIPTION
/cc @alawatthe, @arschmitz

Fixes #1686, #1774

Added `ignoreIfInTheMiddle` option, which is horrible name, any suggestions?

Support for autofixing also added.