### PR TITLE
Enforce LF in gitattributes and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 [*]
 charset = utf-8
 trim_trailing_whitespace = true
+end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text eol=lf


### PR DESCRIPTION
After a fresh clone I had problem with the line breaks on my Windows PC.
Since they are already enforced as LF in the .jscsrc file I enforced them even in gitattributes and editorconfig.