### PR TITLE
Update rule require-padding-newlines-before-export

### DIFF
--- a/lib/rules/require-padding-newlines-before-export.js
+++ b/lib/rules/require-padding-newlines-before-export.js
@@ -17,6 +17,10 @@
  * var a = 2;
  *
  * module.exports = a;
+ *
+ * if (cond) {
+ *    module.exports = a;
+ * }
  * ```
  *
  * ##### Invalid
@@ -24,6 +28,11 @@
  * ```js
  * var a = 2;
  * module.exports = a;
+ *
+ * if (cond) {
+ *    foo();
+ *    module.exports = a;
+ * }
  * ```
  */
 
@@ -47,11 +56,17 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('AssignmentExpression', function(node) {
             var left = node.left;
+            var greatGrandpa = node.parentElement.parentElement;
             if (!(
                 left.object &&
                 left.object.name === 'module' &&
                 left.property &&
                 left.property.name === 'exports')) {
+                return;
+            }
+
+            // module.exports is in a block and is the only statement.
+            if (greatGrandpa.type === 'BlockStatement' && greatGrandpa.body.length === 1) {
                 return;
             }
 
@@ -65,6 +80,7 @@ module.exports.prototype = {
                 message: 'Missing newline before export'
             });
         });
+
     }
 
 };

--- a/test/specs/rules/require-padding-newlines-before-export.js
+++ b/test/specs/rules/require-padding-newlines-before-export.js
@@ -31,5 +31,9 @@ describe('rules/require-padding-newlines-before-export', function() {
             expect(checker.checkString('var a = 2;\nfoo.exports = a;')).to.have.no.errors();
             expect(checker.checkString('var a = 2;\nmodule.foo = a;')).to.have.no.errors();
         });
+
+        it('should not report missing padding if export is only statement in block', function() {
+            expect(checker.checkString('if (true) {\nmodule.exports = a;\n}')).to.have.no.errors();
+        });
     });
 });


### PR DESCRIPTION
Update rule require-padding-newlines-before-export to exclude if only statement in block

Fixes #1883