### PR TITLE
Add `requireEnhancedObjectLiterals`

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -948,6 +948,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-shorthand-arrow-functions'));
     this.registerRule(require('../rules/disallow-identical-destructuring-names'));
     this.registerRule(require('../rules/require-spaces-in-generator'));
+    this.registerRule(require('../rules/require-enhanced-object-literals'));
 
     /* ES6 only (end) */
 

--- a/lib/rules/require-enhanced-object-literals.js
+++ b/lib/rules/require-enhanced-object-literals.js
@@ -1,0 +1,79 @@
+/**
+ * Requires declaring objects via ES6 enhanced object literals
+ *
+ * Type: `Boolean`
+ *
+ * Values: true
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireEnhancedObjectLiterals": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var bar = true;
+ * var obj = {
+ *   foo() { },
+ *   bar
+ * };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var bar = true;
+ * var obj = {
+ *   foo: function() { },
+ *   bar: bar
+ * };
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() { };
+
+module.exports.prototype = {
+    configure: function(option) {
+        assert(option === true, this.getOptionName() + ' requires a true value');
+    },
+
+    getOptionName: function() {
+        return 'requireEnhancedObjectLiterals';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('Property', function(node) {
+            // node.key.name is used when the property key is an unquoted identifier
+            // node.key.value is used when the property key is a quoted string
+            var propertyName = node.key.name || node.key.value;
+            var valueName = node.value.name;
+            var shorthand = node.shorthand;
+
+            // check for non-shorthand properties
+            if (propertyName && propertyName === valueName && !shorthand) {
+                errors.add(
+                  'Property assignment should use enhanced object literal function.\n' +
+                  ' `{ propName: propName }` is not allowed.',
+                  node.loc.start
+                );
+            }
+
+            // check for non-method function properties
+            var valueType = node.value.type;
+            var valueIsMethod = node.method;
+            if (valueType === 'FunctionExpression' && !valueIsMethod) {
+                errors.add(
+                  'Property assignment should use enhanced object literal function.\n' +
+                  ' `{ funcName: function() {} }` is not allowed.',
+                  node.loc.start
+                );
+            }
+        });
+    }
+};

--- a/test/specs/rules/require-enhanced-object-literals.js
+++ b/test/specs/rules/require-enhanced-object-literals.js
@@ -1,0 +1,74 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/require-enhanced-object-literals', function() {
+    describe('when { requireEnhancedObjectLiterals: true }', function() {
+        it('disallows declaring functions as values', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: true });
+
+            expect(checker.checkString('var obj = { foo: function() { } }')).
+              to.have.one.validation.error.from('requireEnhancedObjectLiterals');
+        });
+
+        it('disallows declaring values keyed by the variable name', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: true });
+            var code = 'var foo;\n' +
+                       'var obj = { foo: foo };';
+
+            expect(checker.checkString(code)).
+              to.have.one.validation.error.from('requireEnhancedObjectLiterals');
+        });
+
+        it('allows declaring functions as values', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: true });
+
+            expect(checker.checkString('var obj = { foo() { } }')).to.have.no.errors();
+        });
+
+        it('allows declaring values keyed by the variable name', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: true });
+            var code = 'var foo;\n' +
+                       'var obj = { foo };';
+
+            expect(checker.checkString(code)).to.have.no.errors();
+        });
+    });
+
+    describe('when { requireEnhancedObjectLiterals: false }', function() {
+        it('allows declaring functions as values', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: false });
+
+            expect(checker.checkString('var obj = { foo: function() { } }')).to.no.errors();
+        });
+
+        it('allows declaring values keyed by the variable name', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: false });
+            var code = 'var foo;\n' +
+                       'var obj = { foo: foo };';
+
+            expect(checker.checkString(code)).to.have.no.errors();
+        });
+
+        it('allows declaring functions as values', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: false });
+
+            expect(checker.checkString('var obj = { foo() { } }')).to.have.no.errors();
+        });
+
+        it('allows declaring values keyed by the variable name', function() {
+            var checker = buildChecker({ requireEnhancedObjectLiterals: false });
+            var code = 'var foo;\n' +
+                       'var obj = { foo };';
+
+            expect(checker.checkString(code)).to.have.no.errors();
+        });
+    });
+
+    function buildChecker(rules) {
+        var checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+
+        return checker;
+    }
+});


### PR DESCRIPTION
When `{ requireEnhancedObjectLiterals: true }`, assert that all
object declarations use the new [ES6 enhanced object literals][babel].

[babel]: http://babeljs.io/docs/learn-es2015/#enhanced-object-literals