### PR TITLE
Update airbnb preset braces/bracket spacing

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -12,6 +12,7 @@
     "disallowSpacesInFunctionDeclaration": {
         "beforeOpeningRoundBrace": true
     },
+    "disallowSpacesInsideBrackets": true,
     "disallowEmptyBlocks": true,
     "disallowSpacesInCallExpression": true,
     "disallowSpacesInsideArrayBrackets": true,
@@ -47,6 +48,7 @@
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
     "requireSpacesInForStatement": true,
+    "requireSpacesInsideObjectBrackets": "all",
     "requireSpaceBetweenArguments": true,
     "requireCurlyBraces": [
         "do"


### PR DESCRIPTION
Airbnb added the following:

[18.10](https://github.com/airbnb/javascript#18.10) Do not add spaces inside brackets.

and

[18.11](https://github.com/airbnb/javascript#18.11) Add spaces inside curly braces.