### PR TITLE
requireVarDeclFirst: Fixing an edge case

### DIFF
--- a/lib/rules/require-var-decl-first.js
+++ b/lib/rules/require-var-decl-first.js
@@ -187,7 +187,7 @@ function getCommentOffsetBetweenNodes(previousNode, currentNode, commentTokens, 
             // of the previous node and the previousNode is not the parent of currentNode
             break;
         }
-        
+
         if (comment.range[0] > currentNode.range[0] &&
             comment.range[1] < currentNode.range[1]) {
             // Stop processing comments that are within multiple declarators in a single variable declaration

--- a/lib/rules/require-var-decl-first.js
+++ b/lib/rules/require-var-decl-first.js
@@ -180,6 +180,14 @@ function getCommentOffsetBetweenNodes(previousNode, currentNode, commentTokens, 
             break;
         }
 
+        if (previousNode.range[1] < currentNode.range[0] &&
+            comment.range[0] > previousNode.range[0] &&
+            comment.range[1] < previousNode.range[1]) {
+            // Stop processing comments that are within multiple declarators in a single variable declaration
+            // of the previous node and the previousNode is not the parent of currentNode
+            break;
+        }
+        
         if (comment.range[0] > currentNode.range[0] &&
             comment.range[1] < currentNode.range[1]) {
             // Stop processing comments that are within multiple declarators in a single variable declaration


### PR DESCRIPTION
In this  edge case the comments from previous block scope were being taken and
a false positive error was thrown

Fixes #2022 - issue