### PR TITLE
Add the `disallowVar` rule

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -948,6 +948,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-shorthand-arrow-functions'));
     this.registerRule(require('../rules/disallow-identical-destructuring-names'));
     this.registerRule(require('../rules/require-spaces-in-generator'));
+    this.registerRule(require('../rules/disallow-var'));
 
     /* ES6 only (end) */
 

--- a/lib/rules/disallow-var.js
+++ b/lib/rules/disallow-var.js
@@ -1,0 +1,57 @@
+/**
+ * Disallows declaring variables with `var`.
+ *
+ * Types: `Boolean`
+ *
+ * Values: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowVar": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * let foo;
+ * const bar;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var baz;
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() { };
+
+module.exports.prototype = {
+    configure: function(option) {
+        assert(option === true, this.getOptionName() + ' requires a true value');
+    },
+
+    getOptionName: function() {
+        return 'disallowVar';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('VariableDeclaration', function(node) {
+            for (var i = 0; i < node.declarations.length; i++) {
+                var thisDeclaration = node.declarations[i];
+
+                if (thisDeclaration.parentNode.kind === 'var') {
+                    errors.add(
+                      'Variable declarations should use `let` or `const` not `var`',
+                      node.loc.start
+                    );
+                }
+            }
+        });
+    }
+};

--- a/test/specs/rules/disallow-var.js
+++ b/test/specs/rules/disallow-var.js
@@ -1,0 +1,52 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/disallow-var', function() {
+    describe('when { disallowVar: true }', function() {
+        it('disallows `var` declarations', function() {
+            var checker = buildChecker({ disallowVar: true });
+
+            expect(checker.checkString('var foo;')).to.have.one.validation.error.from('disallowVar');
+        });
+
+        it('allows `let` declarations', function() {
+            var checker = buildChecker({ disallowVar: true });
+
+            expect(checker.checkString('let foo;')).to.have.no.errors();
+        });
+
+        it('allows `const` declarations', function() {
+            var checker = buildChecker({ disallowVar: true });
+
+            expect(checker.checkString('const foo = 1;')).to.have.no.errors();
+        });
+    });
+
+    describe('when { disallowVar: false }', function() {
+        it('allows `var` declarations', function() {
+            var checker = buildChecker({ disallowVar: false });
+
+            expect(checker.checkString('var foo;')).to.have.no.errors();
+        });
+
+        it('allows `let` declarations', function() {
+            var checker = buildChecker({ disallowVar: false });
+
+            expect(checker.checkString('let foo;')).to.have.no.errors();
+        });
+
+        it('allows `const` declarations', function() {
+            var checker = buildChecker({ disallowVar: false });
+
+            expect(checker.checkString('const foo = 1;')).to.have.no.errors();
+        });
+    });
+
+    function buildChecker(rules) {
+        var checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+
+        return checker;
+    }
+});


### PR DESCRIPTION
When `{ disallowVar: true }`, assert that all variable declarations use
`let` or `const`.