### PR TITLE
Fix: `disallowParenthesesAroundArrowParam` - account for non-identifiers (RestElement, ArrayPattern) correctly

### DIFF
--- a/lib/rules/disallow-parentheses-around-arrow-param.js
+++ b/lib/rules/disallow-parentheses-around-arrow-param.js
@@ -58,21 +58,22 @@ module.exports.prototype = {
             if (node.params.length !== 1) {
                 return;
             }
+            var firstParam = node.params[0];
 
             // Old Esprima
             var hasDefaultParameter = node.defaults && node.defaults.length === 1;
             // ESTree
-            var hasDefaultParameterESTree = node.params[0].type === 'AssignmentPattern';
-            var hasDestructuring = node.params[0].type === 'ObjectPattern';
+            var hasDefaultParameterESTree = firstParam.type === 'AssignmentPattern';
+            var hasDestructuring = firstParam.type === 'ObjectPattern' || firstParam.type === 'ArrayPattern';
+            var hasRestElement = firstParam.type === 'RestElement';
 
             if (hasDefaultParameter ||
                 hasDefaultParameterESTree ||
-                hasDefaultParameter ||
-                hasDestructuring) {
+                hasDestructuring ||
+                hasRestElement) {
                 return;
             }
 
-            var firstParam = node.params[0];
             if (isWrapped(firstParam)) {
                 errors.add(
                     'Illegal wrap of arrow function expressions in parentheses',

--- a/lib/rules/require-parentheses-around-arrow-param.js
+++ b/lib/rules/require-parentheses-around-arrow-param.js
@@ -48,9 +48,6 @@ module.exports.prototype = {
     check: function(file, errors) {
         function isWrapped(node) {
             var openParensToken = file.getPrevToken(file.getFirstNodeToken(node));
-            if (openParensToken.value === '...') {
-                openParensToken = file.getPrevToken(openParensToken);
-            }
             var closingParensToken = file.getNextToken(file.getLastNodeToken(node));
             var closingTokenValue = closingParensToken ? closingParensToken.value : '';
 

--- a/test/specs/rules/disallow-parentheses-around-arrow-param.js
+++ b/test/specs/rules/disallow-parentheses-around-arrow-param.js
@@ -41,4 +41,12 @@ describe('rules/disallow-parentheses-around-arrow-param', function() {
     it('should not error with no params #1747', function() {
         assert(checker.checkString('() => {};').isEmpty());
     });
+
+    it('should not report an arrow function expression with a single rest param #1616, #1831', function() {
+        assert(checker.checkString('[1, 2].map((...x) => x);').isEmpty());
+    });
+
+    it('should not report an arrow function expression with a single array param #1831', function() {
+        assert(checker.checkString('[1, 2].map(([x]) => x);').isEmpty());
+    });
 });


### PR DESCRIPTION
@SimenB 

#1831