### PR TITLE
Fix: fixup skipped requirePaddingNewlinesBeforeKeywords test

### DIFF
--- a/lib/rules/require-padding-newlines-before-keywords.js
+++ b/lib/rules/require-padding-newlines-before-keywords.js
@@ -138,6 +138,11 @@ module.exports.prototype = {
                 return;
             }
 
+            // allow returning a function
+            if (prevToken.value === 'return' && token.value === 'function') {
+                return;
+            }
+
             // Do not report `do...while` statements
             if (token.value === 'while' && token.parentElement.type === 'DoWhileStatement') {
                 return;

--- a/test/specs/rules/require-padding-newlines-before-keywords.js
+++ b/test/specs/rules/require-padding-newlines-before-keywords.js
@@ -103,51 +103,50 @@ describe('rules/require-padding-newlines-before-keywords', function() {
 
         it('should not report on first expression in a block', function() {
             expect(checker.checkString(
-                    'function x() { return; }'
-                )).to.have.no.errors();
+                'function x() { return; }'
+            )).to.have.no.errors();
         });
 
         it('should not report in object definitions', function() {
             expect(checker.checkString(
-                    'var obj = {\n' +
-                    '  foo: function x() { return; }\n' +
-                    '};'
-                )).to.have.no.errors();
+                'var obj = {\n' +
+                '  foo: function x() { return; }\n' +
+                '};'
+            )).to.have.no.errors();
         });
 
         it('should not report when parameter inside a function', function() {
             expect(checker.checkString(
-                    'watchlist.on( "watch", function () {} );'
-                )).to.have.no.errors();
+                'watchlist.on( "watch", function () {} );'
+            )).to.have.no.errors();
         });
 
         it('should not report when assigned to a variable', function() {
             expect(checker.checkString(
-                    ' Router.prototype.getPath = function () {};'
-                )).to.have.no.errors();
+                ' Router.prototype.getPath = function () {};'
+            )).to.have.no.errors();
         });
 
         it('should not report when used inside closure', function() {
             expect(checker.checkString(
-                    '( function ( $ ) {} )( jQuery );'
-                )).to.have.no.errors();
+                '( function ( $ ) {} )( jQuery );'
+            )).to.have.no.errors();
         });
 
         it('should report on matching return statement', function() {
             expect(checker.checkString(
-                    'function x() { var a; return; }'
-                )).to.have.one.validation.error.from('requirePaddingNewlinesBeforeKeywords');
+                'function x() { var a; return; }'
+            )).to.have.one.validation.error.from('requirePaddingNewlinesBeforeKeywords');
         });
 
-        // TODO: fix this in CST
-        it.skip('should not report when returning a function', function() {
+        it('should not report when returning a function', function() {
             expect(checker.checkString(
-                    'function x() {\n' +
-                    '  var a = 0;\n' +
-                    '  \n' +
-                    '  return function() {};\n' +
-                    '}'
-                )).to.have.no.errors();
+                'function x() {\n' +
+                '  var a = 0;\n' +
+                '  \n' +
+                '  return function() {};\n' +
+                '}'
+            )).to.have.no.errors();
         });
     });
 });


### PR DESCRIPTION
I thought this was a cst issue since I got an internal error?

But it was just removed in https://github.com/jscs-dev/node-jscs/commit/301232104111027106588f230c371672fb0ace43?

```js
rules/require-padding-newlines-before-keywords true value should not report when returning a function:
     Expected not to have errors, but "internalError: Error running rule requirePaddingNewlinesBeforeKeywords: This is an issue with JSCS and not your codebase.
Please file an issue (with the stack trace below) at: https://github.com/jscs-dev/node-jscs/issues/new
Error: Expected end of node list but "FunctionExpression" found
    at ElementAssert.assertEnd (/Users/hzhu/dev/node-jscs/node_modules/cst/lib/elements/ElementAssert.js:208:23)
    at ReturnStatement._acceptChildren (/Users/hzhu/dev/node-jscs/node_modules/cst/lib/elements/types/ReturnStatement.js:49:22)
    at ReturnStatement._setChildren (/Users/hzhu/dev/node-jscs/node_modules/cst/lib/elements/Element.js:415:18)
```

@markelog 