### PR TITLE
Docs: remove unnecessary paragraph

### DIFF
--- a/lib/rules/disallow-spaces-in-function.js
+++ b/lib/rules/disallow-spaces-in-function.js
@@ -1,6 +1,4 @@
 /**
- * Expression
- *
  * Disallows space before `()` or `{}` in function expressions (both [named](#disallowspacesinnamedfunctionexpression)
  * and [anonymous](#disallowspacesinanonymousfunctionexpression)) and function declarations.
  *

--- a/lib/rules/require-blocks-on-newline.js
+++ b/lib/rules/require-blocks-on-newline.js
@@ -40,13 +40,13 @@
  * }
  * var abc = function() {};
  * ```
- * ```
+ * ```js
  * if (true) { //comments
  *     doSomething();
  * }
  * var abc = function() {};
  * ```
- * ```
+ * ```js
  * if (true) {
  *     doSomething();
  * /** comments *\/
@@ -99,14 +99,14 @@
  *      includeComments: true
  * }
  *
- * ```
+ * ```js
  * if (true) {
  *     //comments
  *     doSomething();
  * }
  * var abc = function() {};
  * ```
-  * ```
+ * ```js
  * if (true) {
  *     doSomething();
  *      //comments
@@ -116,13 +116,13 @@
  *
  * ##### Invalid
  *
- * ```
+ * ```js
  * if (true) { //comments
  *     doSomething();
  * }
  * var abc = function() {};
  * ```
-  * ```
+ * ```js
  * if (true) {
  *     doSomething();
  * /** comments *\/}

--- a/lib/rules/require-dot-notation.js
+++ b/lib/rules/require-dot-notation.js
@@ -47,7 +47,7 @@
  * ```
  *
  * ##### Valid
- * ```
+ * ```js
  * var a = b[c];
  * var a = b.c;
  * var a = b['snake_cased'];
@@ -62,14 +62,14 @@
  *
  * ##### Valid
  *
- * ```
+ * ```js
  * var a = b['yield']; // reserved word in ES5
  * var a = b['let'];
  * ```
  *
  * ##### Invalid
  *
- * ```
+ * ```js
  * var a = b['await']; // reserved word in ES6
  * ```
  *
@@ -82,7 +82,7 @@
  *
  * ##### Valid
  *
- * ```
+ * ```js
  * var a = b['await']; // reserved word in ES6
  * ```
  *

--- a/lib/rules/require-spaces-in-function.js
+++ b/lib/rules/require-spaces-in-function.js
@@ -1,6 +1,4 @@
 /**
- * Expression
- *
  * Requires space before `()` or `{}` in function expressions (both [named](#requirespacesinnamedfunctionexpression)
  * and [anonymous](#requirespacesinanonymousfunctionexpression)) and function declarations.
  *


### PR DESCRIPTION
On the "rules" page (http://jscs.info/rules), the word "Expression" is the only text describing the rule and I don't think it adds something or even belongs here, probably this was a copying error.