### PR TITLE
requireCamelCaseorUpperCaseIdentifiers: Allow object restructuring with ignoreProperties set

### DIFF
--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -129,6 +129,23 @@ module.exports.prototype = {
                     return;
                 }
 
+                /* This enables an identifier to be snake cased via the object
+                 * destructuring pattern. We must check to see if the identifier
+                 * is being used to set values into an object to determine if
+                 * this is a legal assignment.
+                 * Example: ({camelCase: snake_case}) => camelCase.length
+                 */
+                if (prevToken && prevToken.value === ':') {
+                    var node = file.getNodeByRange(token.range[0]);
+                    var parentNode = node.parentNode;
+                    if (parentNode && parentNode.type === 'Property') {
+                        var grandpa = parentNode.parentNode;
+                        if (grandpa && grandpa.type === 'ObjectPattern') {
+                            return;
+                        }
+                    }
+                }
+
                 if (prevToken && (prevToken.value === '.' ||
                     prevToken.value === 'get' || prevToken.value === 'set')) {
                     return;

--- a/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
@@ -67,6 +67,12 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
             expect(checker.checkString('snake_case = a;'))
               .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
         });
+
+        it('should report object destructring', function() {
+            expect(checker.checkString(
+                '({camelCase: snake_case, camelCase2: {camelCase3: snake_case2}}) => camelCase.length;'))
+              .to.have.validation.errors.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
     });
 
     describe('option value `"ignoreProperties"`', function() {
@@ -99,6 +105,12 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
         it('should not report es5 setters', function() {
             expect(checker.checkString('var extend = { set c_d(v) { } };')).to.have.no.errors();
         });
+
+        it('should not report object destructring', function() {
+            expect(checker.checkString(
+                '({camelCase: snake_case, camelCase2: {camelCase3: snake_case2}}) => camelCase.length;'))
+              .to.have.no.errors();
+        });
     });
 
     describe('option object value `"ignoreProperties"`', function() {
@@ -130,6 +142,12 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
 
         it('should not report es5 setters', function() {
             expect(checker.checkString('var extend = { set c_d(v) { } };')).to.have.no.errors();
+        });
+
+        it('should not report object destructring', function() {
+            expect(checker.checkString(
+                '({camelCase: snake_case, camelCase2: {camelCase3: snake_case2}}) => camelCase.length;'))
+              .to.have.no.errors();
         });
     });
 
@@ -277,6 +295,12 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
         it('should report identifiers that start with a capital', function() {
             expect(checker.checkString('E'))
               .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report object destructring', function() {
+            expect(checker.checkString(
+                '({camelCase: snake_case, camelCase2: {camelCase3: snake_case2}}) => camelCase.length;'))
+              .to.have.no.errors();
         });
     });
 });


### PR DESCRIPTION
Allows the object destructuring syntax to be used with objects that have
snake_cased properties and the `ignoreProperties` option set to true.

Fixes #2003 