### PR TITLE
disallowSpaceAfterObjectKeys: fix #1818

### DIFF
--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -163,9 +163,25 @@ module.exports.prototype = {
                 tokens.push(keyToken);
             });
 
+            var noSpace = true;
+            if (exceptAligned) {
+                var withoutSpace = 0;
+                var alignedOnColon = 0;
+                tokens.forEach(function(key) {
+                    var colon = file.getNextToken(key);
+                    var spaces = Math.abs(colon.range[0] - key.range[1]);
+                    if (spaces === 0) {
+                        withoutSpace++;
+                    } else if (spaces === maxKeyEndPos - key.loc.end.column) {
+                        alignedOnColon++;
+                    }
+                });
+
+                noSpace = withoutSpace > alignedOnColon;
+            }
+
             tokens.forEach(function(key) {
                 var colon = file.getNextToken(key);
-                var noSpace = Math.abs(colon.range[0] - key.range[1]) === 0;
                 var spaces = (exceptAligned && !noSpace) ? maxKeyEndPos - key.loc.end.column : 0;
                 errors.assert.spacesBetween({
                     token: key,

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -165,7 +165,8 @@ module.exports.prototype = {
 
             tokens.forEach(function(key) {
                 var colon = file.getNextToken(key);
-                var spaces = exceptAligned ? maxKeyEndPos - key.loc.end.column : 0;
+                var noSpace = Math.abs(colon.range[0] - key.range[1]) === 0;
+                var spaces = (exceptAligned && !noSpace) ? maxKeyEndPos - key.loc.end.column : 0;
                 errors.assert.spacesBetween({
                     token: key,
                     nextToken: colon,

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -159,6 +159,16 @@ describe('rules/disallow-space-after-object-keys', function() {
                         '};'
                     )).to.have.no.errors();
                 });
+
+                it('should report objects with both keys without spaces and aligned on colon #1818', function() {
+                    expect(checker.checkString(
+                      'var f = {\n' +
+                      '  "n": 1,\n' +
+                      '  "xasdf"   : 2,\n' +
+                      '  "fyfyasdf": 0\n' +
+                      '};'
+                    )).to.have.error.count.equal(1);
+                });
             });
 
             describe('with method value', function() {

--- a/test/specs/rules/disallow-space-after-object-keys.js
+++ b/test/specs/rules/disallow-space-after-object-keys.js
@@ -150,6 +150,15 @@ describe('rules/disallow-space-after-object-keys', function() {
                         '};'
                     )).to.have.no.errors();
                 });
+
+                it('should not report keys with no space after them #1818', function() {
+                    expect(checker.checkString(
+                        'var f = {\n' +
+                        '  "name": 1,\n' +
+                        '  "x": 2\n' +
+                        '};'
+                    )).to.have.no.errors();
+                });
             });
 
             describe('with method value', function() {

--- a/test/specs/rules/require-aligned-object-values.js
+++ b/test/specs/rules/require-aligned-object-values.js
@@ -157,7 +157,7 @@ describe('rules/require-aligned-object-values', function() {
                     'bcd : 2\n' +
                 '};',
                 output: 'var x = {\n' +
-                    'a  : 1,\n' +
+                    'a: 1,\n' +
                     'foo: function() {},\n' +
                     'bcd: 2\n' +
                 '};'


### PR DESCRIPTION
Here's my attempt to fix #1818. Adds the following valid case to `disallowSpaceAfterObjectKeys` with `aligned` option:

#### Config
```javascript
disallowSpaceAfterObjectKeys: { allExcept: ['aligned'] }
```

#### Valid
```javascript
var f = {
    "name": 1,
    "x": 2
};
```

Maybe code that counts spaces could be moved to some utils file but I'm not sure where it should belong.