### PR TITLE
requireCapitalizedConstructorsNew: New rule based on jshint newcap.

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -1074,6 +1074,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-space-between-arguments'));
 
     this.registerRule(require('../rules/require-capitalized-constructors'));
+    this.registerRule(require('../rules/require-capitalized-constructors-new'));
 
     this.registerRule(require('../rules/safe-context-keyword'));
 

--- a/lib/rules/require-capitalized-constructors-new.js
+++ b/lib/rules/require-capitalized-constructors-new.js
@@ -1,0 +1,74 @@
+/**
+ * Requires capitalized constructors to to use the `new` keyword
+ *
+ * Types: `Boolean` or `Object`
+ *
+ * Values: `true` or Object with `allExcept` Array of quoted identifiers which are exempted
+ *
+ * JSHint: [`newcap`](http://jshint.com/docs/options/#newcap)
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireCapitalizedConstructors": true
+ * "requireCapitalizedConstructors": {
+ *     "allExcept": ["SomethingNative"]
+ * }
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * var a = new B();
+ * var c = SomethingNative();
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * var d = E();
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true || Array.isArray(options.allExcept),
+            this.getOptionName() + ' option requires a true value or an object of exceptions'
+        );
+        this._allowedConstructors = {};
+
+        var allExcept = options.allExcept;
+        if (allExcept) {
+            for (var i = 0, l = allExcept.length; i < l; i++) {
+                this._allowedConstructors[allExcept[i]] = true;
+            }
+        }
+    },
+
+    getOptionName: function() {
+        return 'requireCapitalizedConstructorsNew';
+    },
+
+    check: function(file, errors) {
+        var allowedConstructors = this._allowedConstructors;
+
+        file.iterateNodesByType('CallExpression', function(node) {
+            if (node.callee.type === 'Identifier' &&
+                !allowedConstructors[node.callee.name] &&
+                node.callee.name[0].toLowerCase() !== node.callee.name[0]
+            ) {
+                errors.add(
+                    'Constructor functions should use the "new" keyword',
+                    node.callee.loc.start.line,
+                    node.callee.loc.start.column
+                );
+            }
+        });
+    }
+
+};

--- a/test/specs/rules/require-capitalized-constructors-new.js
+++ b/test/specs/rules/require-capitalized-constructors-new.js
@@ -1,0 +1,54 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/require-capitalized-constructors-new', function() {
+    var checker;
+
+    function baseCases() {
+        it('should report capitalized constructors without the "new" keyword', function() {
+            expect(checker.checkString('var x = Y();'))
+              .to.have.one.validation.error.from('requireCapitalizedConstructorsNew');
+        });
+
+        it('should not report capitalized construction', function() {
+            expect(checker.checkString('var x = new Y();')).to.have.no.errors();
+        });
+
+        it('should not report member expression construction', function() {
+            expect(checker.checkString('var x = ns.Y();')).to.have.no.errors();
+        });
+
+        it('should not report lowercase function calls', function() {
+            expect(checker.checkString('var x = y();')).to.have.no.errors();
+        });
+    }
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('with `true` value', function() {
+        beforeEach(function() {
+            checker.configure({ requireCapitalizedConstructorsNew: true });
+        });
+
+        baseCases();
+    });
+
+    describe('with `allExcept` value', function() {
+        beforeEach(function() {
+            checker.configure({
+                requireCapitalizedConstructorsNew: {
+                    allExcept: ['SomethingNative']
+                }
+            });
+        });
+
+        baseCases();
+
+        it('should not report exempted construction', function() {
+            expect(checker.checkString('var x = SomethingNative();')).to.have.no.errors();
+        });
+    });
+});


### PR DESCRIPTION
Added a new rule that behaves closer to the behavior of "newcap" in jshint.

Fixes #2046