### PR TITLE
safeContextKeyword: fix destructuring handling

### DIFF
--- a/lib/rules/safe-context-keyword.js
+++ b/lib/rules/safe-context-keyword.js
@@ -50,15 +50,14 @@ module.exports.prototype = {
 
         // var that = this
         file.iterateNodesByType('VariableDeclaration', function(node) {
-            var firstToken = node.firstToken;
-
-            // Miss destructing assignment (#1699)
-            if (file.getNextToken(firstToken).value === '{') {
-                return;
-            }
 
             for (var i = 0; i < node.declarations.length; i++) {
                 var decl = node.declarations[i];
+
+                // Miss destructing assignment (#1699, #2119)
+                if (file.getNextToken(file.getPrevToken(decl)).value === '{') {
+                    continue;
+                }
 
                 // decl.init === null in case of "var foo;"
                 if (decl.init &&

--- a/test/specs/rules/safe-context-keyword.js
+++ b/test/specs/rules/safe-context-keyword.js
@@ -15,6 +15,10 @@ describe('rules/safe-context-keyword', function() {
             expect(checker.checkString('const { smth } = this;')).to.have.no.errors();
         });
 
+        it('should ignore destructuring assignment in multi-variable declarations', function() {
+            expect(checker.checkString('const a = 1, { smth } = this;')).to.have.no.errors();
+        });
+
         describe('not assigning this', function() {
             it('should not report variable declarations', function() {
                 expect(checker.checkString('var a = b;')).to.have.no.errors();


### PR DESCRIPTION
Update `safeContextKeyword` to handle destructuring when multiple
variables are being declared and the destructuring is not the first.

Fixes #2119