### PR TITLE
disallowNewlineBeforeBlockStatements: add allExcept multiLine exception

### DIFF
--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -247,6 +247,22 @@ module.exports.prototype = {
     check: function(file, errors) {
         var setting = this._setting;
         var hasMultiLineEx = this._hasMultiLineEx;
+
+        function assertSameLine(token, nextToken) {
+            errors.assert.sameLine({
+                token: token,
+                nextToken: nextToken,
+                message: 'Newline before curly brace for block statement is disallowed'
+            });
+        }
+        function assertDifferentLine(token, nextToken) {
+            errors.assert.differentLine({
+                token: token,
+                nextToken: nextToken,
+                message: 'Newline before curly brace for block statement is required'
+            });
+        }
+
         file.iterateNodesByType(['BlockStatement', 'ClassBody'], function(node) {
             if (isBareBlock(node)) {
                 return;
@@ -256,33 +272,39 @@ module.exports.prototype = {
                 var openingBrace = file.getFirstNodeToken(node);
                 var prevToken = file.getPrevToken(openingBrace);
 
-                if (hasMultiLineEx === true) {
-                    var parentNode = node.parentNode;
-                    var parentNextToken = file.getFirstNodeToken(parentNode);
-                    var openingRoundBrace = file.findNextToken(parentNextToken, 'Punctuator', '(');
+                if (hasMultiLineEx !== true) {
+                    assertSameLine(prevToken, openingBrace);
+                    return;
+                }
 
-                    var closingRoundBrace = file.findPrevToken(openingBrace, 'Punctuator', ')');
+                // Check if the 'conditions' span on multiple lines.
+                // The simplest way is to check if the round braces are on different lines.
+                //
+                // For example:
+                //     // same line
+                //     for (var i = 0; i < length; i++) {
+                //     }
+                //
+                //     // different lines:
+                //     for (var i = 0;
+                //          i < length;
+                //          i++)
+                //     {
+                //     }
+                var parentNode = node.parentNode;
+                var parentNextToken = file.getFirstNodeToken(parentNode);
+                var openingRoundBrace = file.findNextToken(parentNextToken, 'Punctuator', '(');
+                var closingRoundBrace = file.findPrevToken(openingBrace, 'Punctuator', ')');
 
-                    if (openingRoundBrace && closingRoundBrace &&
-                        openingRoundBrace.loc.start.line !== closingRoundBrace.loc.end.line) {
-                        errors.assert.differentLine({
-                            token: prevToken,
-                            nextToken: openingBrace,
-                            message: 'Newline before curly brace for block statement is required'
-                        });
-                    } else {
-                        errors.assert.sameLine({
-                            token: prevToken,
-                            nextToken: openingBrace,
-                            message: 'Newline before curly brace for block statement is disallowed'
-                        });
-                    }
+                // Not always the conditions are there: to check look for the presence of round braces.
+                // For example:
+                //     try {
+                //     } ...
+                if (openingRoundBrace && closingRoundBrace &&
+                    openingRoundBrace.loc.start.line !== closingRoundBrace.loc.end.line) {
+                    assertDifferentLine(prevToken, openingBrace);
                 } else {
-                    errors.assert.sameLine({
-                        token: prevToken,
-                        nextToken: openingBrace,
-                        message: 'Newline before curly brace for block statement is disallowed'
-                    });
+                    assertSameLine(prevToken, openingBrace);
                 }
             }
         });

--- a/lib/rules/disallow-newline-before-block-statements.js
+++ b/lib/rules/disallow-newline-before-block-statements.js
@@ -1,13 +1,17 @@
 /**
  * Disallows newline before opening curly brace of all block statements.
  *
- * Type: `Boolean` or `Array`
+ * Type: `Boolean` or `Array` or `Object`
  *
  * Values:
  *
  * - `true` always disallows newline before curly brace of block statements
  * - `Array` specifies block-type keywords after which newlines are disallowed before curly brace
  *     - Valid types include: `['if', 'else', 'try', 'catch', 'finally', 'do', 'while', 'for', 'function', 'class']`
+ * - `Object`:
+ *     - `value`: `true` or an Array
+ *     - `allExcept`: Array of exceptions
+ *        - `"multiLine"`: if the conditions span on multiple lines, require a new line before the curly brace
  *
  * #### Example
  *
@@ -162,6 +166,49 @@
  *     return x - 1;
  * }
  * ```
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowNewlineBeforeBlockStatements": {
+ *     "value": true,
+ *     "allExcept": ["multiLine"]
+ * }
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * function myFunc(x,
+ *                 y)
+ * {
+ *     return x + y;
+ * }
+ *
+ * function foo() {
+ *     if (bar && baz &&
+ *         bat)
+ *     {
+ *         return true;
+ *     }
+ * }
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function myFunc(x,
+ *                 y) {
+ *     return x + y;
+ * }
+ *
+ * function foo() {
+ *     if (bar && baz &&
+ *         bat) {
+ *         return true;
+ *     }
+ * }
+ * ```
  */
 
 var assert = require('assert');
@@ -169,7 +216,22 @@ var assert = require('assert');
 module.exports = function() {};
 
 module.exports.prototype = {
-    configure: function(settingValue) {
+    configure: function(options) {
+        var settingValue;
+        this._hasMultiLineEx = false;
+        if (options.constructor === Object) {
+            settingValue = options.value;
+            if (options.allExcept) {
+                assert(
+                    Array.isArray(options.allExcept) && options.allExcept.length === 1 &&
+                    options.allExcept[0] === 'multiLine',
+                    'allExcept option must be an array whose values can be only `multiLine`'
+                );
+                this._hasMultiLineEx = true;
+            }
+        } else {
+            settingValue = options;
+        }
         assert(
             Array.isArray(settingValue) && settingValue.length || settingValue === true,
             'disallowNewlineBeforeBlockStatements option requires non-empty array value or true value'
@@ -184,6 +246,7 @@ module.exports.prototype = {
 
     check: function(file, errors) {
         var setting = this._setting;
+        var hasMultiLineEx = this._hasMultiLineEx;
         file.iterateNodesByType(['BlockStatement', 'ClassBody'], function(node) {
             if (isBareBlock(node)) {
                 return;
@@ -193,11 +256,34 @@ module.exports.prototype = {
                 var openingBrace = file.getFirstNodeToken(node);
                 var prevToken = file.getPrevToken(openingBrace);
 
-                errors.assert.sameLine({
-                    token: prevToken,
-                    nextToken: openingBrace,
-                    message: 'Newline before curly brace for block statement is disallowed'
-                });
+                if (hasMultiLineEx === true) {
+                    var parentNode = node.parentNode;
+                    var parentNextToken = file.getFirstNodeToken(parentNode);
+                    var openingRoundBrace = file.findNextToken(parentNextToken, 'Punctuator', '(');
+
+                    var closingRoundBrace = file.findPrevToken(openingBrace, 'Punctuator', ')');
+
+                    if (openingRoundBrace && closingRoundBrace &&
+                        openingRoundBrace.loc.start.line !== closingRoundBrace.loc.end.line) {
+                        errors.assert.differentLine({
+                            token: prevToken,
+                            nextToken: openingBrace,
+                            message: 'Newline before curly brace for block statement is required'
+                        });
+                    } else {
+                        errors.assert.sameLine({
+                            token: prevToken,
+                            nextToken: openingBrace,
+                            message: 'Newline before curly brace for block statement is disallowed'
+                        });
+                    }
+                } else {
+                    errors.assert.sameLine({
+                        token: prevToken,
+                        nextToken: openingBrace,
+                        message: 'Newline before curly brace for block statement is disallowed'
+                    });
+                }
             }
         });
     }

--- a/test/specs/rules/disallow-newline-before-block-statements.js
+++ b/test/specs/rules/disallow-newline-before-block-statements.js
@@ -379,4 +379,50 @@ describe('rules/disallow-newline-before-block-statements', function() {
             });
         });
     });
+
+    describe('with option value object and allExcept multiLine - ', function() {
+        beforeEach(function() {
+            checker.configure({
+                disallowNewlineBeforeBlockStatements: {
+                    value: true,
+                    allExcept: ['multiLine']
+                }
+            });
+        });
+
+        it('misc checks', function() {
+            expect(checker.checkString('function foo(a,b) { }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('function foo(a,\nb) { }'))
+                .to.have.one.validation.error.from('disallowNewlineBeforeBlockStatements');
+
+            expect(checker.checkString('function foo() { for (var i=0; i<len; i++) { } }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('function foo() { for (var i=0; i<len;\ni++) { } }'))
+                .to.have.one.validation.error.from('disallowNewlineBeforeBlockStatements');
+
+            expect(checker.checkString('function foo() { for (var i=0; i<len;\ni++)\n{ } }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('function foo() { if (true) { } }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('function foo() { if (a && b()) { } }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('function foo() { if (a &&\nb()) { } }'))
+                .to.have.one.validation.error.from('disallowNewlineBeforeBlockStatements');
+
+            expect(checker.checkString('function foo() { if (a &&\nb())\n{ } }'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('(function () {}())'))
+                .to.have.no.errors();
+
+            expect(checker.checkString('try {\n\ty++;\n} catch(e) {\n}'))
+                .to.have.no.errors();
+        });
+    });
 });


### PR DESCRIPTION
This should fix https://github.com/jscs-dev/node-jscs/issues/1956.