### PR TITLE
disallowUnusedParams: correctly output unused param name

### DIFF
--- a/lib/rules/disallow-unused-params.js
+++ b/lib/rules/disallow-unused-params.js
@@ -102,7 +102,7 @@ module.exports.prototype = {
                 var param = params[index];
 
                 errors.cast({
-                    message: 'Param `' + value.name + '` is not used',
+                    message: 'Param `' + value.param.name + '` is not used',
                     line: param.loc.start.line,
                     column: param.loc.start.column,
                     additional: {

--- a/test/specs/rules/disallow-unused-params.js
+++ b/test/specs/rules/disallow-unused-params.js
@@ -23,6 +23,12 @@ describe('rules/disallow-unused-params', function() {
         )).to.have.no.errors();
     });
 
+    it('should report unused param', function() {
+        expect(checker.checkString(
+            'function fun(test) { }'
+        )).to.have.error('Param `test` is not used');
+    });
+
     reportAndFix({
         name: 'function a(b) {}',
         rules: config,


### PR DESCRIPTION
Fixes #1859