### PR TITLE
Preset: allow URLs inside comments in airbnb.json

### DIFF
--- a/presets/airbnb.json
+++ b/presets/airbnb.json
@@ -78,5 +78,8 @@
     "validateLineBreaks": "LF",
     "validateQuoteMarks": { "mark": "'", "escape": true, "ignoreJSX": true },
     "validateIndentation": 2,
-    "maximumLineLength": 100
+    "maximumLineLength": {
+        "value": 100,
+        "allExcept": ["urlComments"]
+    }
 }


### PR DESCRIPTION
Make an exception for URLs inside comments in maximumLineLength rule