### PR TITLE
reCapitalizedComments: add eslint-disable-next-line to the ignore list rules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,6 +211,7 @@ exports.isPragma = function(additionalExceptions) {
         'eslint-enable',
         'eslint-disable',
         'eslint-disable-line',
+        'eslint-disable-next-line',
         'global',
         'jshint',
         'jslint',

--- a/test/specs/rules/require-capitalized-comments.js
+++ b/test/specs/rules/require-capitalized-comments.js
@@ -70,6 +70,7 @@ describe('rules/require-capitalized-comments', function() {
             expect(checker.checkString('/* eslint-disable */')).to.have.no.errors();
             expect(checker.checkString('/* eslint-enable */')).to.have.no.errors();
             expect(checker.checkString('// eslint-disable-line')).to.have.no.errors();
+            expect(checker.checkString('// eslint-disable-next-line')).to.have.no.errors();
 
             expect(checker.checkString('/* jshint strict: true */')).to.have.no.errors();
             expect(checker.checkString('/* globals MY_LIB: false */')).to.have.no.errors();


### PR DESCRIPTION
Added eslint-disable-next-line to pragmaKeywords and the corresponding unit test.

Fixes #2204 - requireCapitalizedComments does not ignore eslint-disable-next-line