### PR TITLE
maxNumberOfLines Enhancing to exclude comments

### DIFF
--- a/lib/rules/maximum-number-of-lines.js
+++ b/lib/rules/maximum-number-of-lines.js
@@ -1,11 +1,15 @@
 /**
  * Requires the file to be at most the number of lines specified
  *
- * Type: `Integer`
+ * Types: `Integer` or `Object`
  *
  * Values:
  * - `Integer`: file should be at most the number of lines specified
- *
+ * - `Object`:
+ *     - `value`: (required) lines should be at most the number of characters specified
+ *     - `allExcept`: (default: `[]`) an array of conditions that will exempt a line
+ *        - `comments`: allows comments to break the rule
+*
  * #### Example
  *
  * ```js
@@ -20,11 +24,24 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            typeof options === 'number',
-            this.getOptionName() + ' option requires number value or should be removed'
-        );
-        this._maximumNumberOfLines = options;
+        this._allowComments = true;
+
+        if (typeof options === 'number') {
+            assert(
+                typeof options === 'number',
+                this.getOptionName() + ' option requires number value or options object'
+            );
+            this._maximumNumberOfLines = options;
+        } else {
+            assert(
+                typeof options.value === 'number',
+                this.getOptionName() + ' option requires the "value" property to be defined'
+            );
+            this._maximumNumberOfLines = options.value;
+
+            var exceptions = options.allExcept || [];
+            this._allowComments = (exceptions.indexOf('comments') === -1);
+        }
     },
 
     getOptionName: function() {
@@ -33,14 +50,16 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var firstToken = file.getFirstToken();
-        var lastToken = file.getLastToken();
+        var lines = this._allowComments ?
+             file.getLines() : file.getLinesWithCommentsRemoved();
 
-        errors.assert.linesBetween({
-            token: firstToken,
-            nextToken: lastToken,
-            atMost: this._maximumNumberOfLines - 1,
-            message: 'File must be at most ' + this._maximumNumberOfLines + ' lines long'
-        });
+        lines = lines.filter(function(line) {return line !== '';});
+
+        if (lines.length > this._maximumNumberOfLines) {
+            errors.add('File must be at most ' + this._maximumNumberOfLines + ' lines long',
+                       firstToken.loc.end.line,
+                       firstToken.loc.end.column);
+        }
     }
 
 };

--- a/test/specs/rules/maximum-number-of-lines.js
+++ b/test/specs/rules/maximum-number-of-lines.js
@@ -27,4 +27,38 @@ describe('rules/maximum-number-of-lines', function() {
             expect(checker.checkString('var x;')).to.have.no.errors();
         });
     });
+
+    describe('object option', function() {
+
+        it('should not report if a number of lines equal to the maximum when allExcept["comments"] is set', function() {
+            checker.configure({
+                maximumNumberOfLines: {
+                    value: 2,
+                    allExcept: ['comments']
+                }
+            });
+            var content = [
+                '//a single line comment',
+                'var xy;',
+                'var xy;',
+                '/* a multiline',
+                ' long comment*/'
+            ].join('\n');
+            expect(checker.checkString(content)).to.have.no.errors();
+        });
+
+        it('should report a number of non-commented lines equal to the maximum', function() {
+            checker.configure({
+                maximumNumberOfLines: {
+                    value: 2
+                }
+            });
+            expect(checker.checkString('/* a multiline comment\n that goes to many lines*/\nvar xy;\nvar xy;'))
+              .to.have.one.validation.error.from('maximumNumberOfLines');
+            expect(checker.checkString('//a single line comment\nvar xy;\nvar xy;'))
+              .to.have.one.validation.error.from('maximumNumberOfLines');
+        });
+
+    });
+
 });


### PR DESCRIPTION
**Feature**: #1880
- Enhancing `maxNumberOfLines` to accept an object value with the ability to skip comments
- The changes now measure Source line comments and doesn't take into account the empty lines.
@hzoo can you let me know if this looks good to you? 