### PR TITLE
disallowSpaceAfterComma: New option

### DIFF
--- a/grouping.json
+++ b/grouping.json
@@ -22,6 +22,7 @@
     "validateLineBreaks",
     "validateIndentation",
     "disallowSpaceBeforeComma",
+    "disallowSpaceAfterComma",
     "disallowSpaceBeforeSemicolon",
     "disallowPaddingNewLinesAfterBlocks",
     "disallowPaddingNewLinesAfterUseStrict",

--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -1066,6 +1066,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-space-before-semicolon'));
 
     this.registerRule(require('../rules/disallow-space-before-comma'));
+    this.registerRule(require('../rules/disallow-space-after-comma'));
 
     this.registerRule(require('../rules/require-space-before-comma'));
     this.registerRule(require('../rules/require-space-after-comma'));

--- a/lib/rules/disallow-space-after-comma.js
+++ b/lib/rules/disallow-space-after-comma.js
@@ -1,0 +1,57 @@
+/**
+ * Disallows spaces after commas
+ *
+ * Types: `Boolean`
+ *
+ * Values: `true` to disallow any spaces after any comma
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowSpaceAfterComma": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * [a,b,c];
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * [a, b, c];
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {
+};
+
+module.exports.prototype = {
+
+    configure: function(option) {
+        assert(
+            option === true,
+            this.getOptionName() + ' option requires true value'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowSpaceAfterComma';
+    },
+
+    check: function(file, errors) {
+        file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
+            var nextToken = file.getNextToken(token);
+
+            errors.assert.noWhitespaceBetween({
+                token: token,
+                nextToken: nextToken,
+                message: 'Illegal space after comma'
+            });
+        });
+    }
+
+};

--- a/test/specs/rules/disallow-space-after-comma.js
+++ b/test/specs/rules/disallow-space-after-comma.js
@@ -1,0 +1,41 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/disallow-space-after-comma', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    it('does not allow spaces after commas', function() {
+        checker.configure({ disallowSpaceAfterComma: true });
+
+        expect(checker.checkString('[a, b]')).to.have.one.validation.error.from('disallowSpaceAfterComma');
+    });
+
+    it('does not allow tabs after commas', function() {
+        checker.configure({ disallowSpaceAfterComma: true });
+
+        expect(checker.checkString('[a,\tb]')).to.have.one.validation.error.from('disallowSpaceAfterComma');
+    });
+
+    it('does allow commas with no spaces', function() {
+        checker.configure({ disallowSpaceAfterComma: true });
+
+        expect(checker.checkString('[a,b,c]')).to.have.no.errors();
+    });
+
+    it('does allow commas with spaces before', function() {
+        checker.configure({ disallowSpaceAfterComma: true });
+
+        expect(checker.checkString('[a ,b ,c]')).to.have.no.errors();
+    });
+
+    it('does allow commas with newline character after', function() {
+        checker.configure({ disallowSpaceAfterComma: true });
+
+        expect(checker.checkString('[a,\nb,\nc]')).to.have.no.errors();
+    });
+});

--- a/test/specs/rules/disallow-space-before-comma.js
+++ b/test/specs/rules/disallow-space-before-comma.js
@@ -15,9 +15,27 @@ describe('rules/disallow-space-before-comma', function() {
         expect(checker.checkString('var a ,b;')).to.have.one.validation.error.from('disallowSpaceBeforeComma');
     });
 
+    it('does not allow tabs before commas', function() {
+        checker.configure({ disallowSpaceBeforeComma: true });
+
+        expect(checker.checkString('var a\t,b;')).to.have.one.validation.error.from('disallowSpaceBeforeComma');
+    });
+
     it('does allow commas with no spaces', function() {
         checker.configure({ disallowSpaceBeforeComma: true });
 
         expect(checker.checkString('var a,b;')).to.have.no.errors();
+    });
+
+    it('does allow commas with spaces after', function() {
+        checker.configure({ disallowSpaceBeforeComma: true });
+
+        expect(checker.checkString('[a, b, c]')).to.have.no.errors();
+    });
+
+    it('does allow commas with newline character before', function() {
+        checker.configure({ disallowSpaceBeforeComma: true });
+
+        expect(checker.checkString('[a\n,b\n,c]')).to.have.no.errors();
     });
 });


### PR DESCRIPTION
Disallows spaces after commas, for example `[1, 2, 3]` is invalid and
`[1,2,3]` is valid.

Fixes #1889
