### PR TITLE
Update mdcs.json

### DIFF
--- a/presets/mdcs.json
+++ b/presets/mdcs.json
@@ -29,5 +29,6 @@
         "afterConsequent": true,
         "beforeAlternate": true
     },
-    "disallowTrailingWhitespace": true
+    "disallowTrailingWhitespace": true,
+    "disallowNewlineBeforeBlockStatements": true
 }


### PR DESCRIPTION
added the rule: ["disallowNewlineBeforeBlockStatements"](http://jscs.info/rule/disallowNewlineBeforeBlockStatements) : true

to follow the requirement:
- Block : _"The opening brackets should always follow a space and not start at a new line"_ on https://github.com/mrdoob/three.js/wiki/Mr.doob's-Code-Style%E2%84%A2