### PR TITLE
disallowTrailingWhitespace: fix autofixing CRLF and CR files

### DIFF
--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -517,6 +517,7 @@ TokenAssert.prototype.noTokenBefore = function(options) {
 TokenAssert.prototype.noTrailingSpaces = function(options) {
     var ignoreEmptyLines = options.ignoreEmptyLines;
     var lines = this._file.getLines();
+    var linebreak = this._file.getLineBreaks()[0] || '\n';
 
     for (var i = 0, l = lines.length; i < l; i++) {
         if (lines[i].match(/\s$/) && !(ignoreEmptyLines && lines[i].match(/^\s*$/))) {
@@ -549,7 +550,7 @@ TokenAssert.prototype.noTrailingSpaces = function(options) {
                     if (precendingToken.type === 'Block') {
 
                         if (ignoreEmptyLines) {
-                            var blockLines = precendingToken.value.split(/\n/);
+                            var blockLines = precendingToken.value.split(/\r\n|\n|\r/);
 
                             for (var k = 0; k < blockLines.length; k++) {
 
@@ -558,9 +559,9 @@ TokenAssert.prototype.noTrailingSpaces = function(options) {
                                 }
                             }
 
-                            precendingToken.value = blockLines.join('\n');
+                            precendingToken.value = blockLines.join(linebreak);
                         } else {
-                            precendingToken.value = precendingToken.value.split(/\s\n/).join('\n');
+                            precendingToken.value = precendingToken.value.split(/\s\r\n|\s\n|\s\r/).join(linebreak);
                         }
                     } else {
                         precendingToken.value = precendingToken.value.split(/\s$/).join('');
@@ -580,7 +581,7 @@ TokenAssert.prototype.noTrailingSpaces = function(options) {
                     targetIndent += whitespace;
                 }
 
-                this._file.setWhitespaceBefore(targetToken, new Array(eolCount).join('\n') + targetIndent);
+                this._file.setWhitespaceBefore(targetToken, new Array(eolCount).join(linebreak) + targetIndent);
                 fixed = true;
             }
 

--- a/test/specs/rules/disallow-trailing-whitespace.js
+++ b/test/specs/rules/disallow-trailing-whitespace.js
@@ -75,6 +75,30 @@ describe('rules/disallow-trailing-whitespace', function() {
         output: '/*\nbla\n\t\n*/'
     });
 
+    reportAndFix({
+        name: 'supports windows line breaks',
+        rules: rules,
+        errors: 2,
+        input: ' \r\nvar a; \r\nvar b;\r\n var c;\r\n',
+        output: '\r\nvar a;\r\nvar b;\r\n var c;\r\n'
+    });
+
+    reportAndFix({
+        name: 'supports windows line breaks in a comment',
+        rules: rules,
+        errors: 1,
+        input: '//hey \r\n',
+        output: '//hey\r\n'
+    });
+
+    reportAndFix({
+        name: 'supports mac line breaks',
+        rules: rules,
+        errors: 2,
+        input: ' \rvar a; \rvar b;\r var c;\r',
+        output: '\rvar a;\rvar b;\r var c;\r'
+    });
+
     describe('option value true', function() {
         beforeEach(function() {
             checker.configure({ disallowTrailingWhitespace: true });


### PR DESCRIPTION
it would be slightly better if this used the line endings option, but that doesn't autofix yet.

thinking about this and the line endings option, have you thought about/would you accept a pr that instead of altering tokens, added a post output hook to fix ? trailing whitespace and eol would be a doddle to fix post output, instead of all the complications in finding the right token..