### PR TITLE
disallow-nested-ternaries: fixes incorrect option type

### DIFF
--- a/lib/rules/disallow-nested-ternaries.js
+++ b/lib/rules/disallow-nested-ternaries.js
@@ -1,9 +1,9 @@
 /**
  * Disallows nested ternaries.
  *
- * Types: `Boolean`, `Integer`
+ * Types: `Boolean`, `Object`
  *
- * Values: `true` or an Integer that describes the maximum levels of nesting to be allowed.
+ * Values: `true` or an Object that contains a `maxLevel` property equal to an integer indicating the maximum levels of nesting to be allowed.
  *
  * #### Examples
  *

--- a/lib/rules/disallow-space-after-object-keys.js
+++ b/lib/rules/disallow-space-after-object-keys.js
@@ -1,7 +1,7 @@
 /**
  * Disallows space after object keys.
  *
- * Types: `Boolean` or `String`
+ * Types: `Boolean`, `String`, or `Object`
  *
  * Values:
  *  - `true`


### PR DESCRIPTION
disallow-space-after-object-keys.js: adds missing option type

Fixes #2092 - disallowNestedTernaries - invalid option types described on website