### PR TITLE
Misc: fix dynamic test requires

### DIFF
--- a/test/specs/grouping.js
+++ b/test/specs/grouping.js
@@ -15,7 +15,9 @@ describe.skip('rule grouping', function() {
     }, {});
 
     describe('exists for every rule', function() {
-        fs.readdirSync(rulesDir).map(function(file) {
+        fs.readdirSync(rulesDir).filter(function(file) {
+            return file.slice(-3) === '.js';
+        }).map(function(file) {
             var Rule = require(path.join(rulesDir, file));
             return Rule.prototype.getOptionName.call();
         }).forEach(function(option) {


### PR DESCRIPTION
When reading in test files from the directory, omit non-js files before attempting to `require` them (relieves annoyances while using any editor(s) that store backup files of anything being worked on within the same directory, e.g., Vim .swp files).