### PR TITLE
requireNumericLiterals: Prevent erroring when first argument is an Identifier.

### DIFF
--- a/lib/rules/require-numeric-literals.js
+++ b/lib/rules/require-numeric-literals.js
@@ -65,7 +65,8 @@ module.exports.prototype = {
 
             if (node.callee.type === 'Identifier' &&
                 node.callee.name === 'parseInt' &&
-                radixName
+                radixName &&
+                node.arguments[0].type === 'Literal'
             ) {
                 errors.add('Use ' + radixName + ' literals instead of parseInt', node);
             }

--- a/test/specs/rules/require-numeric-literals.js
+++ b/test/specs/rules/require-numeric-literals.js
@@ -43,4 +43,9 @@ describe('rules/require-numeric-literals', function() {
     it('should not report for non-identifier call', function() {
         expect(checker.checkString('a[parseInt](1,2);')).to.have.no.errors();
     });
+
+    it('should not report on use of parseInt with an identifier for string', function() {
+        expect(checker.checkString('parseInt(foo);')).to.have.no.errors();
+        expect(checker.checkString('parseInt(foo, 2);')).to.have.no.errors();
+    });
 });


### PR DESCRIPTION
Prior to this fix, the following would trigger an error:

```
let foo = '123';
parseInt(foo, 16);
```

After this change, an error is only triggered when using an actual literal (as intended and indicated by the rule name).

Addresses https://github.com/DockYard/ember-suave/pull/80#issuecomment-183779369.

/cc @hzoo