### PR TITLE
Fix: disallowSpace(After|Before)Comma

### DIFF
--- a/lib/rules/disallow-space-after-comma.js
+++ b/lib/rules/disallow-space-after-comma.js
@@ -1,27 +1,48 @@
 /**
  * Disallows spaces after commas
  *
- * Types: `Boolean`
+ * Types: `Boolean` or `Object`
  *
- * Values: `true` to disallow any spaces after any comma
+ * Values:
+ *   - `Boolean`: `true` to disallow any spaces after any comma
+ *   - `Object`: `"allExcept"` array of exceptions
+ *     - `"sparseArrays"` to allow spaces in place of absent values in sparse arrays
  *
  * #### Example
  *
  * ```js
  * "disallowSpaceAfterComma": true
  * ```
+ * ```js
+ * "disallowSpaceAfterComma" {"allExcept": ["sparseArrays"]}
+ * ```
  *
- * ##### Valid
+ * ##### Valid for mode `true`
  *
  * ```js
  * [a,b,c];
  * ```
  *
- * ##### Invalid
+ * ##### Invalid for mode `true`
  *
  * ```js
  * [a, b, c];
  * ```
+ * ```js
+ * [a,b, , ,c];
+ * ```
+ *
+ * ##### Valid for mode `{"allExcept": ["sparseArrays"]}`
+ *
+ * ```js
+ * [a,b, , ,c];
+ * ```
+ *
+ * ##### Invalid for mode `{"allExcept": ["sparseArrays"]}`
+ *
+ * ```js
+ * [a, b, , , c];
+ * ``
  */
 
 var assert = require('assert');
@@ -31,11 +52,21 @@ module.exports = function() {
 
 module.exports.prototype = {
 
-    configure: function(option) {
+    configure: function(options) {
+        if (typeof options !== 'object') {
+            assert(
+                options === true,
+                this.getOptionName() + ' option requires true value or an object'
+            );
+            var _options = {allExcept: []};
+            return this.configure(_options);
+        }
+
         assert(
-            option === true,
-            this.getOptionName() + ' option requires true value'
+            Array.isArray(options.allExcept),
+            ' property `allExcept` in ' + this.getOptionName() + ' should be an array of strings'
         );
+        this._exceptSparseArrays = options.allExcept.indexOf('sparseArrays') >= 0;
     },
 
     getOptionName: function() {
@@ -43,10 +74,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var exceptSparseArrays = this._exceptSparseArrays;
         file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
             var nextToken = file.getNextToken(token);
 
-            if (nextToken.value === ',') {
+            if (exceptSparseArrays && nextToken.value === ',') {
                 return;
             }
             errors.assert.noWhitespaceBetween({

--- a/lib/rules/disallow-space-before-comma.js
+++ b/lib/rules/disallow-space-before-comma.js
@@ -1,27 +1,48 @@
 /**
  * Disallows spaces before commas
  *
- * Types: `Boolean`
+ * Types: `Boolean` or `Object`
  *
- * Values: `true` to disallow any spaces before any comma
+ * Values:
+ *   - `Boolean`: `true` to disallow any spaces before any comma
+ *   - `Object`: `"allExcept"` array of exceptions
+ *     - `"sparseArrays"` to allow spaces in place of absent values in sparse arrays
  *
  * #### Example
  *
  * ```js
  * "disallowSpaceBeforeComma": true
  * ```
+ * ```js
+ * "disallowSpaceBeforeComma": {"allExcept": ["sparseArrays"]}
+ * ```
  *
- * ##### Valid
+ * ##### Valid for mode `true`
  *
  * ```js
  * var a, b;
  * ```
  *
- * ##### Invalid
+ * ##### Invalid for mode `true`
  *
  * ```js
  * var a ,b;
  * ```
+ * ```js
+ * [a, b, , , c]
+ * ```
+ * ##### Valid for mode `{"allExcept": ["sparseArrays"]}`
+ *
+ * ```js
+ * [a, b, , , c]
+ * ```
+ *
+ * ##### Invalid for mode  `{"allExcept": ["sparseArrays"]}`
+ *
+ * ```js
+ * [a , b , , , c]
+ * ```
+ *
  */
 
 var assert = require('assert');
@@ -31,11 +52,21 @@ module.exports = function() {
 
 module.exports.prototype = {
 
-    configure: function(option) {
+    configure: function(options) {
+        if (typeof options !== 'object') {
+            assert(
+                options === true,
+                this.getOptionName() + ' option requires true value or an object'
+            );
+            var _options = {allExcept: []};
+            return this.configure(_options);
+        }
+
         assert(
-            option === true,
-            this.getOptionName() + ' option requires true value'
+            Array.isArray(options.allExcept),
+            ' property `allExcept` in ' + this.getOptionName() + ' should be an array of strings'
         );
+        this._exceptSparseArrays = options.allExcept.indexOf('sparseArrays') >= 0;
     },
 
     getOptionName: function() {
@@ -43,10 +74,11 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
+        var exceptSparseArrays = this._exceptSparseArrays;
         file.iterateTokensByTypeAndValue('Punctuator', ',', function(token) {
             var prevToken = file.getPrevToken(token);
 
-            if (prevToken.value === ',') {
+            if (exceptSparseArrays && prevToken.value === ',') {
                 return;
             }
             errors.assert.noWhitespaceBetween({

--- a/test/specs/rules/disallow-space-after-comma.js
+++ b/test/specs/rules/disallow-space-after-comma.js
@@ -51,7 +51,21 @@ describe('rules/disallow-space-after-comma', function() {
     });
 
     it('does allow sparse arrays', function() {
+        expect(checker.checkString('[a,,,b,c]')).to.have.no.errors();
+    });
+
+    it('does not allow spaces in sparse arrays', function() {
+        expect(checker.checkString('[a, , ,b,c]')).to.have.error.count.equal(2);
+    });
+
+    it('does allow spaces in sparse arrays when excepted', function() {
+        checker.configure({ disallowSpaceAfterComma: {allExcept: ['sparseArrays']}});
         expect(checker.checkString('[a, , ,b,c]')).to.have.no.errors();
+    });
+
+    it('does allow spaces in sparse arrays when excepted but not before values', function() {
+        checker.configure({ disallowSpaceAfterComma: {allExcept: ['sparseArrays']}});
+        expect(checker.checkString('[a, , , b, c]')).to.have.error.count.equal(2);
     });
 
     it('does not allow spaces after commas in objects', function() {

--- a/test/specs/rules/disallow-space-before-comma.js
+++ b/test/specs/rules/disallow-space-before-comma.js
@@ -51,7 +51,21 @@ describe('rules/disallow-space-before-comma', function() {
     });
 
     it('does allow sparse arrays', function() {
-        expect(checker.checkString('[a, , , b, c]')).to.have.no.errors();
+        expect(checker.checkString('[a,,,b,c]')).to.have.no.errors();
+    });
+
+    it('does not allow spaces in sparse arrays', function() {
+        expect(checker.checkString('[a, , ,b,c]')).to.have.error.count.equal(2);
+    });
+
+    it('does allow spaces in sparse arrays when excepted', function() {
+        checker.configure({ disallowSpaceBeforeComma: {allExcept: ['sparseArrays']}});
+        expect(checker.checkString('[a, , ,b,c]')).to.have.no.errors();
+    });
+
+    it('does allow spaces in sparse arrays when excepted but not after values', function() {
+        checker.configure({ disallowSpaceBeforeComma: {allExcept: ['sparseArrays']}});
+        expect(checker.checkString('[a , , , b , c]')).to.have.error.count.equal(2);
     });
 
     it('does not allow spaces before commas in objects', function() {


### PR DESCRIPTION
Added {allExcept: ['sparseArrays']} option for the rules.

Fixes: #1944