### PR TITLE
Configuration: exclude nested node_modules by default

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -117,7 +117,7 @@ function Configuration() {
      * @protected
      * @type {Array}
      */
-    this._defaultExcludedFileMasks = ['.git/**', 'node_modules/**'];
+    this._defaultExcludedFileMasks = ['.git/**', '*/node_modules/**'];
 
     /**
      * List of existing files that falls under exclusion masks.

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -603,7 +603,7 @@ describe('config/configuration', function() {
                 preset: 'test2'
             });
 
-            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', 'node_modules/**']);
+            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', '*/node_modules/**']);
         });
 
         it('should set `fileExtensions` setting from presets', function() {
@@ -797,7 +797,7 @@ describe('config/configuration', function() {
 
         it('should set default excludeFiles option', function() {
             configuration.load({});
-            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', 'node_modules/**']);
+            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', '*/node_modules/**']);
         });
 
         it('should set default file extensions', function() {


### PR DESCRIPTION
Hello there!

I had a project with a structure similar to this:

```
- /
  - src
    - file1.js
    - file2.js
  - inner-project
    - node_modules
    - package.json
  - node_modules
  - package.json
```

I ran the CLI, and it hung. I looked at the docs, which stated that `node_modules` is excluded by default. But then I wondered if `inner-project`'s node_modules were being included, and it appears they were!

I figured this change might make it easier for new users, even though this is a slightly non-standard project layout. I also wondered if I should add a `*` to `.git` for the case of older git submodules, but not sure.

I understand if this is not really inline with the project needs, so I won't be worried if this isn't approved or is discarded.

Thanks for a great tool!