### PR TITLE
requireDollarBeforeJqueryAssignment: fix Only valiates the first key

### DIFF
--- a/lib/rules/require-dollar-before-jquery-assignment.js
+++ b/lib/rules/require-dollar-before-jquery-assignment.js
@@ -75,6 +75,41 @@ module.exports.prototype = {
             var varName;
             var right;
 
+            function checkIfVarNameShouldStartWithDollar(left, varName, right) {
+
+                if (varName.indexOf('$') === 0 || varName.indexOf('_$') === 0) {
+                    return;
+                }
+
+                if (!right || right.type !== 'CallExpression') {
+                    return;
+                }
+
+                var nextToken = file.getTokenByRangeStart(right.callee.range[0]);
+                if (nextToken.value !== '$') {
+                    return;
+                }
+
+                nextToken = file.getNextToken(nextToken);
+                if (nextToken.value !== '(') {
+                    return;
+                }
+
+                while (!(nextToken.type === 'Punctuator' && nextToken.value === ')')) {
+                    nextToken = file.getNextToken(nextToken);
+                }
+
+                nextToken = file.getNextToken(nextToken);
+
+                if (!nextToken || !(nextToken.type === 'Punctuator' && nextToken.value === '.')) {
+                    errors.add(
+                        'jQuery identifiers must start with a $',
+                        left.loc.start.line,
+                        left.loc.start.column
+                    );
+                }
+            }
+
             if (type === 'VariableDeclarator') {
                 if (token.id.type === 'ObjectPattern') {
                     return;
@@ -83,7 +118,7 @@ module.exports.prototype = {
                 left = token.id;
                 varName = left.name;
                 right = token.init;
-
+                checkIfVarNameShouldStartWithDollar(left, varName, right);
             } else if (ignoreProperties) {
                 return;
 
@@ -95,55 +130,27 @@ module.exports.prototype = {
 
                 varName = left.name || left.property.name;
                 right = token.right;
-
+                checkIfVarNameShouldStartWithDollar(left, varName, right);
             } else {// type === 'ObjectExpression'
-                var props = token.properties[0];
+                var props = token.properties;
 
                 if (!props) {
                     return;
                 }
 
-                left = props.key;
+                props.forEach(function(prop) {
+                    left = prop.key;
 
-                if (!left.name) {
-                    return;
-                }
+                    if (!left.name) {
+                        return;
+                    }
 
-                varName = left.name;
-                right = props.value;
+                    varName = left.name;
+                    right = prop.value;
+                    checkIfVarNameShouldStartWithDollar(left, varName, right);
+                });
             }
 
-            if (varName.indexOf('$') === 0 || varName.indexOf('_$') === 0) {
-                return;
-            }
-
-            if (!right || right.type !== 'CallExpression') {
-                return;
-            }
-
-            var nextToken = file.getTokenByRangeStart(right.callee.range[0]);
-            if (nextToken.value !== '$') {
-                return;
-            }
-
-            nextToken = file.getNextToken(nextToken);
-            if (nextToken.value !== '(') {
-                return;
-            }
-
-            while (!(nextToken.type === 'Punctuator' && nextToken.value === ')')) {
-                nextToken = file.getNextToken(nextToken);
-            }
-
-            nextToken = file.getNextToken(nextToken);
-
-            if (!nextToken || !(nextToken.type === 'Punctuator' && nextToken.value === '.')) {
-                errors.add(
-                    'jQuery identifiers must start with a $',
-                    left.loc.start.line,
-                    left.loc.start.column
-                );
-            }
         });
     }
 };

--- a/lib/rules/require-dollar-before-jquery-assignment.js
+++ b/lib/rules/require-dollar-before-jquery-assignment.js
@@ -75,9 +75,9 @@ module.exports.prototype = {
             var varName;
             var right;
 
-            function checkIfVarNameShouldStartWithDollar(left, varName, right) {
+            function checkIfVarNameShouldStartWithDollar(varName, left, right) {
 
-                if (varName.indexOf('$') === 0 || varName.indexOf('_$') === 0) {
+                if (/^_?\$/.test(varName)) {
                     return;
                 }
 
@@ -100,7 +100,6 @@ module.exports.prototype = {
                 }
 
                 nextToken = file.getNextToken(nextToken);
-
                 if (!nextToken || !(nextToken.type === 'Punctuator' && nextToken.value === '.')) {
                     errors.add(
                         'jQuery identifiers must start with a $',
@@ -118,7 +117,7 @@ module.exports.prototype = {
                 left = token.id;
                 varName = left.name;
                 right = token.init;
-                checkIfVarNameShouldStartWithDollar(left, varName, right);
+                checkIfVarNameShouldStartWithDollar(varName, left, right);
             } else if (ignoreProperties) {
                 return;
 
@@ -130,7 +129,7 @@ module.exports.prototype = {
 
                 varName = left.name || left.property.name;
                 right = token.right;
-                checkIfVarNameShouldStartWithDollar(left, varName, right);
+                checkIfVarNameShouldStartWithDollar(varName, left, right);
             } else {// type === 'ObjectExpression'
                 var props = token.properties;
 
@@ -147,7 +146,7 @@ module.exports.prototype = {
 
                     varName = left.name;
                     right = prop.value;
-                    checkIfVarNameShouldStartWithDollar(left, varName, right);
+                    checkIfVarNameShouldStartWithDollar(varName, left, right);
                 });
             }
 

--- a/test/specs/rules/require-dollar-before-jquery-assignment.js
+++ b/test/specs/rules/require-dollar-before-jquery-assignment.js
@@ -31,6 +31,10 @@ describe('rules/require-dollar-before-jquery-assignment', function() {
             expect(checker.checkString('var x = 2;')).to.have.no.errors();
         });
 
+        it('should not report for var declaration without assignment', function() {
+            expect(checker.checkString('var x;')).to.have.no.errors();
+        });
+
         it('should not report function assignment', function() {
             expect(checker.checkString('var x = function() {};')).to.have.no.errors();
         });

--- a/test/specs/rules/require-dollar-before-jquery-assignment.js
+++ b/test/specs/rules/require-dollar-before-jquery-assignment.js
@@ -177,6 +177,10 @@ describe('rules/require-dollar-before-jquery-assignment', function() {
                 expect(checker.checkString('var x = { foo: $(\'.foo\') }'))
                   .to.have.one.validation.error.from('requireDollarBeforejQueryAssignment');
             });
+
+            it('should look at keys besides the first', function() {
+                expect(checker.checkString('var x = { bar: 1, foo: $(".foo") }')).to.have.error.count.equal(1);
+            });
         });
 
         describe('in object properties', function() {


### PR DESCRIPTION
Added a loop to check each property on an object and stuffed the logic
that checks whether a varName should start with a dollar sign into a
helper function as we may be needing it more than once per
file.iterateNodesByType cycle.

Fixes #1688