### PR TITLE
Preset: Add 'requireSpaceBetweenArguments' to google preset

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -77,6 +77,7 @@
     "requireDotNotation": true,
     "requireSemicolons": true,
     "validateParameterSeparator": ", ",
+    "requireSpaceBetweenArguments": true,
 
     "jsDoc": {
         "checkAnnotations": "closurecompiler",


### PR DESCRIPTION
It's not explicitly mentioned in [the documentation](http://google.github.io/styleguide/javascriptguide.xml) but the examples consistently use a space between arguments.

#996 added this rule to all other presets, but not the google one.