### PR TITLE
Add `requireArrayDestructuring` rule

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -948,6 +948,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-shorthand-arrow-functions'));
     this.registerRule(require('../rules/disallow-identical-destructuring-names'));
     this.registerRule(require('../rules/require-spaces-in-generator'));
+    this.registerRule(require('../rules/require-array-destructuring'));
 
     /* ES6 only (end) */
 

--- a/lib/rules/require-array-destructuring.js
+++ b/lib/rules/require-array-destructuring.js
@@ -1,0 +1,72 @@
+/**
+ * Requires that variable assignment from array values are * destructured.
+ *
+ * Type: `Boolean`
+ *
+ * Values:
+ *  - `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireArrayDestructuring": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var colors = ['red', 'green', 'blue'];
+ * var [ red ] = colors;
+ *
+ * var attributes = {
+ *   colors: ['red', 'green', 'blue'];
+ * };
+ *
+ * var [ red ] = attributes.colors;
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var colors = ['red', 'green', 'blue'];
+ * var red = colors[0];
+ *
+ * var attributes = {
+ *   colors: ['red', 'green', 'blue'];
+ * };
+ *
+ * var red = attributes.colors[0];
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(option) {
+        assert(option === true, this.getOptionName() + ' requires a true value');
+    },
+
+    getOptionName: function() {
+        return 'requireArrayDestructuring';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('VariableDeclaration', function(node) {
+
+            node.declarations.forEach(function(declaration) {
+                if (!declaration.init || declaration.init.type !== 'MemberExpression') {
+                    return;
+                }
+
+                var property = declaration.init.property || {};
+                if (property.type === 'Literal' && /^\d+$/.test(property.value)) {
+                    errors.add('Use array destructuring', property.loc.start);
+                }
+            });
+        });
+    }
+};

--- a/test/specs/rules/require-array-destructuring.js
+++ b/test/specs/rules/require-array-destructuring.js
@@ -1,0 +1,65 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/require-array-destructuring', function() {
+    var nestedWithDestructuring = [
+        'var attributes = {',
+        '  colors: ["red", "green", "blue"]',
+        '};',
+        'var first = attributes.colors[0];'
+    ].join('\n');
+
+    var withDestructuring = [
+        'var colors = ["red", "green", "blue"];',
+        'var [ red ] = colors;'
+    ].join('\n');
+
+    var withIndexing = [
+        'var colors = ["red", "green", "blue"];',
+        'var red = colors[0];'
+    ].join('\n');
+
+    describe('when { requireArrayDestructuring: true }', function() {
+        it('allows array destructuring', function() {
+            var checker = buildChecker({ requireArrayDestructuring: true });
+
+            expect(checker.checkString(withDestructuring)).to.have.no.errors();
+        });
+
+        it('disallows variable assignment via array indexing with a literal', function() {
+            var checker = buildChecker({ requireArrayDestructuring: true });
+
+            expect(checker.checkString(withIndexing)).
+              to.have.one.validation.error.from('requireArrayDestructuring');
+        });
+
+        it('requires nested array destructuring', function() {
+            var checker = buildChecker({ requireArrayDestructuring: true });
+
+            expect(checker.checkString(nestedWithDestructuring))
+              .to.have.one.validation.error.from('requireArrayDestructuring');
+        });
+    });
+
+    describe('when { requireArrayDestructuring: false }', function() {
+        it('allows array destructuring', function() {
+            var checker = buildChecker({ requireArrayDestructuring: false });
+
+            expect(checker.checkString(withDestructuring)).to.have.no.errors();
+        });
+
+        it('allows variable assignment via array indexing with a literal', function() {
+            var checker = buildChecker({ requireArrayDestructuring: false });
+
+            expect(checker.checkString(withDestructuring)).to.have.no.errors();
+        });
+    });
+
+    function buildChecker(rules) {
+        var checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+
+        return checker;
+    }
+});


### PR DESCRIPTION
When `{ requireArrayDestructuring: true }`, assert that variable
declarations use array destructuring when assigning via indexing the
array with a literal.