### PR TITLE
New Rule: (require | disallow)SpacesInsideImportedObjectBraces

### DIFF
--- a/grouping.json
+++ b/grouping.json
@@ -164,7 +164,9 @@
     "requireArrayDestructuring",
     "disallowVar",
     "requireSpaceBeforeDestructuredValues",
-    "disallowArrayDestructuringReturn"
+    "disallowArrayDestructuringReturn",
+    "requireSpacesInsideImportedObjectBraces",
+    "disallowSpacesInsideImportedObjectBraces"
   ],
   "Everything else": [
     "requireUseStrict",

--- a/lib/rules/disallow-spaces-inside-imported-object-braces.js
+++ b/lib/rules/disallow-spaces-inside-imported-object-braces.js
@@ -1,0 +1,82 @@
+/**
+ * Disallow space after opening object curly brace and before closing in import statements.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "disallowSpacesInsideImportedObjectBraces": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * import {foo, bar} from 'foo-bar';
+ *
+ * import {foo as f, bar} from 'foo-bar';
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * import { foo, bar } from 'foo-bar';
+ *
+ * import { foo as f, bar } from 'foo-bar';
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'disallowSpacesInsideImportedObjectBraces';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType(['ImportDeclaration'], function(node) {
+
+            if (!node.specifiers) {
+                return;
+            }
+
+            node.specifiers.forEach(function(specifier) {
+
+                if (specifier.type !== 'ImportSpecifier') {
+                    return;
+                }
+
+                var maybeOpeningBrace = file.getPrevToken(specifier.firstToken);
+                var maybeClosingBrace = file.getNextToken(specifier.lastToken);
+
+                if (maybeOpeningBrace.value === '{') {
+                    errors.assert.noWhitespaceBetween({
+                        token: maybeOpeningBrace,
+                        nextToken: specifier.firstToken,
+                        message: 'Illegal space after opening curly brace'
+                    });
+                }
+
+                if (maybeClosingBrace.value === '}') {
+                    errors.assert.noWhitespaceBetween({
+                        token: specifier.lastToken,
+                        nextToken: maybeClosingBrace,
+                        message: 'Illegal space before closing curly brace'
+                    });
+                }
+            });
+        });
+    }
+};

--- a/lib/rules/require-spaces-inside-imported-object-braces.js
+++ b/lib/rules/require-spaces-inside-imported-object-braces.js
@@ -1,0 +1,84 @@
+/**
+ * Requires space after opening object curly brace and before closing in import statements.
+ *
+ * Type: `Boolean`
+ *
+ * Value: `true`
+ *
+ * #### Example
+ *
+ * ```js
+ * "requireSpacesInsideImportedObjectBraces": true
+ * ```
+ *
+ * ##### Valid
+ *
+ * ```js
+ * import { foo, bar } from 'foo-bar';
+ *
+ * import { foo as f, bar } from 'foo-bar';
+ * ```
+ *
+ * ##### Invalid
+ *
+ * ```js
+ * import {foo, bar} from 'foo-bar';
+ *
+ * import {foo as f, bar} from 'foo-bar';
+ * ```
+ */
+
+var assert = require('assert');
+
+module.exports = function() {};
+
+module.exports.prototype = {
+
+    configure: function(options) {
+        assert(
+            options === true,
+            this.getOptionName() + ' option requires a true value or should be removed'
+        );
+    },
+
+    getOptionName: function() {
+        return 'requireSpacesInsideImportedObjectBraces';
+    },
+
+    check: function(file, errors) {
+        file.iterateNodesByType(['ImportDeclaration'], function(node) {
+
+            if (!node.specifiers) {
+                return;
+            }
+
+            node.specifiers.forEach(function(specifier) {
+
+                if (specifier.type !== 'ImportSpecifier') {
+                    return;
+                }
+
+                var maybeOpeningBrace = file.getPrevToken(specifier.firstToken);
+                var maybeClosingBrace = file.getNextToken(specifier.lastToken);
+
+                if (maybeOpeningBrace.value === '{') {
+                    errors.assert.spacesBetween({
+                        token: maybeOpeningBrace,
+                        nextToken: specifier.firstToken,
+                        exactly: 1,
+                        message: 'One space required after opening curly brace'
+                    });
+                }
+
+                if (maybeClosingBrace.value === '}') {
+                    errors.assert.spacesBetween({
+                        token: specifier.lastToken,
+                        nextToken: maybeClosingBrace,
+                        exactly: 1,
+                        message: 'One space required before closing curly brace'
+                    });
+                }
+            });
+        });
+    }
+};

--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -76,5 +76,6 @@
     "validateIndentation": 2,
     "maximumLineLength": 100,
     "disallowArrayDestructuringReturn": true,
-    "requireShorthandArrowFunctions": true
+    "requireShorthandArrowFunctions": true,
+    "requireSpacesInsideImportedObjectBraces": true
 }

--- a/test/data/options/preset/airbnb.js
+++ b/test/data/options/preset/airbnb.js
@@ -1,3 +1,6 @@
+// requireSpacesInsideImportedObjectBraces
+import { join, resolve } from 'path';
+
 // requireParenthesesAroundIIFE
 (function (window) {
   <Foo

--- a/test/specs/rules/disallow-spaces-inside-imported-object-braces.js
+++ b/test/specs/rules/disallow-spaces-inside-imported-object-braces.js
@@ -1,0 +1,44 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/disallow-spaces-inside-imported-object-braces', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('when { disallowSpacesInsideImportedObjectBraces: true }', function() {
+        beforeEach(function() {
+            checker.configure({ disallowSpacesInsideImportedObjectBraces: true });
+        });
+
+        it('should not report for import without braces', function() {
+            expect(checker.checkString('import fooBar from "foo-bar";')).to.have.no.errors();
+            expect(checker.checkString('import * as fooBar from "foo-bar";')).to.have.no.errors();
+            expect(checker.checkString('import {} from "foo-bar";')).to.have.no.errors();
+        });
+
+        it('should report for import with spaces', function() {
+            expect(
+                checker.checkString('import { foo} from "foo-bar";')
+            ).to.have.error.count.equal(1);
+
+            expect(
+                checker.checkString('import {foo } from "foo-bar";')
+            ).to.have.error.count.equal(1);
+
+            expect(
+                checker.checkString('import { foo, bar } from "foo-bar";')
+            ).to.have.error.count.equal(2);
+
+            expect(
+                checker.checkString('import fooBar, { foo, bar } from "foo-bar";')
+            ).to.have.error.count.equal(2);
+
+            expect(
+                checker.checkString('import {foo as bar, bar as foo } from "foo-bar";')
+            ).to.have.error.count.equal(1);
+        });
+    });
+});

--- a/test/specs/rules/require-spaces-inside-imported-object-braces.js
+++ b/test/specs/rules/require-spaces-inside-imported-object-braces.js
@@ -1,0 +1,40 @@
+var Checker = require('../../../lib/checker');
+var expect = require('chai').expect;
+
+describe('rules/require-spaces-inside-imported-object-braces', function() {
+    var checker;
+    beforeEach(function() {
+        checker = new Checker();
+        checker.registerDefaultRules();
+    });
+
+    describe('when { requireSpacesInsideImportedObjectBraces: true }', function() {
+        beforeEach(function() {
+            checker.configure({ requireSpacesInsideImportedObjectBraces: true });
+        });
+
+        it('should not report for import without braces', function() {
+            expect(checker.checkString('import fooBar from "foo-bar";')).to.have.no.errors();
+            expect(checker.checkString('import * as fooBar from "foo-bar";')).to.have.no.errors();
+            expect(checker.checkString('import {} from "foo-bar";')).to.have.no.errors();
+        });
+
+        it('should report for import without spaces', function() {
+            expect(
+                checker.checkString('import {foo} from "foo-bar";')
+            ).to.have.error.count.equal(2);
+
+            expect(
+                checker.checkString('import {foo, bar} from "foo-bar";')
+            ).to.have.error.count.equal(2);
+
+            expect(
+                checker.checkString('import fooBar, {foo, bar} from "foo-bar";')
+            ).to.have.error.count.equal(2);
+
+            expect(
+                checker.checkString('import {foo as bar, bar as foo} from "foo-bar";')
+            ).to.have.error.count.equal(2);
+        });
+    });
+});


### PR DESCRIPTION
Restrictions for spaces inside imported objects

Fixes #2151