### PR TITLE
add allExcept: ["moduleExports"] in requireMatchingFunctionName rule

### DIFF
--- a/lib/rules/require-matching-function-name.js
+++ b/lib/rules/require-matching-function-name.js
@@ -2,11 +2,12 @@
  * Requires function names to match member and property names.
  *
  * It doesn't affect anonymous functions nor functions assigned to members or
- * properties named with a reserved word.
+ * properties named with a reserved word. Assigning to `module.exports` is also
+ * ignored, unless `includeModuleExports: true` is configured.
  *
- * Type: `Boolean`
+ * Types: `Boolean` or `Object`
  *
- * Value: `true`
+ * Values: `true` or Object with `includeModuleExports: true`
  *
  * #### Example
  *
@@ -30,6 +31,14 @@
  * var test = {foo: function foo() {}};
  * ```
  *
+ * ```js
+ * module.exports = function foo() {};
+ * ```
+ *
+ * ```js
+ * module['exports'] = function foo() {};
+ * ```
+ *
  * ##### Invalid
  *
  * ```js
@@ -45,6 +54,27 @@
  * ```js
  * var test = {foo: function bar() {}};
  * ```
+ *
+ * ```js
+ * var test = {module: {}};
+ * test.module.exports = function foo() {};
+ * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireMatchingFunctionName": { "includeModuleExports": true }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * module.exports = function foo() {};
+ * ```
+ *
+ * ```js
+ * module['exports'] = function foo() {};
+ * ```
  */
 
 var assert = require('assert');
@@ -54,10 +84,16 @@ module.exports = function() {};
 
 module.exports.prototype = {
     configure: function(requireMatchingFunctionName) {
-        assert(
-            requireMatchingFunctionName === true,
-            'requireMatchingFunctionName option requires true value or should be removed'
-        );
+        if (typeof requireMatchingFunctionName === 'object') {
+            assert(requireMatchingFunctionName.includeModuleExports === true,
+                'requireMatchingFunctionName option requires includeModuleExports property to be true for object');
+            this._includeModuleExports = requireMatchingFunctionName.includeModuleExports;
+        } else {
+            assert(
+                requireMatchingFunctionName === true,
+                'requireMatchingFunctionName option requires true value or should be removed'
+            );
+        }
     },
 
     getOptionName: function() {
@@ -65,13 +101,16 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var _includeModuleExports = this._includeModuleExports;
         file.iterateNodesByType(['FunctionExpression'], function(node) {
             switch (node.parentNode.type) {
                 // var foo = function bar() {}
                 // object.foo = function bar() {}
                 // object['foo'] = function bar() {}
                 case 'AssignmentExpression':
-                    checkForMember(node.parentNode, skip, errors);
+                    if (_includeModuleExports || !_isModuleExports(node.parentNode.left)) {
+                        checkForMember(node.parentNode, skip, errors);
+                    }
                     break;
 
                 // object = {foo: function bar() {}}
@@ -95,6 +134,26 @@ module.exports.prototype = {
         }
     }
 };
+
+function _isModuleExports(pattern) {
+    if (pattern.type === 'MemberExpression') {
+        // must be module.sth
+        if (pattern.object.type === 'Identifier' &&
+            pattern.object.name === 'module') {
+
+            if (pattern.property.type === 'Identifier' &&
+                pattern.property.name === 'exports') {
+                // sth.exports
+                return true;
+            } else if (pattern.property.type === 'Literal' &&
+                pattern.property.value === 'exports') {
+                // sth["exports"]
+                return true;
+            }
+        }
+    }
+    return false;
+}
 
 /**
  * Fetching name from a Pattern

--- a/test/specs/rules/require-matching-function-name.js
+++ b/test/specs/rules/require-matching-function-name.js
@@ -89,24 +89,54 @@ describe('rules/require-matching-function-name', function() {
             assertNoErrors('let [ bar ] = [ function bar(){} ];');
         });
 
-        function assertErrorForMemberNameMismatch(js) {
-            assertError(js, 'Function name does not match member name');
-        }
+        // "Ignore module.exports" tests:
 
-        function assertErrorForPropertyNameMismatch(js) {
-            assertError(js, 'Function name does not match property name');
-        }
+        it('should NOT throw when assigning unmatched named function to module.exports', function() {
+            assertNoErrors('var module; module.exports = function foo(name) {};');
+        });
 
-        function assertError(js, message) {
-            var errors = checker.checkString(js).getErrorList();
-            expect(errors.length).to.be.at.least(1);
-            expect(errors[0].rule).to.equal('requireMatchingFunctionName');
-            expect(errors[0].message).to.equal(message);
-        }
+        it('should NOT throw when assigning unmatched named function to module["exports"]', function() {
+            assertNoErrors('var module; module["exports"] = function foo(name) {};');
+        });
 
-        function assertNoErrors(js) {
-            var errors = checker.checkString(js).getErrorList();
-            expect(errors.length).to.equal(0);
-        }
+        it('should report function name when assigning unmatched named function to module ' +
+            'which is a property of other variable', function() {
+            assertErrorForMemberNameMismatch('var foo = {module:{}}; foo.module.exports = function bar(name) {};');
+        });
     });
+
+    describe('option includeModuleExports: true', function() {
+        beforeEach(function() {
+            checker.configure({ requireMatchingFunctionName: { includeModuleExports: true } });
+        });
+
+        it('should report function name when assigning unmatched named function to module.exports', function() {
+            assertErrorForMemberNameMismatch('var module; module.exports = function foo(name) {};');
+        });
+
+        it('should report function name when assigning unmatched named function to module["exports"]', function() {
+            assertErrorForMemberNameMismatch('var module; module["exports"] = function foo(name) {};');
+        });
+
+    });
+
+    function assertErrorForMemberNameMismatch(js) {
+        assertError(js, 'Function name does not match member name');
+    }
+
+    function assertErrorForPropertyNameMismatch(js) {
+        assertError(js, 'Function name does not match property name');
+    }
+
+    function assertError(js, message) {
+        var errors = checker.checkString(js).getErrorList();
+        expect(errors.length).to.be.at.least(1);
+        expect(errors[0].rule).to.equal('requireMatchingFunctionName');
+        expect(errors[0].message).to.equal(message);
+    }
+
+    function assertNoErrors(js) {
+        var errors = checker.checkString(js).getErrorList();
+        expect(errors.length).to.equal(0);
+    }
 });


### PR DESCRIPTION
When allExcept: ['moduleExports'] set, ignore no matching names of function declearation assignment to module.exports.

Valid:

```js
module.exports = function foo() {}

module['exports'] = function bar() {}

k.module.exports = function exports() {}
```

Invalid:

```js
k.module.exports = function baz() {}
```