### PR TITLE
New rule: requireEarlyReturn

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -1135,6 +1135,8 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-tabs'));
 
     this.registerRule(require('../rules/require-aligned-multiline-params'));
+
+    this.registerRule(require('../rules/require-early-return'));
 };
 
 /**

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -1,3 +1,41 @@
+/**
+ * Requires to return early in a function.
+ *
+ * Types: `String`
+ *
+ * Values:
+ *  - `noElse`: disallow to use of else if the corrisponding `if` block contain a return.
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireEarlyReturn": "noElse"
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * function test() {
+ *     if (x) {
+ *         return x;
+ *     }
+ *     return y;
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function test() {
+ *     if (x) {
+ *         return x;
+ *     } else {
+ *         return y;
+ *     }
+ * }
+ * ```
+ */
+
 var assert = require('assert');
 
 module.exports = function() {};
@@ -17,7 +55,7 @@ module.exports.prototype = {
     check: function(file, errors) {
         function addError(entity) {
             errors.add(
-                'use of else after return',
+                'Use of else after return',
                 entity.loc.start.line,
                 entity.loc.start.column
             );
@@ -34,8 +72,10 @@ module.exports.prototype = {
             }
 
             if (ifBranch.type === 'BlockStatement') {
-                if (ifBranch.body[ifBranch.body.length - 1].type === 'ReturnStatement') {
-                    return addError(node.alternate);
+                for (var i = ifBranch.body.length - 1; i >= 0; i--) {
+                    if (ifBranch.body[i].type === 'ReturnStatement') {
+                        return addError(node.alternate);
+                    }
                 }
             }
         });

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -105,7 +105,7 @@ module.exports.prototype = {
                 }
             }
 
-            return addError(node.alternate);
+            return addError(file.getPrevToken(file.getFirstNodeToken(node.alternate)));
         });
     }
 };

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -61,23 +61,31 @@ module.exports.prototype = {
             );
         }
 
+        function hasNodeReturn(node) {
+            if (node.type === 'BlockStatement') {
+                for (var i = node.body.length - 1; i >= 0; i--) {
+                    if (node.body[i].type === 'ReturnStatement') {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return node.type === 'ReturnStatement';
+        }
+
         file.iterateNodesByType('IfStatement', function(node) {
             if (!node.alternate) {
                 return;
             }
 
-            var ifBranch = node.consequent;
-            if (ifBranch.type === 'ReturnStatement') {
-                return addError(node.alternate);
-            }
-
-            if (ifBranch.type === 'BlockStatement') {
-                for (var i = ifBranch.body.length - 1; i >= 0; i--) {
-                    if (ifBranch.body[i].type === 'ReturnStatement') {
-                        return addError(node.alternate);
-                    }
+            // Check if all the parents have a return statement, if not continue to the following IfStatement node.
+            for (var nodeIf = node; nodeIf && nodeIf.type === 'IfStatement'; nodeIf = nodeIf.parentNode) {
+                if (nodeIf.alternate && !hasNodeReturn(nodeIf.consequent)) {
+                    return;
                 }
             }
+
+            return addError(node.alternate);
         });
     }
 };

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -61,6 +61,14 @@ module.exports.prototype = {
             );
         }
 
+        // Check if the IfStatement node contain a ReturnStatement.
+        // If the node has a block, check all the statements in backward order to see if there is one.
+        // This is to ensure that code like this will still return true:
+        //
+        // if (true) {
+        //    return;
+        //    eval();
+        // }
         function hasNodeReturn(node) {
             if (node.type === 'BlockStatement') {
                 for (var i = node.body.length - 1; i >= 0; i--) {
@@ -79,6 +87,18 @@ module.exports.prototype = {
             }
 
             // Check if all the parents have a return statement, if not continue to the following IfStatement node.
+            //
+            // Example:
+            //
+            // if (foo) {
+            //     return;
+            // } else if (bar) {  <-- error
+            //     bar();
+            // } else if (baz) {  <-- safe
+            //     return baz();
+            // } else {           <-- safe
+            //     bas();
+            // }
             for (var nodeIf = node; nodeIf && nodeIf.type === 'IfStatement'; nodeIf = nodeIf.parentNode) {
                 if (nodeIf.alternate && !hasNodeReturn(nodeIf.consequent)) {
                     return;

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === 'noElse',
+            this.getOptionName() + ' option allow only the `noElse` value'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireEarlyReturn';
+    },
+
+    check: function(file, errors) {
+        function addError(entity) {
+            errors.add(
+                'use of else after return',
+                entity.loc.start.line,
+                entity.loc.start.column
+            );
+        }
+
+        file.iterateNodesByType('IfStatement', function(node) {
+            if (!node.alternate) {
+                return;
+            }
+
+            var ifBranch = node.consequent;
+            if (ifBranch.type === 'ReturnStatement') {
+                return addError(node.alternate);
+            }
+
+            if (ifBranch.type === 'BlockStatement') {
+                if (ifBranch.body[ifBranch.body.length - 1].type === 'ReturnStatement') {
+                    return addError(node.alternate);
+                }
+            }
+        });
+    }
+};

--- a/lib/rules/require-early-return.js
+++ b/lib/rules/require-early-return.js
@@ -1,15 +1,15 @@
 /**
  * Requires to return early in a function.
  *
- * Types: `String`
+ * Types: `Boolean`
  *
  * Values:
- *  - `noElse`: disallow to use of else if the corrisponding `if` block contain a return.
+ *  - `true`: disallow to use of else if the corrisponding `if` block contain a return.
  *
  * #### Example
  *
  * ```js
- * "requireEarlyReturn": "noElse"
+ * "requireEarlyReturn": true
  * ```
  *
  * ##### Valid
@@ -43,8 +43,8 @@ module.exports = function() {};
 module.exports.prototype = {
     configure: function(options) {
         assert(
-            options === 'noElse',
-            this.getOptionName() + ' option allow only the `noElse` value'
+            options === true,
+            this.getOptionName() + ' option allow only the `true` value'
         );
     },
 

--- a/test/specs/rules/require-early-return.js
+++ b/test/specs/rules/require-early-return.js
@@ -63,6 +63,11 @@ describe('rules/require-early-return', function() {
                 str = 'function foo() { if (x) if (y) return; else var b }';
                 expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
             });
+
+            it('should report the use of else after return in a nested chain of if-else mixed', function() {
+                str = 'function foo() { if (x) { } else { if (y) return; else var b } }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
         });
 
         describe('safe if-else - ', function() {

--- a/test/specs/rules/require-early-return.js
+++ b/test/specs/rules/require-early-return.js
@@ -9,9 +9,9 @@ describe('rules/require-early-return', function() {
         checker.registerDefaultRules();
     });
 
-    describe('with option value noElse - ', function() {
+    describe('with option value `true` - ', function() {
         beforeEach(function() {
-            checker.configure({ requireEarlyReturn: 'noElse' });
+            checker.configure({ requireEarlyReturn: true });
         });
 
         var str;

--- a/test/specs/rules/require-early-return.js
+++ b/test/specs/rules/require-early-return.js
@@ -16,9 +16,12 @@ describe('rules/require-early-return', function() {
 
         var str;
 
-        // Should be errors
+        describe('errors with simple if-else - ', function() {
+            it('should report the use of else after return on an if-else block', function() {
+                str = 'if (true) { return } else { }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
 
-        describe('simple if-else - ', function() {
             it('should report the use of else after return', function() {
                 str = 'function foo() { if (x) { return y; } else { return z; } }';
                 expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
@@ -33,9 +36,14 @@ describe('rules/require-early-return', function() {
                 str = 'function foo() { if (x) return y; else return z; }';
                 expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
             });
+
+            it('should report the use of else after return when the if block contain a return', function() {
+                str = 'function test() { if (true) { return; eval() } else {} }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
         });
 
-        describe('complex if-else - ', function() {
+        describe('errors with complex if-else - ', function() {
             it('should report the use of else after return in a chain of if-else', function() {
                 str = 'function foo() { if (x) { return y; } else if (z) { return w; } else { return t; } }';
                 expect(checker.checkString(str)).to.have.errors.from('requireEarlyReturn');
@@ -57,9 +65,12 @@ describe('rules/require-early-return', function() {
             });
         });
 
-        // Should pass
-
         describe('safe if-else - ', function() {
+            it('should not report on an empty if', function() {
+                str = 'function test() { if (true) { } }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+
             it('should not report the use of else after return', function() {
                 str = 'function foo() { if (x) { return y; } return z; }';
                 expect(checker.checkString(str)).to.have.no.errors();
@@ -72,23 +83,6 @@ describe('rules/require-early-return', function() {
 
             it('should not report the use of else after return with nested if', function() {
                 str = 'function foo() { if (x) { if (z) { return y; } } else { return z; } }';
-                expect(checker.checkString(str)).to.have.no.errors();
-            });
-        });
-
-        // One should fail, one should pass
-
-        describe('check isPercentage function - ', function() {
-            it('should report errors', function() {
-                str = 'function isPercentage(val) {' +
-                    'if (val >= 0) { if (val < 100) { return true; } else { return false; } } else { return false; }' +
-                    '}';
-                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
-            });
-            it('should not report errors', function() {
-                str = 'function isPercentage(val) {' +
-                    'if (val >= 0) { if (val < 100) { return true; } return false; } return false;' +
-                    '}';
                 expect(checker.checkString(str)).to.have.no.errors();
             });
         });

--- a/test/specs/rules/require-early-return.js
+++ b/test/specs/rules/require-early-return.js
@@ -76,8 +76,18 @@ describe('rules/require-early-return', function() {
                 expect(checker.checkString(str)).to.have.no.errors();
             });
 
-            it('should not report the use of else after return with blocks', function() {
+            it('should not report the use of else after return with blocks 1', function() {
                 str = 'function foo() { if (x) { foo(); } else if (z) { var t = "foo"; } else { return w; } }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+
+            it('should not report the use of else after return with blocks 2', function() {
+                str = 'function foo() { if (x) { bar(); } else if (z) { return "foo"; } else { baz(); } }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+
+            it('should not report the use of else after return with blocks without braces', function() {
+                str = 'function foo() { if (x) bar(); else if (z) return "foo"; else baz(); }';
                 expect(checker.checkString(str)).to.have.no.errors();
             });
 

--- a/test/specs/rules/require-early-return.js
+++ b/test/specs/rules/require-early-return.js
@@ -1,0 +1,96 @@
+var expect = require('chai').expect;
+var Checker = require('../../../lib/checker');
+
+describe('rules/require-early-return', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('with option value noElse - ', function() {
+        beforeEach(function() {
+            checker.configure({ requireEarlyReturn: 'noElse' });
+        });
+
+        var str;
+
+        // Should be errors
+
+        describe('simple if-else - ', function() {
+            it('should report the use of else after return', function() {
+                str = 'function foo() { if (x) { return y; } else { return z; } }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+
+            it('should report the use of else after return with small blocks', function() {
+                str = 'function foo() { if (x) { var a; return y; } else { return z; } }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+
+            it('should report the use of else after return without braces', function() {
+                str = 'function foo() { if (x) return y; else return z; }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+        });
+
+        describe('complex if-else - ', function() {
+            it('should report the use of else after return in a chain of if-else', function() {
+                str = 'function foo() { if (x) { return y; } else if (z) { return w; } else { return t; } }';
+                expect(checker.checkString(str)).to.have.errors.from('requireEarlyReturn');
+            });
+
+            it('should report the use of else after return in an if-else', function() {
+                str = 'function foo() { if (x) { return y; } else { var t = "foo"; } return t; }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+
+            it('should report the use of else after return in a nested chain of if-else', function() {
+                str = 'function foo() { if (x) { if (y) { return y; } else { return x; } } else { return z; } }';
+                expect(checker.checkString(str)).to.have.errors.from('requireEarlyReturn');
+            });
+
+            it('should report the use of else after return in a nested chain of if-else without braces', function() {
+                str = 'function foo() { if (x) if (y) return; else var b }';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+        });
+
+        // Should pass
+
+        describe('safe if-else - ', function() {
+            it('should not report the use of else after return', function() {
+                str = 'function foo() { if (x) { return y; } return z; }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+
+            it('should not report the use of else after return with blocks', function() {
+                str = 'function foo() { if (x) { foo(); } else if (z) { var t = "foo"; } else { return w; } }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+
+            it('should not report the use of else after return with nested if', function() {
+                str = 'function foo() { if (x) { if (z) { return y; } } else { return z; } }';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+        });
+
+        // One should fail, one should pass
+
+        describe('check isPercentage function - ', function() {
+            it('should report errors', function() {
+                str = 'function isPercentage(val) {' +
+                    'if (val >= 0) { if (val < 100) { return true; } else { return false; } } else { return false; }' +
+                    '}';
+                expect(checker.checkString(str)).to.have.one.validation.error.from('requireEarlyReturn');
+            });
+            it('should not report errors', function() {
+                str = 'function isPercentage(val) {' +
+                    'if (val >= 0) { if (val < 100) { return true; } return false; } return false;' +
+                    '}';
+                expect(checker.checkString(str)).to.have.no.errors();
+            });
+        });
+    });
+});


### PR DESCRIPTION
With this PR now this config `{ requireEarlyReturn: 'noElse' }` would cause the use of else after return to be forbidden.
While this should close https://github.com/jscs-dev/node-jscs/issues/1223, it doesn't change the if conditions as seems requested in the first comment.
