### PR TITLE
Preset: enforce Airbnb rule 25.1 (requireDollarBeforejQueryAssignment)

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -44,6 +44,7 @@
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireCamelCaseOrUpperCaseIdentifiers": true,
+    "requireDollarBeforejQueryAssignment": true,
     "requireLineFeedAtFileEnd": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,


### PR DESCRIPTION
This PR adds [`requireDollarBeforejQueryAssignment`](http://jscs.info/rule/requireDollarBeforejQueryAssignment) to enforce [Airbnb rule 25.1](https://github.com/airbnb/javascript/blob/c2fd8fbbd6cf058244024db3ab791ddba15567a1/README.md#25.1):

> Prefix jQuery object variables with a `$`.
>
> ```javascript
> // bad
> const sidebar = $('.sidebar');
>
> // good
> const $sidebar = $('.sidebar');
>
> // good
> const $sidebarBtn = $('.sidebar-btn');
> ```