### PR TITLE
JS-file: make parsers to not confuse token types

### DIFF
--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -929,7 +929,7 @@ JsFile.prototype = {
     },
 
     /**
-     * Temporary fix (I hope, two years and counting :-) for esprima tokenizer
+     * Temporary fix (I hope, two years and counting :-) for esprima/babylon tokenizer
      * (https://github.com/jquery/esprima/issues/317)
      * Fixes #83, #180
      *
@@ -938,9 +938,12 @@ JsFile.prototype = {
     _fixEsprimaIdentifiers: function() {
         var _this = this;
 
-        this.iterateNodesByType(['Property', 'MemberExpression'], function(node) {
+        this.iterateNodesByType(['Property', 'MethodDefinition', 'MemberExpression'], function(node) {
             switch (node.type) {
                 case 'Property':
+                    convertKeywordToIdentifierIfRequired(node.key);
+                    break;
+                case 'MethodDefinition':
                     convertKeywordToIdentifierIfRequired(node.key);
                     break;
                 case 'MemberExpression':
@@ -951,6 +954,7 @@ JsFile.prototype = {
 
         function convertKeywordToIdentifierIfRequired(node) {
             var token = _this.getTokenByRangeStart(node.range[0]);
+
             if (token.type === 'Keyword') {
                 token.type = 'Identifier';
             }

--- a/test/specs/js-file.js
+++ b/test/specs/js-file.js
@@ -1,10 +1,15 @@
+var fs = require('fs');
+
 var expect = require('chai').expect;
+var sinon = require('sinon');
+
 var esprima = require('esprima');
 var babelJscs = require('babel-jscs');
-var JsFile = require('../../lib/js-file');
-var sinon = require('sinon');
-var fs = require('fs');
+
 var assign = require('lodash').assign;
+var keywords = Object.keys(require('reserved-words').KEYWORDS[6]);
+
+var JsFile = require('../../lib/js-file');
 
 describe('js-file', function() {
 
@@ -58,6 +63,24 @@ describe('js-file', function() {
                     'new: true, with: true, catch: true, try: true, finally: true, \'\': true, null: true, 0: true' +
                     '})';
                 createJsFile(str).getTokens().forEach(function(token) {
+                    expect(token.type).to.not.equal('Keyword');
+                });
+            });
+
+            it('should affect method definition tokens', function() {
+                var str = keywords.map(function(token) {
+                    return token + '() {}';
+                });
+
+                str = 'class test {\n' + str.join('\n') + '\n}';
+
+                createJsFile(str).getTokens().forEach(function(token, i) {
+
+                    // Exclude first "class"
+                    if (i === 0) {
+                        return;
+                    }
+
                     expect(token.type).to.not.equal('Keyword');
                 });
             });


### PR DESCRIPTION
Fixes #1855