### PR TITLE
Preset: WordPress requireBlocksOnNewline

### DIFF
--- a/presets/wordpress.json
+++ b/presets/wordpress.json
@@ -18,5 +18,6 @@
     "requireCapitalizedComments": {
         "allExcept": ["global", "exported", "jshint", "eslint", "jslint"]
     },
-    "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties"
+    "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
+    "requireBlocksOnNewLines": true
 }

--- a/presets/wordpress.json
+++ b/presets/wordpress.json
@@ -19,5 +19,5 @@
         "allExcept": ["global", "exported", "jshint", "eslint", "jslint"]
     },
     "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
-    "requireBlocksOnNewLines": true
+    "requireBlocksOnNewline": true
 }


### PR DESCRIPTION
See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/:

> `if`/`else`/`for`/`while`/`try` blocks should always use braces, and *always go on multiple lines*.