### PR TITLE
Fix typo in disallowMultipleVarDecl rule

### DIFF
--- a/lib/rules/disallow-multiple-var-decl.js
+++ b/lib/rules/disallow-multiple-var-decl.js
@@ -10,7 +10,7 @@
  *    - `'strict'` disallows all multiple variable declarations
  *    - `'allExcept'` array of exceptions:
  *       - `'undefined'` allows declarations where all variables are not defined
- *       - `'required'` allows declarations where all variables are importing external modules with require
+ *       - `'require'` allows declarations where all variables are importing external modules with require
  *
  * #### Example
  *


### PR DESCRIPTION
The doc for rule disallowMultipleVarDecl states that the allExcept array can get a required value, while actually is should be require - fix that.