### PR TITLE
Updated rule requireNewlineBeforeSingleStatementsInIf

### DIFF
--- a/lib/rules/require-newline-before-single-statements-in-if.js
+++ b/lib/rules/require-newline-before-single-statements-in-if.js
@@ -16,6 +16,9 @@
  * ```js
  * if (x)
  *    doX();
+ *
+ * if (x)
+ *    doX();
  * else
  *    doY();
  *
@@ -30,6 +33,8 @@
  * ##### Invalid
  *
  * ```js
+ * if (x) doX();
+ *
  * if (x) doX();
  * else doY();
  *
@@ -57,10 +62,6 @@ module.exports.prototype = {
     },
 
     check: function(file, errors) {
-        function isExpressionStatement(entity) {
-            return entity.type === 'ExpressionStatement';
-        }
-
         function assertDifferentLine(token, nextToken) {
             errors.assert.differentLine({
               token: token,
@@ -82,15 +83,9 @@ module.exports.prototype = {
             var consequentNode = node.consequent;
             var alternateNode = node.alternate;
 
-            if (!alternateNode) {
-                return;
-            }
+            assertDifferentLine(consequentNode, getToken(consequentNode, 'Keyword', 'previousSibling'));
 
-            if (isExpressionStatement(consequentNode)) {
-                assertDifferentLine(consequentNode, getToken(consequentNode, 'Keyword', 'previousSibling'));
-            }
-
-            if (isExpressionStatement(alternateNode)) {
+            if (alternateNode) {
                 assertDifferentLine(alternateNode, getToken(alternateNode, 'Keyword', 'previousSibling'));
             }
         });

--- a/test/specs/rules/require-newline-before-single-statements-in-if.js
+++ b/test/specs/rules/require-newline-before-single-statements-in-if.js
@@ -14,36 +14,95 @@ describe('rules/require-newline-before-single-statements-in-if', function() {
             checker.configure({ requireNewlineBeforeSingleStatementsInIf: true });
         });
 
-        it('should not blow up for single branch `if`', function() {
-            expect(checker.checkString('if (x) true')).to.have.no.errors();
+        it('should not report missing newline for single `if` branch in a block statment on a newline', function() {
+            expect(checker.checkString('if (x) {\n doX();\n}'))
+                .to.have.no.errors();
         });
 
-        it('should ignore if in a block statment', function() {
-            expect(checker.checkString('if (x) {\n doX();\n} else {\n doY();\n}')).to.have.no.errors();
+        it('should not report missing newline for `if` and `else` branches in a block statment on a newline', function() {
+            expect(checker.checkString('if (x) {\n doX();\n} else {\n doY();\n}'))
+                .to.have.no.errors();
         });
 
-        it('should not report missing newline before conditional statement', function() {
+        it('should not report missing newline for `if`, `else if` and `else` branches in a block statment on newlines',
+            function() {
+                expect(checker.checkString('if (x) {\n doX(); }\nelse if (y) {\n doY(); }\n else {\n doZ(); }'))
+                    .to.have.no.errors();
+        });
+
+        it('should report missing newline for single `if` branch in a block statment on same line', function() {
+            expect(checker.checkString('if (x) { doX(); }'))
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf')
+        });
+
+        it('should report missing newline for `if` branch in a block statment on same line', function() {
+            expect(checker.checkString('if (x) { doX(); }\n else\n doY();'))
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf')
+        });
+
+        it('should report missing newline for `else` branch in a block statment on same line', function() {
+            expect(checker.checkString('if (x) {\ndoX();\n}\nelse { doY(); }'))
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf')
+        });
+
+        it('should report missing newline for `else if` branch in a block statment on same line', function() {
+            expect(checker.checkString('if (x) {\ndoX();\n}\nelse if (y) { doY(); }\nelse {\n doZ(); }'))
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf')
+        });
+
+        it('should report missing two newlines for `if` and `else` branches in a block statment on same line', function() {
+            expect(checker.checkString('if (x) { doX(); }\n else { doY(); }'))
+                .to.have.error.count.equal(2);
+        });
+
+        it('should report missing three newlines for `if` ,`else if` and `else` branches in a block statment on same line',
+            function() {
+                expect(checker.checkString('if (x) { doX(); }\nelse if (y) { doY(); }\n else { doZ(); }'))
+                    .to.have.error.count.equal(3);
+        });
+
+        it('should not report missing newline for single `if` branch', function() {
+            expect(checker.checkString('if (x)\ntrue')).to.have.no.errors();
+        });
+
+        it('should not report missing newline for `if` and `else` branches on newlines', function() {
             expect(checker.checkString('if (x)\ndoX();\nelse \ndoY();\n')).to.have.no.errors();
         });
 
-        it('should not report missing newline before conditional for nested else if', function() {
+        it('should not report missing newline for `if`, `else if` and `else` branches on newlines', function() {
             expect(checker.checkString('if (x)\ndoX();\nelse if (v)\ndoV();\nelse\ndoY();'))
-              .to.have.no.errors();
+                .to.have.no.errors();
         });
 
-        it('should report missing newline before conditional for consequent', function() {
+        it('should report missing newline for single `if` branch', function() {
+            expect(checker.checkString('if (x) true'))
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf')
+        });
+
+        it('should report missing newline for `if` branch', function() {
             expect(checker.checkString('if (x) doX();\nelse\n doY();'))
-              .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
         });
 
-        it('should report missing newline before conditional for alternate', function() {
+        it('should report missing newline for `else` branch', function() {
             expect(checker.checkString('if (x)\ndoX();\nelse doY();'))
-              .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
         });
 
-        it('should report missing newline before conditional for nested else if', function() {
+        it('should report missing newline for `else if` branch', function() {
             expect(checker.checkString('if (x)\ndoX();\nelse if (v) doV();\nelse\ndoY();'))
-              .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
+                .to.have.one.validation.error.from('requireNewlineBeforeSingleStatementsInIf');
+        });
+
+        it('should report missing two newlines for `if` and `else` branches on same line', function() {
+            expect(checker.checkString('if (x) doX();\n else doY();'))
+                .to.have.error.count.equal(2);
+        });
+
+        it('should report missing three newlines for `if` ,`else if` and `else` branches on same line',
+            function() {
+                expect(checker.checkString('if (x) doX();\nelse if (y) doY();\nelse doZ();'))
+                    .to.have.error.count.equal(3);
         });
     });
 });


### PR DESCRIPTION
Display warning for single `if` branch. Added more tests.

Fixes: #2174