### PR TITLE
disallowSpaceBeforeObjectValues: Fixed description.

### DIFF
--- a/lib/rules/disallow-space-before-object-values.js
+++ b/lib/rules/disallow-space-before-object-values.js
@@ -1,5 +1,5 @@
 /**
- * Disallows space after object keys.
+ * Disallows space before object values.
  *
  * Type: `Boolean`
  *


### PR DESCRIPTION
Changed from "Disallows space after object keys." to "Disallows space
before object values.".