### PR TITLE
`requirePaddingNewlinesBeforeKeywords`: allow returning functions on same line

### DIFF
--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -131,7 +131,10 @@ module.exports.prototype = {
             // Handle special cases listed in specialCasesToken array
             if (prevToken && prevToken.value === specialCases[token.value]) {
                 return;
-            } else if (prevToken  && token.value === 'while' &&
+            // Allow returning a function
+            } else if (prevToken && prevToken.value === 'return' && token.value === 'function') {
+                return;
+            } else if (prevToken && token.value === 'while' &&
                 file.getNodesByFirstToken(token).length === 0) {
                 return;
             // Handle excludedTokens

--- a/test/specs/rules/require-padding-newlines-before-keywords.js
+++ b/test/specs/rules/require-padding-newlines-before-keywords.js
@@ -138,5 +138,15 @@ describe('rules/require-padding-newlines-before-keywords', function() {
                     'function x() { var a; return; }'
                 )).to.have.one.validation.error.from('requirePaddingNewlinesBeforeKeywords');
         });
+
+        it('should not report when returning a function', function() {
+            expect(checker.checkString(
+                    'function x() {\n' +
+                    '  var a = 0;\n' +
+                    '  \n' +
+                    '  return function() {};\n' +
+                    '}'
+                )).to.have.no.errors();
+        });
     });
 });


### PR DESCRIPTION
When returning functions when not on the first line in the current scope, the style checker fails.
with the following config:
```json
  "requirePaddingNewlinesBeforeKeywords": true
```

```js
// Invalid
function func() {
    var a = 0;

    return function() {}
}
```
This adds an exception in the logic of the rule to allow returning an anonymous function.

```js
// valid
function func() {
    var a = 0;
    
    return function() {/*...*/}
}
```