### PR TITLE
add units suffix support to requireCamelCaseOrUpperCaseIdentifiers

### DIFF
--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -115,9 +115,15 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateTokensByType('Identifier', function(token) {
             var value = token.value;
-            if (value.replace(/^_+|_+$/g, '').indexOf('_') === -1 || value.toUpperCase() === value) {
+
+            // Leading and trailing underscores signify visibility/scope and do not affect
+            // validation of the rule.  Remove them to simplify the checks.
+            var isPrivate = (value[0] === '_');
+            value = value.replace(/^_+|_+$/g, '');
+
+            if (value.indexOf('_') === -1 || value.toUpperCase() === value) {
                 if (!this._strict) {return;}
-                if (value[0].toUpperCase() !== value[0] || value[0] === '_') {
+                if (value.length === 0 || value[0].toUpperCase() !== value[0] || isPrivate) {
                     return;
                 }
             }

--- a/lib/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/lib/rules/require-camelcase-or-uppercase-identifiers.js
@@ -10,6 +10,8 @@
  * - `Object`:
  *    - `ignoreProperties`:  boolean that allows an exception for object property names
  *    - `strict`: boolean that forces the first character to not be capitalized
+ *    - `allowedPrefixes`: array of String or RegExp values permitted as prefixes before `_`
+ *    - `allowedSuffixes`: array of String or RegExp values permitted as suffixes after `_`
  *
  * JSHint: [`camelcase`](http://jshint.com/docs/options/#camelcase)
  *
@@ -19,6 +21,10 @@
  * "requireCamelCaseOrUpperCaseIdentifiers": true
  *
  * "requireCamelCaseOrUpperCaseIdentifiers": {"ignoreProperties": true, "strict": true}
+ *
+ * "requireCamelCaseOrUpperCaseIdentifiers": {"allowedPrefixes": ["opt", /pfx\d+/]}
+ *
+ * "requireCamelCaseOrUpperCaseIdentifiers": {"allowedSuffixes": ["dCel", /[kMG]?Hz/]}
  * ```
  *
  * ##### Valid for mode `true`
@@ -79,9 +85,126 @@
  * var snake_case = { SnakeCase: 6 };
  * ```
  *
+ * ##### Valid for `{ allowedPrefix: ["opt", /pfx\d+/] }`
+ * ```js
+ * var camelCase = 0;
+ * var CamelCase = 1;
+ * var _camelCase = 2;
+ * var camelCase_ = 3;
+ * var UPPER_CASE = 4;
+ * var opt_camelCase = 5;
+ * var pfx32_camelCase = 6;
+ * ```
+ *
+ * ##### Invalid for `{ allowedPrefix: ["opt", /pfx\d+/] }`
+ * ```js
+ * var lower_case = 1;
+ * var Mixed_case = 2;
+ * var mixed_Case = 3;
+ * var req_camelCase = 4;
+ * var pfx_CamelCase = 5;
+ * ```
+ *
+ * ##### Valid for `{ allowedSuffixes: ["dCel", /[kMG]?Hz/] }`
+ * ```js
+ * var camelCase = 0;
+ * var CamelCase = 1;
+ * var _camelCase = 2;
+ * var camelCase_ = 3;
+ * var UPPER_CASE = 4;
+ * var camelCase_dCel = 5;
+ * var _camelCase_MHz = 6;
+ * ```
+ *
+ * ##### Invalid for `{ allowedSuffixes: ["dCel", /[kMG]?Hz/] }`
+ * ```js
+ * var lower_case = 1;
+ * var Mixed_case = 2;
+ * var mixed_Case = 3;
+ * var camelCase_cCel = 4;
+ * var CamelCase_THz = 5;
+ * ```
  */
 
 var assert = require('assert');
+
+// Helper for validating allowedPrefixes/allowedSuffixes
+function isArrayOfStringOrRegExp(arr) {
+    if (!Array.isArray(arr)) {
+        return false;
+    }
+    return arr.reduce(function(pv, cv) {
+        return pv && (typeof cv === 'string' || cv instanceof RegExp);
+    }, true);
+}
+
+// Return undefined or the start of the unprefixed value.
+function startAfterStringPrefix(value, prefix) {
+    var start = prefix.length + 1;
+    if (start >= value.length) {
+        return;
+    }
+    if (value.charAt(prefix.length) !== '_') {
+        return;
+    }
+    if (value.substr(0, prefix.length) !== prefix) {
+        return;
+    }
+    return start;
+}
+
+// Return undefined or the start of the unprefixed value.
+function startAfterRegExpPrefix(value, prefix) {
+    var match = prefix.exec(value);
+    if (!match) {
+        return;
+    }
+    if (match.index !== 0) {
+        return;
+    }
+    var start = match[0].length + 1;
+    if (start >= value.length) {
+        return;
+    }
+    if (value.charAt(match[0].length) !== '_') {
+        return;
+    }
+    return start;
+}
+
+// Return undefined or the end of the unsuffixed value.
+function endBeforeStringSuffix(value, suffix) {
+    var ends = value.length - (1 + suffix.length);
+    if (ends <= 0) {
+        return;
+    }
+    if (value.charAt(ends) !== '_') {
+        return;
+    }
+    if (value.substr(ends + 1) !== suffix) {
+        return;
+    }
+    return ends;
+}
+
+// Return undefined or the end of the unsuffixed value.
+function endBeforeRegExpSuffix(value, suffix) {
+    var match = suffix.exec(value);
+    if (!match) {
+        return;
+    }
+    var ends = match.index - 1;
+    if (ends <= 0) {
+        return;
+    }
+    if (value.charAt(ends) !== '_') {
+        return;
+    }
+    if ((ends + 1 + match[0].length) !== value.length) {
+        return;
+    }
+    return ends;
+}
 
 module.exports = function() {};
 
@@ -101,11 +224,32 @@ module.exports.prototype = {
         }
 
         assert(
-          typeof options.ignoreProperties === 'boolean' || typeof options.strict === 'boolean',
-          this.getOptionName() + ' option should have boolean values for ignoreProperties and/or strict'
+          !options.hasOwnProperty('ignoreProperties') || typeof options.ignoreProperties === 'boolean',
+          this.getOptionName() + ' option should have boolean value for ignoreProperties'
         );
         this._ignoreProperties = options.ignoreProperties;
+
+        assert(
+          !options.hasOwnProperty('strict') || typeof options.strict === 'boolean',
+          this.getOptionName() + ' option should have boolean value for strict'
+        );
         this._strict = options.strict;
+
+        assert(
+          !options.hasOwnProperty('allowedPrefixes') || isArrayOfStringOrRegExp(options.allowedPrefixes),
+          this.getOptionName() + ' option should have array of string or RegExp for allowedPrefixes'
+        );
+        if (Array.isArray(options.allowedPrefixes)) {
+            this._allowedPrefixes = options.allowedPrefixes;
+        }
+
+        assert(
+          !options.hasOwnProperty('allowedSuffixes') || isArrayOfStringOrRegExp(options.allowedSuffixes),
+          this.getOptionName() + ' option should have array of string or RegExp for allowedSuffixes'
+        );
+        if (Array.isArray(options.allowedSuffixes)) {
+            this._allowedSuffixes = options.allowedSuffixes;
+        }
     },
 
     getOptionName: function() {
@@ -120,6 +264,44 @@ module.exports.prototype = {
             // validation of the rule.  Remove them to simplify the checks.
             var isPrivate = (value[0] === '_');
             value = value.replace(/^_+|_+$/g, '');
+
+            // Strip at most one prefix permitted text and underscore from the identifier.  This
+            // transformation cannot change an acceptable identifier into an unacceptable
+            // identifier so we can continue with the normal verification of whatever it produces.
+            var i;
+            var len;
+            if (this._allowedPrefixes) {
+                for (i = 0, len = this._allowedPrefixes.length; i < len; ++i) {
+                    var prefix = this._allowedPrefixes[i];
+                    var start;
+                    if (typeof prefix === 'string') {
+                        start = startAfterStringPrefix(value, prefix);
+                    } else {
+                        start = startAfterRegExpPrefix(value, prefix);
+                    }
+                    if (start !== undefined) {
+                        value = value.substr(start);
+                        break;
+                    }
+                }
+            }
+
+            // As with prefix but for a suffix underscore and permitted text.
+            if (this._allowedSuffixes) {
+                for (i = 0, len = this._allowedSuffixes.length; i < len; ++i) {
+                    var suffix = this._allowedSuffixes[i];
+                    var ends;
+                    if (typeof suffix === 'string') {
+                        ends = endBeforeStringSuffix(value, suffix);
+                    } else {
+                        ends = endBeforeRegExpSuffix(value, suffix);
+                    }
+                    if (ends !== undefined) {
+                        value = value.substr(0, ends);
+                        break;
+                    }
+                }
+            }
 
             if (value.indexOf('_') === -1 || value.toUpperCase() === value) {
                 if (!this._strict) {return;}

--- a/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
@@ -9,6 +9,19 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
         checker.registerDefaultRules();
     });
 
+    describe('invalid configuration', function() {
+        it('should report bad prefix values', function() {
+            expect(function() {
+                checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedPrefixes: [42, 'str']} });
+            }).to.throw('AssertionError');
+        });
+        it('should report bad suffix values', function() {
+            expect(function() {
+                checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedSuffixes: {}} });
+            }).to.throw('AssertionError');
+        });
+    });
+
     describe('option value `true`', function() {
         beforeEach(function() {
             checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: true });
@@ -301,6 +314,196 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
             expect(checker.checkString(
                 '({camelCase: snake_case, camelCase2: {camelCase3: snake_case2}}) => camelCase.length;'))
               .to.have.no.errors();
+        });
+    });
+
+    describe('option value `{allowedPrefixes: ["opt", /pfx\d+/]}`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedPrefixes: ['opt', /pfx\d+/]} });
+        });
+
+        it('should not report identifiers too short to have a prefix', function() {
+            expect(checker.checkString('var id = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unrecognized string prefix', function() {
+            expect(checker.checkString('var req_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized string prefix', function() {
+            expect(checker.checkString('var opt_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a hidden recognized string prefix', function() {
+            expect(checker.checkString('var _opt_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a recognized string non-prefix without underscore', function() {
+            expect(checker.checkString('var notopt = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report a recognized string non-prefix with underscore', function() {
+            expect(checker.checkString('var xopt_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized RegExp prefix without underscore', function() {
+            expect(checker.checkString('var pfx5 = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a recognized RegExp non-prefix without underscore', function() {
+            expect(checker.checkString('var nopfx5 = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report a recognized RegExp non-prefix with underscore', function() {
+            expect(checker.checkString('var xpfx_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report an unrecognized RegExp prefix', function() {
+            expect(checker.checkString('var pfx_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized RegExp prefix', function() {
+            expect(checker.checkString('var pfx32_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report a recognized RegExp prefix with trailing garbage', function() {
+            expect(checker.checkString('var pfx32x_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+    });
+
+    describe('option value `{allowedPrefixes: ["o_t", /p_x\d+/}`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedPrefixes: ['o_t', /p_x\d+/]} });
+        });
+
+        it('should report an unrecognized string prefix', function() {
+            expect(checker.checkString('var r_q_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized string prefix', function() {
+            expect(checker.checkString('var o_t_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a hidden recognized string prefix', function() {
+            expect(checker.checkString('var _o_t_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unrecognized RegExp prefix', function() {
+            expect(checker.checkString('var p_x_camelCase = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized RegExp prefix', function() {
+            expect(checker.checkString('var p_x32_camelCase = 0;'))
+              .to.have.no.errors();
+        });
+    });
+
+    describe('option value `{allowedSuffixes: ["dCel", /[kMG]?Hz/]}`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedSuffixes: ['dCel', /[kMG]?Hz/]} });
+        });
+
+        it('should not report identifiers too short to have a suffix', function() {
+            expect(checker.checkString('var id = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unrecognized string suffix', function() {
+            expect(checker.checkString('var temp_Cel = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized string suffix', function() {
+            expect(checker.checkString('var temp_dCel = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unrecognized RegExp suffix', function() {
+            expect(checker.checkString('var freq_THz = 1;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized RegExp suffix', function() {
+            expect(checker.checkString('var freq_Hz = 1;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a RegExp suffix without underscore', function() {
+            expect(checker.checkString('var MHz = 1;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a string non-suffix', function() {
+            expect(checker.checkString('var tempdCel = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should not report a RegExp non-suffix', function() {
+            expect(checker.checkString('var freqHz = 1;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unanchored recognized RegExp suffix that is not a suffix', function() {
+            expect(checker.checkString('var freq_MHz3 = 1;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+    });
+
+    describe('option value `{allowedSuffixes: ["dC_l", /[kMG]?H_z/}`', function() {
+        beforeEach(function() {
+            checker.configure({ requireCamelCaseOrUpperCaseIdentifiers: {allowedSuffixes: ['dC_l', /[kMG]?H_z/]} });
+        });
+
+        it('should report an unrecognized string suffix', function() {
+            expect(checker.checkString('var temp_C_l = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized string suffix', function() {
+            expect(checker.checkString('var temp_dC_l = 0;'))
+              .to.have.no.errors();
+        });
+
+        it('should report an unrecognized RegExp suffix', function() {
+            expect(checker.checkString('var freq_TH_z = 1;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should not report a recognized RegExp suffix', function() {
+            expect(checker.checkString('var freq_H_z = 1;'))
+              .to.have.no.errors();
+        });
+
+        it('should report a string non-suffix', function() {
+            expect(checker.checkString('var tempdC_l = 0;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report a RegExp non-suffix', function() {
+            expect(checker.checkString('var freqH_z = 1;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
+        });
+
+        it('should report an unanchored recognized RegExp suffix that is not a suffix', function() {
+            expect(checker.checkString('var freq_MH_z3 = 1;'))
+              .to.have.one.validation.error.from('requireCamelCaseOrUpperCaseIdentifiers');
         });
     });
 });

--- a/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
+++ b/test/specs/rules/require-camelcase-or-uppercase-identifiers.js
@@ -36,7 +36,7 @@ describe('rules/require-camelcase-or-uppercase-identifiers', function() {
             expect(checker.checkString('var _x = "x", __y = "y";')).to.have.no.errors();
         });
 
-        it('should report trailing underscores', function() {
+        it('should not report trailing underscores', function() {
             expect(checker.checkString('var x_ = "x", y__ = "y";')).to.have.no.errors();
         });
 


### PR DESCRIPTION
I've got projects where I want to use `requireCamelCaseOrUpperCaseIdentifiers` but have a higher priority requirement that variables and properties that hold measurements specify the [units of measure](http://unitsofmeasure.org/ucum.html) in a suffix with an underscore separator.  For example: `ambientTemperature_cCel` or `centerFrequency_kHz`.

My solution is to augment the configuration value for `requireCamelCaseOrUpperCaseIdentifiers` to take an optional `units` property which is an array of strings or regular expressions identifying allowed units that are permitted as a underscore-separated suffix.  If an identifier has one of these suffixes and would pass the rule if the suffix was removed, then it is allowed with the suffix as well.

Is this enhancement of interest, or is there an existing way to solve this?  (I noticed issue #1900 which is similar but I specifically want the non-suffix part to still be processed by the rule.)
