### PR TITLE
Minor spelling fix for "sentence"

### DIFF
--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -37,7 +37,7 @@
  *
  * // A textblock may also have multiple lines.
  * // Those lines can be uppercase as well to support
- * // sentense breaks in textblocks
+ * // sentence breaks in textblocks
  *
  * // 123 or any non-alphabetical starting character
  * // @are also valid anywhere

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -88,7 +88,7 @@ describe('rules/require-capitalized-comments', function() {
                 assertEmpty([
                     '// A textblock may also have multiple lines.',
                     '// Those lines can be uppercase as well to support',
-                    '// sentense breaks in textblocks'
+                    '// sentence breaks in textblocks'
                 ].join('\n'));
             });
 


### PR DESCRIPTION
Replaces occurences of "sentense" with "sentence".