### PR TITLE
`maximumLineLength` - rewrite `functionSignature` handling, include `FunctionExpression`

### DIFF
--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -127,35 +127,23 @@ module.exports.prototype = {
         }
 
         if (this._allowFunctionSignature) {
-            var functionDeclarationLocs = [];
-            var searchBodyForDecl = function searchBodyForDecl(node) {
-                node.body.forEach(function(bodyNode) {
-                    if (bodyNode.type === 'FunctionDeclaration') {
-                        // get the loc for the `function Identifier` portion
-                        functionDeclarationLocs.push(bodyNode.id.loc);
-                        // get the locs for the params
-                        bodyNode.params.forEach(function(param) { functionDeclarationLocs.push(param.loc); });
-                        return;
+            file.iterateNodesByType('FunctionDeclaration', function(node) {
+                removeLoc(node.id);
+                node.params.forEach(removeLoc);
+            });
 
-                    } else if (bodyNode.type === 'ClassDeclaration') {
-                        searchBodyForDecl(bodyNode.body);
-                        return;
+            file.iterateNodesByType('MethodDefinition', function(node) {
+                removeLoc(node.key);
+                // node.value is a FunctionExpression, params are handled there
+            });
 
-                    } else if (bodyNode.type === 'MethodDefinition') {
-                        // get the loc for method name
-                        functionDeclarationLocs.push(bodyNode.key.loc);
-                        // get the locs for the params
-                        bodyNode.value.params.forEach(function(param) { functionDeclarationLocs.push(param.loc); });
-                        return;
-                    }
-                });
-            };
-            searchBodyForDecl(file.getTree());
-
-            functionDeclarationLocs.forEach(function(loc) {
-                for (var i = loc.start.line; i <= loc.end.line; i++) {
-                    lines[i - 1] = '';
+            file.iterateNodesByType('FunctionExpression', function(node) {
+                // need to remove the first line, because we can't be sure there's any id or params
+                lines[node.loc.start.line - 1] = '';
+                if (node.id) {
+                    removeLoc(node.id);
                 }
+                node.params.forEach(removeLoc);
             });
         }
 

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -37,6 +37,34 @@
  * ```js
  * var aLineOf41Chars = 1234567890123456789;
  * ```
+ *
+ * #### Example for allExcept functionSignature
+ *
+ * ```js
+ * "maximumLineLength": { "value": 40, "allExcept": [ "functionSignature" ] }
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var f = function(with, many, _many_, arguments) { .... };
+ * let f = x => x * x * x * x * x * x * x * x;
+ * (function(foo, bar, baz, quux, cuttlefish) {
+ *     function namesNaamesNaaamesNaaaames() {
+ *         ...
+ *     }
+ * })();
+ * const longNameIgnoredAsWell = (a, b) => a * b;
+ * class X { myLongMethodName(withPossiblyManyArgs) { ... } };
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * function x() { // valid
+ *     return "function_bodies_are_not_protected";
+ * }
+ * ```
  */
 
 var assert = require('assert');

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -137,7 +137,7 @@ module.exports.prototype = {
                 // node.value is a FunctionExpression, params are handled there
             });
 
-            file.iterateNodesByType('FunctionExpression', function(node) {
+            file.iterateNodesByType(['ArrowFunctionExpression', 'FunctionExpression'], function(node) {
                 // need to remove the first line, because we can't be sure there's any id or params
                 lines[node.loc.start.line - 1] = '';
                 if (node.id) {

--- a/lib/rules/maximum-line-length.js
+++ b/lib/rules/maximum-line-length.js
@@ -106,11 +106,15 @@ module.exports.prototype = {
         // This check should not be destructive
         lines = lines.slice();
 
+        var removeLoc = function(tokenOrNode) {
+            for (var i = tokenOrNode.loc.start.line; i <= tokenOrNode.loc.end.line; i++) {
+                lines[i - 1] = '';
+            }
+        };
+
         if (this._allowRegex) {
             file.iterateTokensByType('RegularExpression', function(token) {
-                for (var i = token.loc.start.line; i <= token.loc.end.line; i++) {
-                    lines[i - 1] = '';
-                }
+                removeLoc(token);
             });
         }
 
@@ -158,9 +162,7 @@ module.exports.prototype = {
         if (this._allowRequire) {
             file.iterateNodesByType('CallExpression', function(node) {
                 if (node.callee.name === 'require') {
-                    for (var i = node.loc.start.line; i <= node.loc.end.line; i++) {
-                        lines[i - 1] = '';
-                    }
+                    removeLoc(node);
                 }
             });
         }

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -214,9 +214,9 @@ describe('rules/maximum-line-length', function() {
             expect(checker.checkString(code)).to.have.no.errors();
         });
 
-        it('should report functions stored in variables', function() {
+        it('should not report functions stored in variables', function() {
             var code = 'var fn = function() {};';
-            expect(checker.checkString(code)).to.have.one.validation.error.from('maximumLineLength');
+            expect(checker.checkString(code)).to.have.no.errors();
         });
 
         it('should not report functions within IIFE blocks', function() {

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -224,6 +224,13 @@ describe('rules/maximum-line-length', function() {
             expect(checker.checkString(code)).to.have.no.errors();
         });
 
+        it('should not report arrow functions', function() {
+            var code = '(aVeryVeryLongLongParameter => 42);\n' +
+                    '(() => "parameterless arrow function");\n' +
+                    '((foo, bar, baz, $rootScope) => "quux");';
+            expect(checker.checkString(code)).to.have.no.errors();
+        });
+
         it('should not report functions within IIFE blocks', function() {
             var code = '(function() {\n' +
                     '   function myCoolFunction(argument) { }\n' +

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -215,7 +215,12 @@ describe('rules/maximum-line-length', function() {
         });
 
         it('should not report functions stored in variables', function() {
-            var code = 'var fn = function() {};';
+            var code = 'var fn1 = function(longer) { return null; };\n' +
+                    'let fn2 = function(longer) { return null; };\n' +
+                    'const fn3 = function() { return "no_params_or_id"; };\n' +
+                    'var fn4 = function myFn4() { return null; };\n' +
+                    'let fn5 = function myFn5() { return null; };\n' +
+                    'const fn6 = function myFn6(whynot) { return null; };';
             expect(checker.checkString(code)).to.have.no.errors();
         });
 

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -218,6 +218,13 @@ describe('rules/maximum-line-length', function() {
             var code = 'var fn = function() {};';
             expect(checker.checkString(code)).to.have.one.validation.error.from('maximumLineLength');
         });
+
+        it('should not report functions within IIFE blocks', function() {
+            var code = '(function() {\n' +
+                    '   function myCoolFunction(argument) { }\n' +
+                    '})();';
+            expect(checker.checkString(code)).to.have.no.errors();
+        });
     });
 
     describe('allExcept["require"] option', function() {

--- a/test/specs/rules/maximum-line-length.js
+++ b/test/specs/rules/maximum-line-length.js
@@ -225,6 +225,11 @@ describe('rules/maximum-line-length', function() {
                     '})();';
             expect(checker.checkString(code)).to.have.no.errors();
         });
+
+        it('should report functions within comments', function() {
+            var code = '// function myCoolFunction(argument) { }';
+            expect(checker.checkString(code)).to.have.one.validation.error.from('maximumLineLength');
+        });
     });
 
     describe('allExcept["require"] option', function() {


### PR DESCRIPTION
This closes #2032 - `maximumLineLength` `allExcept: ['functionSignature']` - broken in IIFE.

I've essentially rewritten the functionSignature handling to use `iterateNodesByType` instead of the recursive `searchBodyForDecl`, and include `FunctionExpression` (as well as the previously checked `FunctionDeclaration` and `MethodDefiniton`)
    
Also abstracted common boilerplate into a local `removeLoc` function - the empty lines `.loc.start.line - 1` through `.loc.end.line - 1` logic is used in multiple places there and warrants a helper.

Spec changes:

   * add  `should not report functions within IIFE blocks`
   * change: `should` to `should not` in `.. report functions stored in variables`
   * extended that same spec to test for multiple variations - var, let or const, with or without parameters or name
   * add `should report functions within comments` - that one mostly so that we verify at least something can fail (which *may* previously have been the job of `should report functions stored in variables`)
