### PR TITLE
Yandex preset: add "allExcept": ["shorthand"] to requireSpacesInAnony…

### DIFF
--- a/presets/yandex.json
+++ b/presets/yandex.json
@@ -47,7 +47,8 @@
     },
     "requireSpacesInAnonymousFunctionExpression": {
         "beforeOpeningRoundBrace": true,
-        "beforeOpeningCurlyBrace": true
+        "beforeOpeningCurlyBrace": true,
+        "allExcept": ["shorthand"]
     },
     "disallowSpacesInNamedFunctionExpression": {
         "beforeOpeningRoundBrace": true


### PR DESCRIPTION
…mousFunctionExpression rule

See https://github.com/jscs-dev/node-jscs/issues/1805

I can't understand how I can add test for this rule to https://github.com/jscs-dev/node-jscs/blob/master/test/data/options/preset/yandex.js, because it works only in `ES6`.