### PR TITLE
disallowQuotedKeysInObjects: fix Types and Values documentation

### DIFF
--- a/lib/rules/disallow-quoted-keys-in-objects.js
+++ b/lib/rules/disallow-quoted-keys-in-objects.js
@@ -1,15 +1,15 @@
 /**
  * Disallows quoted keys in object if possible.
  *
- * Types: `String` or `Boolean`
+ * Types: `Boolean`, `String` or `Object`
  *
  * Values:
  *
  *  - `true` for strict mode
  *  - `"allButReserved"` (*deprecated* use `"allExcept": ["reserved"]`)
- * - `Object`:
+ *  - `Object`:
  *    - `"allExcept"` array of exceptions:
- *       - `"reserved"` allows ES3+ reserved words to remain quoted
+ *      - `"reserved"` allows ES3+ reserved words to remain quoted
  *         which is helpful when using this option with JSHint's `es3` flag.
  *
  * #### Example


### PR DESCRIPTION
- Added Object to the list of Types
  Should String be removed since it's deprecated?

- Fixed Values list formatting
  Was creating an extra indentation level