### PR TITLE
requireSpaceBeforeBinaryOperators: report "operator =" instead of "undefined"

### DIFF
--- a/lib/rules/require-space-before-binary-operators.js
+++ b/lib/rules/require-space-before-binary-operators.js
@@ -113,7 +113,7 @@ module.exports.prototype = {
                     errors.assert.whitespaceBetween({
                         token: prevToken,
                         nextToken: operatorToken,
-                        message: 'Operator ' + node.operator + ' should not stick to preceding expression'
+                        message: 'Operator ' + operator + ' should not stick to preceding expression'
                     });
                 }
             }

--- a/test/specs/rules/require-space-before-binary-operators.js
+++ b/test/specs/rules/require-space-before-binary-operators.js
@@ -89,7 +89,8 @@ describe('rules/require-space-before-binary-operators', function() {
 
     it('should report for assignment expression', function() {
         checker.configure({ requireSpaceBeforeBinaryOperators: ['='] });
-        expect(checker.checkString('var x=1')).to.have.one.validation.error.from('requireSpaceBeforeBinaryOperators');
+        expect(checker.checkString('var x=1'))
+          .to.have.one.error('Operator = should not stick to preceding expression');
     });
 
     it('should report for assignment expressions', function() {


### PR DESCRIPTION
Similar to #907, but for the spacing before the = operator.
Before: "Operator undefined should not stick to preceding expression"
After : "Operator = should not stick to preceding expression"