### PR TITLE
Add `requireObjectDestructuring` rule

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -948,6 +948,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-shorthand-arrow-functions'));
     this.registerRule(require('../rules/disallow-identical-destructuring-names'));
     this.registerRule(require('../rules/require-spaces-in-generator'));
+    this.registerRule(require('../rules/require-object-destructuring'));
 
     /* ES6 only (end) */
 

--- a/lib/rules/require-object-destructuring.js
+++ b/lib/rules/require-object-destructuring.js
@@ -1,0 +1,77 @@
+/**
+ * Requires variable declarations from objects via destructuring
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * Version: `ES6`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireObjectDestructuring": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var { foo } = SomeThing;
+ * var { bar } = SomeThing.foo;
+ * var { val } = SomeThing['some.key'];
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var foo = SomeThing.foo;
+ * var bar = SomeThing.foo.bar;
+ * var val = SomeThing['some.key'].val;
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(option) {
+        var isTrue = option === true;
+
+        assert(
+            isTrue || (typeof option === 'object' && Array.isArray(option.allExcept)),
+            this.getOptionName() + ' requires the value `true` ' +
+              'or an object with an `allExcept` array property'
+        );
+
+        this._propertyExceptions = !isTrue && option.allExcept || [];
+    },
+
+    getOptionName: function() {
+        return 'requireObjectDestructuring';
+    },
+
+    check: function(file, errors) {
+        var propertyExceptions = this._propertyExceptions;
+
+        file.iterateNodesByType('VariableDeclaration', function(node) {
+
+            node.declarations.forEach(function(declaration) {
+                var declarationId = declaration.id || {};
+                var declarationInit = declaration.init || {};
+
+                if (declarationId.type !== 'Identifier' || declarationInit.type !== 'MemberExpression') {
+                    return;
+                }
+
+                var propertyName = declarationInit.property && declarationInit.property.name;
+
+                if (declarationId.name === propertyName &&
+                    propertyExceptions.indexOf(propertyName) < 0) {
+
+                    errors.add('Property assignments should use destructuring', node.loc.start);
+                }
+            });
+        });
+    }
+};

--- a/test/specs/rules/require-object-destructuring.js
+++ b/test/specs/rules/require-object-destructuring.js
@@ -1,0 +1,53 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/require-object-destructuring', function() {
+    describe('when { requireObjectDestructuring: true }', function() {
+        it('disallows direct property access/assignment', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var foo = SomeThing.foo;')).
+              to.have.one.validation.error.from('requireObjectDestructuring');
+        });
+
+        it('disallows nested property access/assignment', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var bar = SomeThing.foo.bar;')).
+              to.have.one.validation.error.from('requireObjectDestructuring');
+        });
+
+        it('disallows access/assignment with a string literal', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var val = SomeThing["some.key"].val;')).
+              to.have.one.validation.error.from('requireObjectDestructuring');
+        });
+
+        it('allows destructuring direct property access/assignment', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var { foo } = SomeThing;')).to.have.no.errors();
+        });
+
+        it('allows destructuring nested property access/assignment', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var { bar } = SomeThing.foo;')).to.have.no.errors();
+        });
+
+        it('allows destructuring access/assignment with a string literal', function() {
+            var checker = buildChecker({ requireObjectDestructuring: true });
+
+            expect(checker.checkString('var { val } = SomeThing["some.key"];')).to.have.no.errors();
+        });
+    });
+
+    function buildChecker(rules) {
+        var checker = new Checker();
+        checker.registerDefaultRules();
+        checker.configure(rules);
+
+        return checker;
+    }
+});


### PR DESCRIPTION
When `{ requireObjectDestructuring: true }`, assert that variable
declarations use object destructuring when assigning via object access.