### PR TITLE
Improve *SpacesInsideParentheses rules

### DIFF
--- a/lib/rules/disallow-spaces-inside-parentheses.js
+++ b/lib/rules/disallow-spaces-inside-parentheses.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after opening round bracket and before closing.
  *
- * Types: `Object` or `Boolean`
+ * Types: `Boolean` or `Object`
  *
  * Values: Either `true` or Object with `"only"` property as an array of tokens
  *
@@ -20,12 +20,12 @@
  * ##### Valid for `only` value
  *
  * ```js
- * "disallowSpacesInsideParentheses": { "only": [ "{", "}" ] }
+ * "disallowSpacesInsideParentheses": { "only": [ "{", "}", "\"" ] }
  * ```
- *
  * ```js
  * var x = ( 1 + 2 );
  * var x = foo({});
+ * var x = foo("1");
  * ```
  *
  * ##### Invalid
@@ -60,13 +60,24 @@ module.exports.prototype = {
             assert(false, error);
         }
 
+        this._onlySingleQuote = false;
+        this._onlyDoubleQuote = false;
+        this._only = null;
+
         if (option.only) {
             this._only = {};
+
             (option.only).forEach(function(value) {
+                if (value === '\'') {
+                    this._onlySingleQuote = true;
+                }
+
+                if (value === '"') {
+                    this._onlyDoubleQuote = true;
+                }
+
                 this._only[value] = true;
             }, this);
-        } else {
-            this._only = null;
         }
     },
 
@@ -76,12 +87,31 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var only = this._only;
+        var singleQuote = this._onlySingleQuote;
+        var doubleQuote = this._onlyDoubleQuote;
 
         file.iterateTokenByValue('(', function(token) {
             var nextToken = file.getNextToken(token, {includeComments: true});
             var value = nextToken.value;
+            var shouldReturn = true;
 
-            if (only && !(value in only)) {
+            if (doubleQuote && nextToken.type === 'String' && value[0] === '"') {
+                shouldReturn = false;
+            }
+
+            if (singleQuote && nextToken.type === 'String' && value[0] === '\'') {
+                shouldReturn = false;
+            }
+
+            if (only && value in only) {
+                shouldReturn = false;
+            }
+
+            if (!only) {
+                shouldReturn = false;
+            }
+
+            if (shouldReturn) {
                 return;
             }
 
@@ -95,18 +125,33 @@ module.exports.prototype = {
         file.iterateTokenByValue(')', function(token) {
             var prevToken = file.getPrevToken(token, {includeComments: true});
             var value = prevToken.value;
+            var shouldReturn = true;
+
+            if (doubleQuote && prevToken.type === 'String' && value[value.length - 1] === '"') {
+                shouldReturn = false;
+            }
+
+            if (singleQuote && prevToken.type === 'String' && value[value.length - 1] === '\'') {
+                shouldReturn = false;
+            }
 
             if (only) {
-                if (!(value in only)) {
-                    return;
+                if (value in only) {
+                    shouldReturn = false;
                 }
 
                 if (
                     value === ']' &&
                     file.getNodeByRange(prevToken.range[0]).type === 'MemberExpression'
                 ) {
-                    return;
+                    shouldReturn = true;
                 }
+            } else {
+                shouldReturn = false;
+            }
+
+            if (shouldReturn) {
+                return;
             }
 
             errors.assert.noWhitespaceBetween({

--- a/lib/rules/require-spaces-inside-parentheses.js
+++ b/lib/rules/require-spaces-inside-parentheses.js
@@ -10,6 +10,7 @@
  *        in a row
  *  - `Object`:
  *      - `"all"`: true
+ *      - `"ignoreParenthesizedExpression"`: true
  *      - `"except"`: Array specifying list of tokens that can occur after an opening bracket or before a
  *        closing bracket without a space
  *
@@ -37,6 +38,12 @@
  * var x = Math.pow(( 1 + 2 ), ( 3 + 4 ));
  * ```
  *
+ * ##### Valid for mode `{ "all": true, "ignoreParenthesizedExpression": true }`
+ *
+ * ```js
+ * if ( !("foo" in obj) ) {}
+ * ```
+ *
  * ##### Valid for mode `{ "all": true, "except": [ "{", "}" ] }`
  *
  * ```js
@@ -58,6 +65,7 @@
  */
 
 var assert = require('assert');
+var TokenCategorizer = require('../token-categorizer');
 
 module.exports = function() {};
 
@@ -89,6 +97,7 @@ module.exports.prototype = {
         this._exceptions = {};
         this._exceptSingleQuote = false;
         this._exceptDoubleQuote = false;
+        this._ignoreParenthesizedExpression = false;
 
         if (isObject) {
             mode = 'all' in value ? 'all' : 'allButNested';
@@ -104,6 +113,10 @@ module.exports.prototype = {
 
                 this._exceptions[value] = true;
             }, this);
+
+            if (value.ignoreParenthesizedExpression === true) {
+                this._ignoreParenthesizedExpression = true;
+            }
 
         } else {
             mode = value;
@@ -122,10 +135,18 @@ module.exports.prototype = {
         var exceptions = this._exceptions;
         var singleQuote = this._exceptSingleQuote;
         var doubleQuote = this._exceptDoubleQuote;
+        var ignoreParenthesizedExpression = this._ignoreParenthesizedExpression;
 
         file.iterateTokenByValue('(', function(token) {
             var nextToken = file.getNextToken(token, {includeComments: true});
             var value = nextToken.value;
+
+            if (
+                ignoreParenthesizedExpression &&
+                TokenCategorizer.categorizeOpenParen(token, file) === 'ParenthesizedExpression'
+            ) {
+                return;
+            }
 
             if (value in exceptions) {
                 return;
@@ -154,6 +175,13 @@ module.exports.prototype = {
         file.iterateTokenByValue(')', function(token) {
             var prevToken = file.getPrevToken(token, {includeComments: true});
             var value = prevToken.value;
+
+            if (
+                ignoreParenthesizedExpression &&
+                TokenCategorizer.categorizeCloseParen(token, file) === 'ParenthesizedExpression'
+            ) {
+                return;
+            }
 
             if (value in exceptions) {
 

--- a/lib/rules/require-spaces-inside-parentheses.js
+++ b/lib/rules/require-spaces-inside-parentheses.js
@@ -21,7 +21,7 @@
  * ```js
  * "requireSpacesInsideParentheses": {
  *     "all": true,
- *     "except": [ "{", "}" ]
+ *     "except": [ "{", "}", "\"" ]
  * }
  * ```
  *
@@ -41,6 +41,13 @@
  *
  * ```js
  * var x = Math.pow( foo({ test: 1 }) );
+ * ```
+ *
+ * ##### Valid for mode `{ "all": true, "except": [ "\"" ] }`
+ *
+ * ```js
+ * var x = foo("string");
+ * var x = foo( 1 );
  * ```
  *
  * ##### Invalid
@@ -80,11 +87,21 @@ module.exports.prototype = {
         }
 
         this._exceptions = {};
+        this._exceptSingleQuote = false;
+        this._exceptDoubleQuote = false;
 
         if (isObject) {
             mode = 'all' in value ? 'all' : 'allButNested';
 
             (value.except || []).forEach(function(value) {
+                if (value === '\'') {
+                    this._exceptSingleQuote = true;
+                }
+
+                if (value === '"') {
+                    this._exceptDoubleQuote = true;
+                }
+
                 this._exceptions[value] = true;
             }, this);
 
@@ -103,12 +120,22 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var exceptions = this._exceptions;
+        var singleQuote = this._exceptSingleQuote;
+        var doubleQuote = this._exceptDoubleQuote;
 
         file.iterateTokenByValue('(', function(token) {
             var nextToken = file.getNextToken(token, {includeComments: true});
             var value = nextToken.value;
 
             if (value in exceptions) {
+                return;
+            }
+
+            if (doubleQuote && nextToken.type === 'String' && value[0] === '"') {
+                return;
+            }
+
+            if (singleQuote && nextToken.type === 'String' && value[0] === '\'') {
                 return;
             }
 
@@ -137,6 +164,14 @@ module.exports.prototype = {
                 )) {
                     return;
                 }
+            }
+
+            if (doubleQuote && prevToken.type === 'String' && value[value.length - 1] === '"') {
+                return;
+            }
+
+            if (singleQuote && prevToken.type === 'String' && value[value.length - 1] === '\'') {
+                return;
             }
 
             // Skip for empty parentheses

--- a/test/specs/rules/disallow-spaces-inside-parentheses.js
+++ b/test/specs/rules/disallow-spaces-inside-parentheses.js
@@ -104,6 +104,40 @@ describe('rules/disallow-spaces-inside-parentheses', function() {
     });
 
     describe('"only" option', function() {
+        describe('quotes', function() {
+            it('should handle double quotes', function() {
+                checker.configure({
+                    disallowSpacesInsideParentheses: {
+                        only: ['"']
+                    }
+                });
+
+                assert(checker.checkString('foo( "bar" )').getErrorCount() === 2);
+                assert(checker.checkString('( "1 + 2 ) * 3').getErrorCount() === 1);
+                assert(checker.checkString('if ( "1 + 2 )\n    3').getErrorCount() === 1);
+            });
+
+            it('should handle single quotes', function() {
+                checker.configure({
+                    disallowSpacesInsideParentheses: {
+                        only: ['\'']
+                    }
+                });
+                assert(checker.checkString('foo( \'bar\' )').getErrorCount() === 2);
+                assert(checker.checkString('( \'1 + 2 ) * 3').getErrorCount() === 1);
+                assert(checker.checkString('if ( \'1 + 2 )\n    3').getErrorCount() === 1);
+            });
+
+            it('should report single but not double quotes', function() {
+                checker.configure({
+                    disallowSpacesInsideParentheses: {
+                        only: ['\'']
+                    }
+                });
+                assert(checker.checkString('foo( "bar" );foo( \'bar\' )').getErrorCount() === 2);
+            });
+        });
+
         describe('"{", "}", "[", "]", "function"', function() {
             beforeEach(function() {
                 checker.configure({

--- a/test/specs/rules/require-spaces-inside-parentheses.js
+++ b/test/specs/rules/require-spaces-inside-parentheses.js
@@ -95,6 +95,42 @@ describe('rules/require-spaces-inside-parentheses', function() {
             assert(checker.checkString('for (var i = 0; i < 100; i++) {}').isEmpty());
         });
 
+        describe('quotes', function() {
+            it('should handle double quotes', function() {
+                checker.configure({
+                    requireSpacesInsideParentheses: {
+                        all: true,
+                        except: ['"']
+                    }
+                });
+                assert(checker.checkString('foo("bar")').isEmpty());
+                assert(checker.checkString('(\'1 + 2) * 3').getErrorCount() === 1);
+                assert(checker.checkString('if (\'1 + 2)\n    3').getErrorCount() === 1);
+            });
+
+            it('should handle single quotes', function() {
+                checker.configure({
+                    requireSpacesInsideParentheses: {
+                        all: true,
+                        except: ['\'']
+                    }
+                });
+                assert(checker.checkString('foo(\'bar\')').isEmpty());
+                assert(checker.checkString('(\'1 + 2) * 3').getErrorCount() === 1);
+                assert(checker.checkString('if (\'1 + 2)\n    3').getErrorCount() === 1);
+            });
+
+            it('should report single but not double quotes', function() {
+                checker.configure({
+                    requireSpacesInsideParentheses: {
+                        all: true,
+                        except: ['\'']
+                    }
+                });
+                assert(checker.checkString('foo("bar");foo(\'bar\')').getErrorCount() === 2);
+            });
+        });
+
         describe('"{", "}", "[", "]", "function"', function() {
             beforeEach(function() {
                 checker.configure({

--- a/test/specs/rules/require-spaces-inside-parentheses.js
+++ b/test/specs/rules/require-spaces-inside-parentheses.js
@@ -84,6 +84,19 @@ describe('rules/require-spaces-inside-parentheses', function() {
         });
     });
 
+    describe('`ignoreParenthesizedExpression` option', function() {
+        it('should not report parenthesized expression', function() {
+            checker.configure({
+                requireSpacesInsideParentheses: {
+                    all: true,
+                    ignoreParenthesizedExpression: true
+                }
+            });
+
+            assert(checker.checkString('if ( !("foo" in obj) ) {}').isEmpty());
+        });
+    });
+
     describe('exceptions', function() {
         it('should not require spaces for "for" keyword', function() {
             checker.configure({


### PR DESCRIPTION
* Exclude quotes
* Introduce the `ignoreParenthesizedExpression` option for `requreSpacesInsideParentheses` rule

Fixes #836
Ref #1069