### PR TITLE
requireSpaceAfterComma

### DIFF
--- a/lib/rules/require-space-after-comma.js
+++ b/lib/rules/require-space-after-comma.js
@@ -1,27 +1,45 @@
 /**
  * Requires space after comma
  *
- * Types: `Boolean`
+ * Types: `Boolean`, or `String`
  *
- * Values: `true` to require a space after any comma
+ * Values:
+ *  - `Boolean`: `true` to require a space after any comma
+ *  - `String`: `"exceptTrailingCommas"` to require a space after all but trailing commas
  *
  * #### Example
  *
  * ```js
  * "requireSpaceAfterComma": true
  * ```
+ * ```
+ * "requireSpaceAfterComma": "exceptTrailingCommas"
+ * ```
  *
- * ##### Valid
+ * ##### Valid for mode `true`
  *
  * ```js
  * var a, b;
  * ```
  *
- * ##### Invalid
+ * ##### Invalid for mode `true`
  *
  * ```js
  * var a,b;
  * ```
+ *
+ *##### Valid for mode `"exceptTrailingCommas"`
+ *
+ * ```js
+ * var a = [1, 2,];
+ * ```
+ *
+ * ##### Invalid for mode `"exceptTrailingCommas"`
+ *
+ * ```js
+ * var a = [a,b,];
+ * ```
+ *
  */
 
 var assert = require('assert');
@@ -33,9 +51,10 @@ module.exports.prototype = {
 
     configure: function(option) {
         assert(
-            option === true,
-            this.getOptionName() + ' option requires true value'
+            option === true || option === 'exceptTrailingCommas',
+            this.getOptionName() + ' option requires true value or "exceptTrailingCommas"'
         );
+        this._exceptTrailingCommas = option === 'exceptTrailingCommas';
     },
 
     getOptionName: function() {
@@ -43,7 +62,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var exceptTrailingCommas = this._exceptTrailingCommas;
         file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
+            if (exceptTrailingCommas && [']', '}'].indexOf(file.getNextToken(token).value) >= 0) {
+                return;
+            }
             errors.assert.whitespaceBetween({
                 token: token,
                 nextToken: file.getNextToken(token),

--- a/lib/rules/require-space-after-comma.js
+++ b/lib/rules/require-space-after-comma.js
@@ -1,11 +1,13 @@
 /**
  * Requires space after comma
  *
- * Types: `Boolean`, or `String`
+ * Types: `Boolean`, or `Object`
  *
  * Values:
  *  - `Boolean`: `true` to require a space after any comma
- *  - `String`: `"exceptTrailingCommas"` to require a space after all but trailing commas
+ *  - `Object`:
+ *    - `"allExcept"` array of exceptions:
+ *      - `"trailing"` ignore trailing commas
  *
  * #### Example
  *
@@ -13,7 +15,7 @@
  * "requireSpaceAfterComma": true
  * ```
  * ```
- * "requireSpaceAfterComma": "exceptTrailingCommas"
+ * "requireSpaceAfterComma": {"allExcept": ["trailing"]}
  * ```
  *
  * ##### Valid for mode `true`
@@ -28,13 +30,13 @@
  * var a,b;
  * ```
  *
- *##### Valid for mode `"exceptTrailingCommas"`
+ *##### Valid for mode `{"allExcept": ["trailing"]}`
  *
  * ```js
  * var a = [1, 2,];
  * ```
  *
- * ##### Invalid for mode `"exceptTrailingCommas"`
+ * ##### Invalid for mode `{"allExcept": ["trailing"]}`
  *
  * ```js
  * var a = [a,b,];
@@ -49,12 +51,21 @@ module.exports = function() {
 
 module.exports.prototype = {
 
-    configure: function(option) {
+    configure: function(options) {
+        if (typeof options !== 'object') {
+            assert(
+                options === true,
+                this.getOptionName() + ' option requires true value or an object'
+            );
+            var _options = {allExcept: []};
+            return this.configure(_options);
+        }
+
         assert(
-            option === true || option === 'exceptTrailingCommas',
-            this.getOptionName() + ' option requires true value or "exceptTrailingCommas"'
+            Array.isArray(options.allExcept),
+            ' property `allExcept` in ' + this.getOptionName() + ' should be an array of strings'
         );
-        this._exceptTrailingCommas = option === 'exceptTrailingCommas';
+        this._exceptTrailingCommas = options.allExcept.indexOf('trailing') >= 0;
     },
 
     getOptionName: function() {

--- a/test/specs/rules/require-space-after-comma.js
+++ b/test/specs/rules/require-space-after-comma.js
@@ -7,67 +7,169 @@ describe('rules/require-space-after-comma', function() {
     beforeEach(function() {
         checker = new Checker();
         checker.registerDefaultRules();
-        checker.configure({ requireSpaceAfterComma: true });
     });
 
-    it('should report error when no space is given', function() {
-        expect(checker.checkString('var a,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
+    describe('option value true', function() {
+
+        beforeEach(function() {
+            checker.configure({ requireSpaceAfterComma: true });
+        });
+
+        it('should report error when no space is given', function() {
+            expect(checker.checkString('var a,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
+        });
+
+        it('should report error when space is given before but not after comma', function() {
+            expect(checker.checkString('var a ,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
+        });
+
+        it('should allow space after comma in var declaration', function() {
+            expect(checker.checkString('var a, b;')).to.have.no.errors();
+        });
+
+        it('should allow space after and before comma in var declaration', function() {
+            expect(checker.checkString('var a , b;')).to.have.no.errors();
+        });
+
+        it('should allow new line after comma in var declaration', function() {
+            expect(checker.checkString('var a,\nb,\nc;')).to.have.no.errors();
+        });
+
+        it('should report errors when no space is given in arrays', function() {
+            expect(checker.checkString('var a = [1,2,3,4];')).to.have.error.count.equal(3);
+        });
+
+        it('should report errors when space is given before but not after commas in arrays', function() {
+            expect(checker.checkString('var a = [1 ,2 ,3 ,4];')).to.have.error.count.equal(3);
+        });
+
+        it('should allow space after comma in arrays', function() {
+            expect(checker.checkString('var a = [1, 2, 3, 4];')).to.have.no.errors();
+        });
+
+        it('should allow space after and before comma in arrays', function() {
+            expect(checker.checkString('var a = [1 , 2 , 3 , 4];')).to.have.no.errors();
+        });
+
+        it('should report error when no space is given after trailing comma in array', function() {
+            expect(checker.checkString('var a = [1, 2, 3, 4,];')).to.have.error.count.equal(1);
+        });
+
+        it('should allow new line after comma in arrays', function() {
+            expect(checker.checkString('var a = [1,\n2,\n3];')).to.have.no.errors();
+        });
+
+        it('should report errors when no space is given in objects', function() {
+            expect(checker.checkString('var a = {x:1,y:2,z:3};')).to.have.error.count.equal(2);
+        });
+
+        it('should report error when no space is given after trailing comma in object', function() {
+            expect(checker.checkString('var a = {x:1, y:2, z:3,};')).to.have.error.count.equal(1);
+        });
+
+        it('should report errors when space is given before but not after commas in objects', function() {
+            expect(checker.checkString('var a = {x:1 ,y:2 ,z:3};')).to.have.error.count.equal(2);
+        });
+
+        it('should allow space after comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1, y: 2, z: 3};')).to.have.no.errors();
+        });
+
+        it('should allow space after and before comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1 , y: 2 , z: 3};')).to.have.no.errors();
+        });
+
+        it('should allow new line after comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1,\ny: 2,\nz: 3};')).to.have.no.errors();
+        });
+
+        it('should report errors when no space is given after trailing comma in object in array', function() {
+            expect(checker.checkString('var a = [{a:1, b:2,}, {c:3, d:4,},];')).to.have.error.count.equal(3);
+        });
+
     });
 
-    it('should report error when space is given before but not after comma', function() {
-        expect(checker.checkString('var a ,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
-    });
+    describe('option value "exceptTrailingCommas"', function() {
 
-    it('should allow space after comma in var declaration', function() {
-        expect(checker.checkString('var a, b;')).to.have.no.errors();
-    });
+        beforeEach(function() {
+            checker.configure({ requireSpaceAfterComma: 'exceptTrailingCommas' });
+        });
 
-    it('should allow space after and before comma in var declaration', function() {
-        expect(checker.checkString('var a , b;')).to.have.no.errors();
-    });
+        it('should report error when no space is given', function() {
+            expect(checker.checkString('var a,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
+        });
 
-    it('should allow new line after comma in var declaration', function() {
-        expect(checker.checkString('var a,\nb,\nc;')).to.have.no.errors();
-    });
+        it('should report error when space is given before but not after comma', function() {
+            expect(checker.checkString('var a ,b;')).to.have.one.validation.error.from('requireSpaceAfterComma');
+        });
 
-    it('should report errors when no space is given in arrays', function() {
-        expect(checker.checkString('var a = [1,2,3,4];')).to.have.error.count.equal(3);
-    });
+        it('should allow space after comma in var declaration', function() {
+            expect(checker.checkString('var a, b;')).to.have.no.errors();
+        });
 
-    it('should report errors when space is given before but not after commas in arrays', function() {
-        expect(checker.checkString('var a = [1 ,2 ,3 ,4];')).to.have.error.count.equal(3);
-    });
+        it('should allow space after and before comma in var declaration', function() {
+            expect(checker.checkString('var a , b;')).to.have.no.errors();
+        });
 
-    it('should allow space after comma in arrays', function() {
-        expect(checker.checkString('var a = [1, 2, 3, 4];')).to.have.no.errors();
-    });
+        it('should allow new line after comma in var declaration', function() {
+            expect(checker.checkString('var a,\nb,\nc;')).to.have.no.errors();
+        });
 
-    it('should allow space after and before comma in arrays', function() {
-        expect(checker.checkString('var a = [1 , 2 , 3 , 4];')).to.have.no.errors();
-    });
+        it('should report errors when no space is given in arrays', function() {
+            expect(checker.checkString('var a = [1,2,3,4];')).to.have.error.count.equal(3);
+        });
 
-    it('should allow new line after comma in arrays', function() {
-        expect(checker.checkString('var a = [1,\n2,\n3];')).to.have.no.errors();
-    });
+        it('should report errors when space is given before but not after commas in arrays', function() {
+            expect(checker.checkString('var a = [1 ,2 ,3 ,4];')).to.have.error.count.equal(3);
+        });
 
-    it('should report errors when no space is given in objects', function() {
-        expect(checker.checkString('var a = {x:1,y:2,z:3};')).to.have.error.count.equal(2);
-    });
+        it('should allow space after comma in arrays', function() {
+            expect(checker.checkString('var a = [1, 2, 3, 4];')).to.have.no.errors();
+        });
 
-    it('should report errors when space is given before but not after commas in objects', function() {
-        expect(checker.checkString('var a = {x:1 ,y:2 ,z:3};')).to.have.error.count.equal(2);
-    });
+        it('should allow space after and before comma in arrays', function() {
+            expect(checker.checkString('var a = [1 , 2 , 3 , 4];')).to.have.no.errors();
+        });
 
-    it('should allow space after comma in objects', function() {
-        expect(checker.checkString('var a = {x: 1, y: 2, z: 3};')).to.have.no.errors();
-    });
+        it('should allow space after trailing comma in arrays', function() {
+            expect(checker.checkString('var a = [1, 2, 3, 4, ];')).to.have.no.errors();
+        });
 
-    it('should allow space after and before comma in objects', function() {
-        expect(checker.checkString('var a = {x: 1 , y: 2 , z: 3};')).to.have.no.errors();
-    });
+        it('should allow no space after trailing comma in arrays', function() {
+            expect(checker.checkString('var a = [1, 2, 3, 4,];')).to.have.no.errors();
+        });
 
-    it('should allow new line after comma in objects', function() {
-        expect(checker.checkString('var a = {x: 1,\ny: 2,\nz: 3};')).to.have.no.errors();
-    });
+        it('should allow new line after comma in arrays', function() {
+            expect(checker.checkString('var a = [1,\n2,\n3];')).to.have.no.errors();
+        });
 
+        it('should report errors when no space is given in objects', function() {
+            expect(checker.checkString('var a = {x:1,y:2,z:3};')).to.have.error.count.equal(2);
+        });
+
+        it('should allow when no space is given after trailing comma in object', function() {
+            expect(checker.checkString('var a = {x:1, y:2, z:3,};')).to.have.no.errors();
+        });
+
+        it('should report errors when space is given before but not after commas in objects', function() {
+            expect(checker.checkString('var a = {x:1 ,y:2 ,z:3};')).to.have.error.count.equal(2);
+        });
+
+        it('should allow space after comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1, y: 2, z: 3};')).to.have.no.errors();
+        });
+
+        it('should allow space after and before comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1 , y: 2 , z: 3};')).to.have.no.errors();
+        });
+
+        it('should allow new line after comma in objects', function() {
+            expect(checker.checkString('var a = {x: 1,\ny: 2,\nz: 3};')).to.have.no.errors();
+        });
+
+        it('should allow when no space is given after trailing comma in object in array', function() {
+            expect(checker.checkString('var a = [{a:1, b:2,}, {c:3, d:4,},];')).to.have.no.errors();
+        });
+
+    });
 });

--- a/test/specs/rules/require-space-after-comma.js
+++ b/test/specs/rules/require-space-after-comma.js
@@ -92,7 +92,7 @@ describe('rules/require-space-after-comma', function() {
     describe('option value "exceptTrailingCommas"', function() {
 
         beforeEach(function() {
-            checker.configure({ requireSpaceAfterComma: 'exceptTrailingCommas' });
+            checker.configure({ requireSpaceAfterComma: { allExcept: ['trailing'] } });
         });
 
         it('should report error when no space is given', function() {
@@ -169,6 +169,16 @@ describe('rules/require-space-after-comma', function() {
 
         it('should allow when no space is given after trailing comma in object in array', function() {
             expect(checker.checkString('var a = [{a:1, b:2,}, {c:3, d:4,},];')).to.have.no.errors();
+        });
+
+    });
+
+    describe('incorrect configuration', function() {
+
+        it('should not accept options without a valid key', function() {
+            expect(function() {
+                checker.configure({ requireSpaceAfterComma: {} });
+            }).to.throw('AssertionError');
         });
 
     });


### PR DESCRIPTION
New rule value: exceptTrailingCommas will allow commas to be followed by
either } or ] as an alternative to a space.

Fixes #1915