### PR TITLE
require-camelcase-or-uppercase-identifiers strict mode

### DIFF
--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -63,12 +63,24 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(options) {
-        assert(
-            options === true || options === 'ignoreProperties',
-            this.getOptionName() + ' option requires a true value or `ignoreProperties`'
-        );
+        if (typeof options !== 'object') {
+            assert(
+              options === true || options === 'ignoreProperties',
+              this.getOptionName() + ' option requires a true value or `ignoreProperties`'
+            );
+            var _options = {
+                ignoreProperties: options === 'ignoreProperties' ? true : false,
+                strict: false
+            };
+            return this.configure(_options);
+        }
 
-        this._ignoreProperties = (options === 'ignoreProperties');
+        assert(
+          typeof options.ignoreProperties === 'boolean' || typeof options.strict === 'boolean',
+          this.getOptionName() + ' option should have boolean values for ignoreProperties and/or strict'
+        );
+        this._ignoreProperties = options.ignoreProperties;
+        this._strict = options.strict;
     },
 
     getOptionName: function() {
@@ -79,7 +91,13 @@ module.exports.prototype = {
         file.iterateTokensByType('Identifier', function(token) {
             var value = token.value;
             if (value.replace(/^_+|_+$/g, '').indexOf('_') === -1 || value.toUpperCase() === value) {
-                return;
+                if (this._strict) {
+                    if (value[0].toUpperCase() !== value[0] || value[0] === '_') {
+                        return;
+                    }
+                }else {
+                    return;
+                }
             }
             if (this._ignoreProperties) {
                 var nextToken = file.getNextToken(token);

--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -1,12 +1,15 @@
 /**
  * Requires identifiers to be camelCased or UPPERCASE_WITH_UNDERSCORES
  *
- * Types: `Boolean` or `String`
+ * Types: `Boolean` or `String` or `Object`
  *
  * Values:
  *
  * - `true`
- * - `"ignoreProperties"` allows an exception for object property names.
+ * - `"ignoreProperties"` allows an exception for object property names. Deprecated, Please use the `Object` value
+ * - `Object`:
+ *    - `ignoreProperties`:  boolean that allows an exception for object property names
+ *    - `strict`: boolean that forces the first character to not be capitalized
  *
  * JSHint: [`camelcase`](http://jshint.com/docs/options/#camelcase)
  *
@@ -14,6 +17,8 @@
  *
  * ```js
  * "requireCamelCaseOrUpperCaseIdentifiers": true
+ *
+ * "requireCamelCaseOrUpperCaseIdentifiers": {ignoreProperties: true, strict: true}
  * ```
  *
  * ##### Valid for mode `true`
@@ -111,11 +116,8 @@ module.exports.prototype = {
         file.iterateTokensByType('Identifier', function(token) {
             var value = token.value;
             if (value.replace(/^_+|_+$/g, '').indexOf('_') === -1 || value.toUpperCase() === value) {
-                if (this._strict) {
-                    if (value[0].toUpperCase() !== value[0] || value[0] === '_') {
-                        return;
-                    }
-                }else {
+                if (!this._strict) {return;}
+                if (value[0].toUpperCase() !== value[0] || value[0] === '_') {
                     return;
                 }
             }

--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -54,6 +54,26 @@
  * var mixed_Case = 3;
  * var snake_case = { snake_case: 6 };
  * ```
+ *
+ * ##### Valid for mode `strict`
+ *
+ * ```js
+ * var camelCase = 0;
+ * var _camelCase = 2;
+ * var camelCase_ = 3;
+ * var UPPER_CASE = 4;
+ * var obj.snake_case = 5;
+ * var camelCase = { snake_case: 6 };
+ * ```
+ *
+ * ##### Invalid for mode `strict`
+ *
+ * ```js
+ * var Mixed_case = 2;
+ * var Snake_case = { snake_case: 6 };
+ * var snake_case = { SnakeCase: 6 };
+ * ```
+ *
  */
 
 var assert = require('assert');

--- a/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
@@ -100,4 +100,183 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
             expect(checker.checkString('var extend = { set c_d(v) { } };')).to.have.no.errors();
         });
     });
+
+    describe('option object value `"ignoreProperties"`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {ignoreProperties: true} });
+        });
+
+        it('should not report object keys', function() {
+            expect(checker.checkString('var extend = { snake_case: a };')).to.have.no.errors();
+        });
+
+        it('should not report object properties', function() {
+            expect(checker.checkString('var extend = a.snake_case;')).to.have.no.errors();
+        });
+
+        it('should report identifiers that are the last token', function() {
+            expect(checker.checkString('var a = snake_case'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that are the first token', function() {
+            expect(checker.checkString('snake_case = a;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report es5 getters', function() {
+            expect(checker.checkString('var extend = { get a_b() { } };')).to.have.no.errors();
+        });
+
+        it('should not report es5 setters', function() {
+            expect(checker.checkString('var extend = { set c_d(v) { } };')).to.have.no.errors();
+        });
+    });
+
+    describe('option object value `"strict"`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {strict: true} });
+        });
+
+        it('should report capital', function() {
+            expect(checker.checkString('var X = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report capital word', function() {
+            expect(checker.checkString('var Xoe = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report capital used even with second one lower cased', function() {
+            expect(checker.checkString('var Xy = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report no capital used', function() {
+            expect(checker.checkString('var xy = "x";')).to.have.no.errors();
+        });
+
+        it('should not report leading underscores', function() {
+            expect(checker.checkString('var _x = "x", __y = "y";')).to.have.no.errors();
+        });
+
+        it('should report trailing underscores', function() {
+            expect(checker.checkString('var x_ = "x", y__ = "y";')).to.have.no.errors();
+        });
+
+        it('should not report underscore.js', function() {
+            expect(checker.checkString('var extend = _.extend;')).to.have.no.errors();
+        });
+
+        it('should not report node globals', function() {
+            expect(checker.checkString('var a = __dirname + __filename;')).to.have.no.errors();
+        });
+
+        it('should report object keys', function() {
+            expect(checker.checkString('var extend = { snake_case: a };'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report object properties', function() {
+            expect(checker.checkString('var extend = a.snake_case;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report object properties without capital', function() {
+            expect(checker.checkString('var extend = a.snakeCase;')).to.have.no.errors();
+        });
+
+        it('should report object properties with capital', function() {
+            expect(checker.checkString('var extend = a.SnakeCase;'))
+            .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that are the last token', function() {
+            expect(checker.checkString('var a = snake_case'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that are the first token', function() {
+            expect(checker.checkString('snake_case = a;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that start with a capital', function() {
+            expect(checker.checkString('E'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+    });
+
+    describe('option object value `"strict"` and `"ignoreProperties"`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {strict: true, ignoreProperties: true} });
+        });
+
+        it('should report capital', function() {
+            expect(checker.checkString('var X = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report capital word', function() {
+            expect(checker.checkString('var Xoe = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report capital used even with second one lower cased', function() {
+            expect(checker.checkString('var Xy = "x";'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report no capital used', function() {
+            expect(checker.checkString('var xy = "x";')).to.have.no.errors();
+        });
+
+        it('should not report leading underscores', function() {
+            expect(checker.checkString('var _x = "x", __y = "y";')).to.have.no.errors();
+        });
+
+        it('should report trailing underscores', function() {
+            expect(checker.checkString('var x_ = "x", y__ = "y";')).to.have.no.errors();
+        });
+
+        it('should not report underscore.js', function() {
+            expect(checker.checkString('var extend = _.extend;')).to.have.no.errors();
+        });
+
+        it('should not report node globals', function() {
+            expect(checker.checkString('var a = __dirname + __filename;')).to.have.no.errors();
+        });
+
+        it('should not report object keys', function() {
+            expect(checker.checkString('var extend = { snake_case: a };')).to.have.no.errors();
+        });
+
+        it('should not report object properties', function() {
+            expect(checker.checkString('var extend = a.snake_case;')).to.have.no.errors();
+        });
+
+        it('should not report object properties without capital', function() {
+            expect(checker.checkString('var extend = a.snakeCase;')).to.have.no.errors();
+        });
+
+        it('should report object properties with capital', function() {
+            expect(checker.checkString('var extend = a.SnakeCase;')).to.have.no.errors();
+        });
+
+        it('should report identifiers that are the last token', function() {
+            expect(checker.checkString('var a = snake_case'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that are the first token', function() {
+            expect(checker.checkString('snake_case = a;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report identifiers that start with a capital', function() {
+            expect(checker.checkString('E'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+    });
 });


### PR DESCRIPTION
Added a strict mode, rendering capitals as a first character invalid for
an identifier.

@markelog this 'should' add the strict mode we talked about on gitter.