### PR TITLE
requireCapitalizedComments: add back autofix

### DIFF
--- a/lib/rules/require-capitalized-comments.js
+++ b/lib/rules/require-capitalized-comments.js
@@ -106,6 +106,7 @@
  */
 
 var assert = require('assert');
+var cst = require('cst');
 
 var isPragma = require('../utils').isPragma;
 var letterPattern = require('../../patterns/L');
@@ -279,6 +280,9 @@ module.exports.prototype = {
         var comment = error.additional;
         var first = this._getFirstChar(comment);
 
-        comment.value = comment.value.replace(first, first.toUpperCase());
+        var newValue = comment.value.replace(first, first.toUpperCase());
+        var newComment = new cst.Token(comment.type, newValue);
+
+        comment.parentElement.replaceChild(newComment, comment);
     }
 };

--- a/test/specs/rules/disallow-comma-before-line-break.js
+++ b/test/specs/rules/disallow-comma-before-line-break.js
@@ -12,7 +12,7 @@ describe('rules/disallow-comma-before-line-break', function() {
         checker.configure(rules);
     });
 
-    describe.skip('autofix', function() {
+    describe('autofix', function() {
         reportAndFix({
             name: 'illegal comma placement in multiline var declaration',
             rules: rules,

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -317,8 +317,7 @@ describe('rules/require-capitalized-comments', function() {
         });
     });
 
-    // TODO: 3.0
-    describe.skip('fix', function() {
+    describe('fix', function() {
         reportAndFix({
             name: 'simple case',
             rules: {


### PR DESCRIPTION
Btw, `node.key.replaceChild(newKey, key);` surprised me at first lol (thought the params were switched)