### PR TITLE
requireObjectKeysOnNewLine: add 'sameLine' as allExcept rule

### DIFF
--- a/lib/rules/require-object-keys-on-new-line.js
+++ b/lib/rules/require-object-keys-on-new-line.js
@@ -1,14 +1,17 @@
 /**
  * Requires placing object keys on new line
  *
- * Type: `Boolean`
+ * Types: `Boolean` or `Object`
  *
- * Value: `true`
+ * Values: `true` or Object with `allExcept` Array of quoted identifiers which are exempted
  *
  * #### Example
  *
  * ```js
  * "requireObjectKeysOnNewLine": true
+ * "requireObjectKeysOnNewLine": {
+ *     "allExcept": ["sameLine"]
+ * }
  * ```
  *
  * ##### Valid
@@ -27,6 +30,22 @@
  *     b: 'b', c: 'c'
  * };
  * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b', c: 'c'
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var a = {
+ *     b: 'b', c: 'c',
+ *     d: 'd'
+ * };
  */
 
 var assert = require('assert');
@@ -36,9 +55,14 @@ module.exports = function() {};
 module.exports.prototype = {
     configure: function(options) {
         assert(
-            options === true,
-            this.getOptionName() + ' option requires a true value or should be removed'
+            options === true || Array.isArray(options.allExcept),
+            this.getOptionName() + ' option requires a true value or an object of exceptions'
         );
+
+        this._isSameLine = false;
+        if (Array.isArray(options.allExcept)) {
+            this._isSameLine = options.allExcept[0] === 'sameLine';
+        }
     },
 
     getOptionName: function() {
@@ -46,17 +70,39 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var message = 'Object keys must go on a new line';
+        var isSameLine = this._isSameLine;
+
+        if (isSameLine) {
+            message = 'Object keys must go on a new line if they aren\'t all on the same line';
+        }
+
         file.iterateNodesByType('ObjectExpression', function(node) {
+            var firstKeyToken;
+            var lastValueToken;
+
+            if (isSameLine) {
+                if (node.properties.length > 1) {
+                    firstKeyToken = file.getFirstNodeToken(node.properties[0].key);
+                    lastValueToken = file.getLastNodeToken(node.properties[node.properties.length - 1].value);
+
+                    if (firstKeyToken.loc.end.line === lastValueToken.loc.start.line) {
+                        // It's ok, all keys and values are on the same line.
+                        return;
+                    }
+                }
+            }
+
             for (var i = 1; i < node.properties.length; i++) {
-                var lastValueToken = file.getLastNodeToken(node.properties[i - 1].value);
+                lastValueToken = file.getLastNodeToken(node.properties[i - 1].value);
                 var comma = file.findNextToken(lastValueToken, 'Punctuator', ',');
 
-                var firstKeyToken = file.getFirstNodeToken(node.properties[i].key);
+                firstKeyToken = file.getFirstNodeToken(node.properties[i].key);
 
                 errors.assert.differentLine({
                     token: comma,
                     nextToken: firstKeyToken,
-                    message: 'Object keys must go on a new line'
+                    message: message
                 });
             }
         });

--- a/test/specs/rules/require-object-keys-on-new-line.js
+++ b/test/specs/rules/require-object-keys-on-new-line.js
@@ -3,38 +3,82 @@ var Checker = require('../../../lib/checker');
 var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 
 describe('rules/require-object-keys-on-new-line', function() {
-    var rules = { requireObjectKeysOnNewLine: true };
     var checker;
 
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure(rules);
     });
 
-    reportAndFix({
-        name: 'object assignment with missing padding',
-        rules: rules,
-        input: 'var a = {foo: "bar",bar: "baz"}',
-        output: 'var a = {foo: "bar",\nbar: "baz"}'
+    describe('with option value true - ', function() {
+        var rules = { requireObjectKeysOnNewLine: true };
+
+        beforeEach(function() {
+            checker.configure(rules);
+        });
+
+        reportAndFix({
+            name: 'object assignment with missing padding',
+            rules: rules,
+            input: 'var a = {foo: "bar",bar: "baz"}',
+            output: 'var a = {foo: "bar",\nbar: "baz"}'
+        });
+
+        reportAndFix({
+            name: 'function argument with missing padding',
+            rules: rules,
+            input: 'foo({foo: "bar", bar: "baz"})',
+            output: 'foo({foo: "bar",\n bar: "baz"})'
+        });
+
+        it('should not report object with padding', function() {
+            expect(checker.checkString('var a = {foo: "bar",\nbar: "baz"}')).to.have.no.errors();
+        });
+
+        it('should not report argument with padding', function() {
+            expect(checker.checkString('foo({foo: "bar",\nbar: "baz"})')).to.have.no.errors();
+        });
+
+        it('should not report object with one key', function() {
+            expect(checker.checkString('var a = {a: "b"};')).to.have.no.errors();
+        });
     });
 
-    reportAndFix({
-        name: 'function argument with missing padding',
-        rules: rules,
-        input: 'foo({foo: "bar", bar: "baz"})',
-        output: 'foo({foo: "bar",\n bar: "baz"})'
-    });
+    describe('option value {"allExcept":["sameLine"]}', function() {
+        var rules = { requireObjectKeysOnNewLine: { allExcept: ['sameLine'] } };
 
-    it('should not report object with padding', function() {
-        expect(checker.checkString('var a = {foo: "bar",\nbar: "baz"}')).to.have.no.errors();
-    });
+        beforeEach(function() {
+            checker.configure(rules);
+        });
 
-    it('should not report argument with padding', function() {
-        expect(checker.checkString('foo({foo: "bar",\nbar: "baz"})')).to.have.no.errors();
-    });
+        reportAndFix({
+            name: 'object assignment with some padding',
+            rules: rules,
+            input: 'var a = {foo: "bar",bar: "baz",\nbaz: "foo"}',
+            output: 'var a = {foo: "bar",\nbar: "baz",\nbaz: "foo"}'
+        });
 
-    it('should not report object with one key', function() {
-        expect(checker.checkString('var a = {a: "b"};')).to.have.no.errors();
+        it('should not report object with one key', function() {
+            expect(checker.checkString('var a = {a: "b"};')).to.have.no.errors();
+        });
+
+        it('should not report object with keys on the same line as the declaration', function() {
+            expect(checker.checkString('var a = {a: "b",c: "d",e: "f"};')).to.have.no.errors();
+        });
+
+        it('should not report object with keys on the same line', function() {
+            expect(checker.checkString('var a = {\na: "b",c: "d",e: "f"\n};')).to.have.no.errors();
+        });
+
+        it('should not report object with padding', function() {
+            expect(checker.checkString('var a = {\na: "b",\nc: "d",\ne: "f"\n};')).to.have.no.errors();
+        });
+
+        it('should report on require object keys on new line', function() {
+            expect(checker.checkString('var a = {\na: "b",c: "d",\ne: "f"\n};'))
+                .to.have.one.validation.error.from('requireObjectKeysOnNewLine');
+            expect(checker.checkString('var a = {a: "b",c: "d",\ne: "f"\n};'))
+                .to.have.one.validation.error.from('requireObjectKeysOnNewLine');
+        });
     });
 });


### PR DESCRIPTION
Fixes #1898.
I am not sure everything is correct but seems to work.