### PR TITLE
New Rule: disallowSpacesInsideTemplateStringPlaceholders (ES6)

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -834,6 +834,7 @@ Configuration.prototype.registerDefaultRules = function() {
     this.registerRule(require('../rules/disallow-identical-destructuring-names'));
     this.registerRule(require('../rules/require-spaces-in-generator'));
     this.registerRule(require('../rules/disallow-spaces-in-generator'));
+    this.registerRule(require('../rules/disallow-spaces-inside-template-string-placeholders'));
     this.registerRule(require('../rules/require-object-destructuring'));
     this.registerRule(require('../rules/require-enhanced-object-literals'));
     this.registerRule(require('../rules/require-array-destructuring'));

--- a/lib/rules/disallow-spaces-inside-template-string-placeholders.js
+++ b/lib/rules/disallow-spaces-inside-template-string-placeholders.js
@@ -1,0 +1,69 @@
+/**
+ * Disallows spaces before and after curly brace inside template string placeholders.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowSpacesInsideTemplateStringPlaceholders": true
+ * ```
+ *
+ * ##### Valid for mode `true`
+ *
+ * ```js
+ * `Hello ${name}!`
+ * ```
+ *
+ * ##### Invalid for mode `true`
+ *
+ * ```js
+ * `Hello ${ name}!`
+ * `Hello ${name }!`
+ * `Hello ${ name }!`
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowSpacesInsideTemplateStringPlaceholders';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType('TemplateLiteral', function(node) {
+            node.childElements
+                .filter(function(element) {
+                    return element.isToken && element.type === 'Punctuator';
+                })
+                .forEach(function(element) {
+                    if (element.value === '${' && element.nextSibling.isWhitespace) {
+                        errors.assert.noWhitespaceBetween({
+                            token: element,
+                            nextToken: element.nextCodeToken,
+                            message: 'Illegal space after "${"'
+                        });
+                    }
+                    if (element.value === '}' && element.previousSibling.isWhitespace) {
+                        errors.assert.noWhitespaceBetween({
+                            token: element.previousCodeToken,
+                            nextToken: element,
+                            message: 'Illegal space before "}"'
+                        });
+                    }
+                });
+        });
+    }
+};

--- a/test/specs/rules/disallow-spaces-inside-template-string-placeholders.js
+++ b/test/specs/rules/disallow-spaces-inside-template-string-placeholders.js
@@ -1,0 +1,51 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/disallow-spaces-inside-template-string-placeholders', function() {
+    var checker;
+
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+
+        checker.configure({
+            disallowSpacesInsideTemplateStringPlaceholders: true
+        });
+    });
+
+    it('should report with space after opening curly brace', function() {
+        expect(checker.checkString('`${ 1}`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+
+    it('should report with space before closing curly brace', function() {
+        expect(checker.checkString('`${1 }`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+
+    it('should report with spaces before opening and after closing curly braces', function() {
+        expect(checker.checkString('`${ 1 }`')).to.have.error.count.equal(2);
+    });
+
+    it('should report with more than one space in placeholder', function() {
+        expect(checker.checkString('`${  1}`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+
+    it('should report with space in second placeholder', function() {
+        expect(checker.checkString('`${1} + ${ 2}`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+
+    it('should not report with no spaces in placeholder', function() {
+        expect(checker.checkString('`${1}`')).to.have.no.errors();
+    });
+
+    it('should work with tagged template string', function () {
+        expect(checker.checkString('tag`${1}`')).to.have.no.errors();
+        expect(checker.checkString('tag`${1 }`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+        expect(checker.checkString('tag`${ 1}`')).to.have.one.validation.error
+            .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+});


### PR DESCRIPTION
Disallows spaces before and after curly brace inside template string placeholders.

Type: `Boolean`

Value: `true`

#### Example

```js
"disallowSpacesInsideTemplateStringPlaceholders": true
```

##### Valid for mode `true`

```js
`Hello ${name}!`
```

##### Invalid for mode `true`

```js
`Hello ${ name}!`
`Hello ${name }!`
`Hello ${ name }!`
```