### PR TITLE
fix Issue2041

### DIFF
--- a/lib/rules/require-space-before-keywords.js
+++ b/lib/rules/require-space-before-keywords.js
@@ -1,9 +1,11 @@
 /**
  * Requires space before keyword.
  *
- * Types: `Array` or `Boolean`
+ * Types: `Array`, `Boolean` or `Object`
  *
- * Values: Array of quoted keywords or `true` to require all possible keywords to have a preceding space.
+ * Values: `true` to require all possible keywords to have a preceding space,
+ * Array of quoted keywords
+ * or an Object with the `allExcept` property set with an Array of quoted keywords.
  *
  * #### Example
  *

--- a/lib/rules/require-space-before-keywords.js
+++ b/lib/rules/require-space-before-keywords.js
@@ -41,12 +41,20 @@ module.exports = function() {};
 module.exports.prototype = {
 
     configure: function(keywords) {
+        var isValidObject = (keywords === Object(keywords) && keywords.hasOwnProperty('allExcept'));
+
         assert(
-            Array.isArray(keywords) || keywords === true,
-            this.getOptionName() + ' option requires array or true value');
+            Array.isArray(keywords) || keywords === true || isValidObject,
+            this.getOptionName() + ' option requires array, object with "allExcept" property or true value');
 
         if (keywords === true) {
             keywords = defaultKeywords;
+        }
+
+        if (isValidObject) {
+            keywords = defaultKeywords.filter(function(keyword) {
+                return (keywords.allExcept.indexOf(keyword) === -1);
+            });
         }
 
         this._keywords = keywords;

--- a/lib/rules/require-space-before-keywords.js
+++ b/lib/rules/require-space-before-keywords.js
@@ -3,7 +3,7 @@
  *
  * Types: `Array`, `Boolean` or `Object`
  *
- * Values: `true` to require all possible keywords to have a preceding space,
+ * Values: `true` to require all possible keywords to have a preceding space (except `function`),
  * Array of quoted keywords
  * or an Object with the `allExcept` property set with an Array of quoted keywords.
  *
@@ -37,6 +37,7 @@
 var assert = require('assert');
 
 var defaultKeywords = require('../utils').spacedKeywords;
+var ignoredKeywords = ['function'];
 
 module.exports = function() {};
 
@@ -49,15 +50,14 @@ module.exports.prototype = {
             Array.isArray(keywords) || keywords === true || isValidObject,
             this.getOptionName() + ' option requires array, object with "allExcept" property or true value');
 
-        if (keywords === true) {
-            keywords = defaultKeywords;
+        var excludedKeywords = ignoredKeywords;
+        if (isValidObject) {
+            excludedKeywords = keywords.allExcept;
         }
 
-        if (isValidObject) {
-            keywords = defaultKeywords.filter(function(keyword) {
-                return (keywords.allExcept.indexOf(keyword) === -1);
-            });
-        }
+        keywords = defaultKeywords.filter(function(keyword) {
+            return (excludedKeywords.indexOf(keyword) === -1);
+        });
 
         this._keywords = keywords;
     },

--- a/test/specs/rules/require-space-before-keywords.js
+++ b/test/specs/rules/require-space-before-keywords.js
@@ -56,6 +56,16 @@ describe('rules/require-space-before-keywords', function() {
         expect(checker.checkString('if (true) x++;else x--;')).to.have.no.errors();
     });
 
+    it('should not report missing space on function by default', function() {
+        checker.configure({ requireSpaceBeforeKeywords: true });
+
+        expect(checker.checkString(
+            '[].forEach(function (arg) {\n' +
+                'console.log(arg);\n' +
+            '});'
+        )).to.have.no.errors();
+    });
+
     it('should report on all possible ES3 keywords if a value of true is supplied', function() {
         checker.configure({ requireSpaceBeforeKeywords: true });
 
@@ -81,12 +91,10 @@ describe('rules/require-space-before-keywords', function() {
     });
 
     it('should not report missing space on excluded keyword', function() {
-        checker.configure({ requireSpaceBeforeKeywords: { allExcept: ['function'] } });
+        checker.configure({ requireSpaceBeforeKeywords: { allExcept: ['else'] } });
 
         expect(checker.checkString(
-            '[].forEach(function (arg) {\n' +
-                'console.log(arg);\n' +
-            '});'
+            'if (true) {\n}else { x++; }'
         )).to.have.no.errors();
     });
 
@@ -98,5 +106,19 @@ describe('rules/require-space-before-keywords', function() {
 
         expect(errors).to.have.one.validation.error.from('requireSpaceBeforeKeywords');
         expect(errors.explainError(error)).to.have.string('Missing space before "else" keyword');
+    });
+
+    it('should report missing space on function when not specified in allExcept array', function() {
+        checker.configure({ requireSpaceBeforeKeywords: { allExcept: ['else'] } });
+
+        var errors = checker.checkString(
+            '[].forEach(function (arg) {\n' +
+                'console.log(arg);\n' +
+            '});'
+        );
+        var error = errors.getErrorList()[0];
+
+        expect(errors).to.have.one.validation.error.from('requireSpaceBeforeKeywords');
+        expect(errors.explainError(error)).to.have.string('Missing space before "function" keyword');
     });
 });

--- a/test/specs/rules/require-space-before-keywords.js
+++ b/test/specs/rules/require-space-before-keywords.js
@@ -79,4 +79,24 @@ describe('rules/require-space-before-keywords', function() {
         expect(errors).to.have.one.validation.error.from('requireSpaceBeforeKeywords');
         expect(errors.explainError(error)).to.have.string('Missing space before "catch" keyword');
     });
+
+    it('should not report missing space on excluded keyword', function() {
+        checker.configure({ requireSpaceBeforeKeywords: { allExcept: ['function'] } });
+
+        expect(checker.checkString(
+            '[].forEach(function (arg) {\n' +
+                'console.log(arg);\n' +
+            '});'
+        )).to.have.no.errors();
+    });
+
+    it('should report missing space in not excluded keywords', function() {
+        checker.configure({ requireSpaceBeforeKeywords: { allExcept: ['function'] } });
+
+        var errors = checker.checkString('if (true) {\n}else { x++; }');
+        var error = errors.getErrorList()[0];
+
+        expect(errors).to.have.one.validation.error.from('requireSpaceBeforeKeywords');
+        expect(errors.explainError(error)).to.have.string('Missing space before "else" keyword');
+    });
 });


### PR DESCRIPTION
**requireSpaceBeforeKeywords**

Added a new value option for the rule, an Object with an _allExcept_ property, to inform which keywords shouldn't be targeted by the rule.

Fixes issue #2041, as asked by user radek-holy

I went for the extra value approach as indicated in the issue, because I thought it would be more of a general approach that can be used across other rules and to behave similar as all other rules.