### PR TITLE
airbnb preset - rule #8.2 - omit the braces

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -75,5 +75,7 @@
     "validateQuoteMarks": { "mark": "'", "escape": true, "ignoreJSX": true },
     "validateIndentation": 2,
     "maximumLineLength": 100,
-    "disallowArrayDestructuringReturn": true
+    "disallowArrayDestructuringReturn": true,
+    "disallowParenthesesAroundArrowParam": true,
+    "requireShorthandArrowFunctions": true
 }

--- a/test/data/options/preset/airbnb.js
+++ b/test/data/options/preset/airbnb.js
@@ -425,4 +425,16 @@
     }
   })();
 
+  // disallowParenthesesAroundArrowParam
+  // requireShorthandArrowFunctions
+  // https://github.com/airbnb/javascript#8.2
+  (function () {
+    [1, 2, 3].map(number => number * 2);
+  })();
+
+  (function () {
+  [1, 2, 3].map((number) => {
+    const nextNumber = number + 1;
+    return `A string containing the ${nextNumber}.`;
+  });
 })(window);


### PR DESCRIPTION
> If the function body consists of a single expression, omit the braces and use the implicit return. Otherwise, keep the braces and use a return statement.

[See rule #8.2](https://github.com/airbnb/javascript#8.2)