### PR TITLE
disallowSpacesInsideTemplateStringPlaceholders: don't check space out…

### DIFF
--- a/lib/rules/disallow-spaces-inside-template-string-placeholders.js
+++ b/lib/rules/disallow-spaces-inside-template-string-placeholders.js
@@ -45,25 +45,52 @@ module.exports.prototype = {
     check: function(file, errors) {
         file.iterateNodesByType('TemplateLiteral', function(node) {
             var first = file.getFirstNodeToken(node);
-            var nextFist = file.getNextToken(first, {includeWhitespace: true});
             var last = file.getLastNodeToken(node);
-            var prevLast = file.getPrevToken(last, {includeWhitespace: true});
 
-            if (nextFist.isWhitespace) {
-                errors.assert.noWhitespaceBetween({
-                    token: first,
-                    nextToken: file.getNextToken(first),
-                    message: 'Illegal space after "${"'
-                });
-            }
+            // Iterate over tokens inside TemplateLiteral node.
+            for (var token = first; ; token = file.getNextToken(token)) {
+                if (containsPlaceholderStart(token)) {
+                    var nextFist = file.getNextToken(token, {includeWhitespace: true});
+                    if (nextFist.isWhitespace) {
+                        errors.assert.noWhitespaceBetween({
+                            token: token,
+                            nextToken: file.getNextToken(token),
+                            message: 'Illegal space after "${"'
+                        });
+                    }
+                }
 
-            if (prevLast.isWhitespace) {
-                errors.assert.noWhitespaceBetween({
-                    token: file.getPrevToken(last),
-                    nextToken: last,
-                    message: 'Illegal space before "}"'
-                });
+                if (containsPlaceholderEnd(token)) {
+                    var prevLast = file.getPrevToken(token, {includeWhitespace: true});
+                    if (prevLast.isWhitespace) {
+                        errors.assert.noWhitespaceBetween({
+                            token: file.getPrevToken(token),
+                            nextToken: token,
+                            message: 'Illegal space before "}"'
+                        });
+                    }
+                }
+
+                if (token === last) {
+                    return;
+                }
             }
         });
     }
 };
+
+/**
+ * @param {Object} token
+ * @returns {Boolean}
+ */
+function containsPlaceholderStart(token) {
+    return token.type === 'Template' && /\${$/.test(token.value);
+}
+
+/**
+ * @param {Object} token
+ * @returns {Boolean}
+ */
+function containsPlaceholderEnd(token) {
+    return token.type === 'Template' && /^}/.test(token.value);
+}

--- a/test/specs/rules/disallow-spaces-inside-template-string-placeholders.js
+++ b/test/specs/rules/disallow-spaces-inside-template-string-placeholders.js
@@ -32,10 +32,29 @@ describe('rules/disallow-spaces-inside-template-string-placeholders', function()
             .from('disallowSpacesInsideTemplateStringPlaceholders');
     });
 
-    // Enabled in 3.0 but kinda hard to implement it in 2.x
-    it.skip('should report with space in second placeholder', function() {
+    it('should report with space in second placeholder', function() {
         expect(checker.checkString('`${1} + ${ 2}`')).to.have.one.validation.error
             .from('disallowSpacesInsideTemplateStringPlaceholders');
+    });
+
+    it('should report with spaces in both placeholders', function() {
+        expect(checker.checkString('`${ 1 } + ${ 2 }`')).to.have.error.count.equal(4);
+    });
+
+    it('should report with spaces in placeholder with expression', function() {
+        expect(checker.checkString('`${ foo() }`')).to.have.error.count.equal(2);
+    });
+
+    it('should not report with spaces before and after template string', function() {
+        expect(checker.checkString('x = `` ')).to.have.no.errors();
+    });
+
+    it('should not report with space before template string with closing curly brace', function() {
+        expect(checker.checkString('x = `}`')).to.have.no.errors();
+    });
+
+    it('should not report with spaces inside curly braces without dollar sign', function() {
+        expect(checker.checkString('`{ x }`')).to.have.no.errors();
     });
 
     it('should not report with no spaces in placeholder', function() {


### PR DESCRIPTION
…side template literal

Fixes #2137

\cc @markelog 