### PR TITLE
disallowTrailingWhitespace: fix bugs by post processing

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -30,8 +30,9 @@ Errors.prototype = {
      * @param {String} message
      * @param {Number|Object} line
      * @param {Number} [column] optional if line is an object
+     * @param {Boolean} [fixed] optional if error is fixed
      */
-    add: function(message, line, column) {
+    add: function(message, line, column, fixed) {
         if (typeof line === 'object') {
             column = line.column;
             line = line.line;
@@ -40,7 +41,8 @@ Errors.prototype = {
         var errorInfo = {
             message: message,
             line: line,
-            column: column
+            column: column,
+            fixed: fixed
         };
 
         this._validateInput(errorInfo);

--- a/lib/js-file.js
+++ b/lib/js-file.js
@@ -862,6 +862,18 @@ JsFile.prototype = {
     },
 
     /**
+     * Registers a function to be run when rendering which can modify the output
+     *
+     * @param {Function} postProcessor
+     */
+    registerPostRenderProcessor: function(postProcessor) {
+        if (!this.postRenderProcessors) {
+            this.postRenderProcessors = [];
+        }
+        this.postRenderProcessors.push(postProcessor);
+    },
+
+    /**
      * Renders JS-file sources using token list.
      *
      * @returns {String}
@@ -886,6 +898,12 @@ JsFile.prototype = {
 
                 default:
                     result += token.value;
+            }
+        }
+
+        if (this.postRenderProcessors) {
+            for (i = 0; i < this.postRenderProcessors.length; i++) {
+                result = this.postRenderProcessors[i](result);
             }
         }
 

--- a/lib/rules/validate-line-breaks.js
+++ b/lib/rules/validate-line-breaks.js
@@ -69,12 +69,22 @@ module.exports.prototype = {
             return;
         }
 
+        var needsFixing = false;
+        var allowedLineBreak = this._allowedLineBreak;
+
         file.getLineBreaks().some(function(lineBreak, i) {
-            if (lineBreak !== this._allowedLineBreak) {
-                errors.add('Invalid line break', i + 1, lines[i].length);
+            if (lineBreak !== allowedLineBreak) {
+                needsFixing = true;
+                errors.add('Invalid line break', i + 1, lines[i].length, true);
                 return this._reportOncePerFile;
             }
         }, this);
-    }
 
+        if (needsFixing) {
+            file.registerPostRenderProcessor(function(output) {
+                var lines = output.split(/\r\n|\n|\r/);
+                return lines.join(allowedLineBreak);
+            });
+        }
+    }
 };

--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -517,82 +517,37 @@ TokenAssert.prototype.noTokenBefore = function(options) {
 TokenAssert.prototype.noTrailingSpaces = function(options) {
     var ignoreEmptyLines = options.ignoreEmptyLines;
     var lines = this._file.getLines();
+    var needsFixing = false;
 
     for (var i = 0, l = lines.length; i < l; i++) {
         if (lines[i].match(/\s$/) && !(ignoreEmptyLines && lines[i].match(/^\s*$/))) {
-            var fixed = false;
-            var currentLineNumber = i + 1;
-            var startLineNumber;
-            var precendingToken;
-            var targetToken;
-
-            while (!precendingToken && currentLineNumber > 0) {
-                precendingToken = this._file.getLastTokenOnLine(currentLineNumber, {
-                    includeComments: true
-                });
-                currentLineNumber--;
-            }
-
-            if (precendingToken === null) {
-                targetToken = this._file.getFirstToken({includeComments: true});
-                startLineNumber = 1;
-            } else {
-                targetToken = this._file.getNextToken(precendingToken, {
-                    includeComments: true
-                });
-                startLineNumber = precendingToken.loc.end.line;
-
-                if (precendingToken.isComment &&
-                    precendingToken.loc.start.line <= (i + 1) &&
-                    precendingToken.loc.end.line >= (i + 1)) {
-
-                    if (precendingToken.type === 'Block') {
-
-                        if (ignoreEmptyLines) {
-                            var blockLines = precendingToken.value.split(/\n/);
-
-                            for (var k = 0; k < blockLines.length; k++) {
-
-                                if (!blockLines[k].match(/^\s*$/) || k === 0) {
-                                    blockLines[k] = blockLines[k].split(/\s$/).join('');
-                                }
-                            }
-
-                            precendingToken.value = blockLines.join('\n');
-                        } else {
-                            precendingToken.value = precendingToken.value.split(/\s\n/).join('\n');
-                        }
-                    } else {
-                        precendingToken.value = precendingToken.value.split(/\s$/).join('');
-                    }
-
-                    fixed = true;
-                }
-            }
-
-            if (targetToken !== null && !fixed) {
-                var eolCount = targetToken.loc.start.line - startLineNumber + 1;
-                var targetIndent = '';
-                var targetLine = lines[targetToken.loc.start.line - 1];
-                for (var j = 0, whitespace = targetLine.charAt(j);
-                    whitespace.match(/\s/);
-                    j++, whitespace = targetLine.charAt(j)) {
-                    targetIndent += whitespace;
-                }
-
-                this._file.setWhitespaceBefore(targetToken, new Array(eolCount).join('\n') + targetIndent);
-                fixed = true;
-            }
-
-            precendingToken = null;
+            needsFixing = true;
 
             this.emit('error', {
                 message: 'Illegal trailing whitespace',
                 line: i + 1,
                 column: lines[i].length,
-                fixed: fixed
+                fixed: true
             });
         }
+    }
+
+    if (needsFixing) {
+        this._file.registerPostRenderProcessor(function(output) {
+            // get the line break from the output and not this._file.getLineBreaks
+            // to work with autofixing eol running first
+            var firstLineBreakMatch = output.match(/\r\n|\n|\r/);
+            var lineBreak = firstLineBreakMatch ? firstLineBreakMatch[0] : '\n';
+            var lines = output.split(/\r\n|\n|\r/);
+            for (var i = 0; i < lines.length; i++) {
+                var line = lines[i];
+                if (ignoreEmptyLines && line.match(/^\s*$/)) {
+                    continue;
+                }
+                lines[i] = line.replace(/\s+$/, '');
+            }
+            return lines.join(lineBreak);
+        });
     }
 };
 

--- a/test/specs/rules/disallow-trailing-whitespace.js
+++ b/test/specs/rules/disallow-trailing-whitespace.js
@@ -52,10 +52,34 @@ describe('rules/disallow-trailing-whitespace', function() {
     });
 
     reportAndFix({
+        name: 'illegal multiple-whitespace in comment block',
+        rules: rules,
+        errors: 1,
+        input: '/*\n *      \n */',
+        output: '/*\n *\n */'
+    });
+
+    reportAndFix({
+        name: 'illegal multiple-whitespace in comment block when ignoring empty lines',
+        rules: { disallowTrailingWhitespace: 'ignoreEmptyLines' },
+        errors: 1,
+        input: '/*\n *      \n\n */',
+        output: '/*\n *\n\n */'
+    });
+
+    reportAndFix({
         name: 'illegal whitespace in comment line',
         rules: rules,
         errors: 1,
         input: '// line 1 \n// line 2\n',
+        output: '// line 1\n// line 2\n'
+    });
+
+    reportAndFix({
+        name: 'illegal multiple-whitespace in comment line',
+        rules: rules,
+        errors: 1,
+        input: '// line 1      \n// line 2\n',
         output: '// line 1\n// line 2\n'
     });
 
@@ -73,6 +97,54 @@ describe('rules/disallow-trailing-whitespace', function() {
         errors: 1,
         input: '/* \nbla\n\t\n*/',
         output: '/*\nbla\n\t\n*/'
+    });
+
+    reportAndFix({
+        name: 'fixes spaces on the last line',
+        rules: rules,
+        errors: 1,
+        input: 'var a;\n ',
+        output: 'var a;\n'
+    });
+
+    reportAndFix({
+        name: 'fixes space and comment on the last line',
+        rules: rules,
+        errors: 1,
+        input: 'var a;\n/**/ ',
+        output: 'var a;\n/**/'
+    });
+
+    reportAndFix({
+        name: 'fixes spaces on the last lines',
+        rules: rules,
+        errors: 3,
+        input: 'var a;\n \n \n ',
+        output: 'var a;\n\n\n'
+    });
+
+    reportAndFix({
+        name: 'supports windows line breaks',
+        rules: rules,
+        errors: 2,
+        input: ' \r\nvar a; \r\nvar b;\r\n var c;\r\n',
+        output: '\r\nvar a;\r\nvar b;\r\n var c;\r\n'
+    });
+
+    reportAndFix({
+        name: 'supports windows line breaks in a comment',
+        rules: rules,
+        errors: 1,
+        input: '//hey \r\n',
+        output: '//hey\r\n'
+    });
+
+    reportAndFix({
+        name: 'supports mac line breaks',
+        rules: rules,
+        errors: 2,
+        input: ' \rvar a; \rvar b;\r var c;\r',
+        output: '\rvar a;\rvar b;\r var c;\r'
     });
 
     describe('option value true', function() {

--- a/test/specs/rules/validate-line-breaks.js
+++ b/test/specs/rules/validate-line-breaks.js
@@ -1,4 +1,5 @@
 var Checker = require('../../../lib/checker');
+var reportAndFix = require('../../lib/assertHelpers').reportAndFix;
 var expect = require('chai').expect;
 
 describe('rules/validate-line-breaks', function() {
@@ -15,9 +16,12 @@ describe('rules/validate-line-breaks', function() {
     });
 
     describe('LF', function() {
-        it('should report invalid line break character once per file', function() {
-            checker.configure({ validateLineBreaks: 'LF' });
-            expect(checker.checkString('x = 1;\r\ny = 2;\r\n')).to.have.one.validation.error.from('validateLineBreaks');
+        reportAndFix({
+            name: 'invalid line break character once per file',
+            rules: { validateLineBreaks: 'LF' },
+            errors: 1,
+            input: 'x = 1;\r\ny = 2;\r\n',
+            output: 'x = 1;\ny = 2;\n'
         });
 
         it('should report all invalid line break character', function() {
@@ -32,9 +36,12 @@ describe('rules/validate-line-breaks', function() {
     });
 
     describe('CR', function() {
-        it('should report invalid line break character once per file', function() {
-            checker.configure({ validateLineBreaks: 'CR' });
-            expect(checker.checkString('x = 1;\r\ny = 2;\r\n')).to.have.one.validation.error.from('validateLineBreaks');
+        reportAndFix({
+            name: 'invalid line break character once per file',
+            rules: { validateLineBreaks: 'CR' },
+            errors: 1,
+            input: 'x = 1;\r\ny = 2;\r\n',
+            output: 'x = 1;\ry = 2;\r'
         });
 
         it('should report all invalid line break character', function() {
@@ -49,9 +56,20 @@ describe('rules/validate-line-breaks', function() {
     });
 
     describe('CRLF', function() {
-        it('should report invalid line break character once per file', function() {
-            checker.configure({ validateLineBreaks: 'CRLF' });
-            expect(checker.checkString('x = 1;\ny = 2;\n')).to.have.one.validation.error.from('validateLineBreaks');
+        reportAndFix({
+            name: 'invalid line break character once per file - LF -> CRLF',
+            rules: { validateLineBreaks: 'CRLF' },
+            errors: 1,
+            input: 'x = 1;\ny = 2;\n',
+            output: 'x = 1;\r\ny = 2;\r\n'
+        });
+
+        reportAndFix({
+            name: 'invalid line break character once per file - CR -> CRLF',
+            rules: { validateLineBreaks: 'CRLF' },
+            errors: 1,
+            input: 'x = 1;\ry = 2;\r',
+            output: 'x = 1;\r\ny = 2;\r\n'
         });
 
         it('should report all invalid line break character', function() {


### PR DESCRIPTION
As noted in #1980 I think this is a better way of doing it.

All tests and fixes from #1978, #1979, #1980 are present and also add autofixing of the validate line breaks rule.