### PR TITLE
CLI: "auto-configure" argument should always be at the end

### DIFF
--- a/bin/jscs
+++ b/bin/jscs
@@ -15,7 +15,7 @@ program
     .usage('[options] <file ...>')
     .description('A code style linter for programmatically enforcing your style guide.')
     .option('-c, --config [path]', 'configuration file path')
-    .option('--auto-configure [path]', 'auto-generate a JSCS configuration file')
+    .option('--auto-configure <path> [paths]', 'auto-generate a JSCS configuration file')
     .option('-x, --fix', 'fix code style violations (applies to fixable violations)')
     .option('--extract <mask>', 'set file masks from which to extract JavaScript', function(value, memo) {
         return memo ? memo.concat(value) : [value];


### PR DESCRIPTION
We still can't parse `jscs path --auto-configure`, but at least we
will show meaningful error

Fixes #1862