### PR TITLE
Misc: Make an exception for esnext/verbose since they are removed

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -378,6 +378,30 @@ Configuration.prototype._getOptionsFromConfig = function(config) {
     }, {});
 };
 
+Configuration.prototype._errorOnRemovedOptions = function(config) {
+    var errors = ['Config values to remove in 3.0:'];
+
+    if (config.hasOwnProperty('esprima')) {
+        errors.push('The `esprima` option since CST uses babylon (the babel parser) under the hood');
+    }
+
+    if (config.hasOwnProperty('esprimaOptions')) {
+        errors.push('The `esprimaOptions` option.');
+    }
+
+    if (config.hasOwnProperty('esnext')) {
+        errors.push('The `esnext` option is enabled by default.');
+    }
+
+    if (config.hasOwnProperty('verbose')) {
+        errors.push('The `verbose` option is enabled by default.');
+    }
+
+    if (errors.length > 1) {
+        throw new Error(errors.join('\n'));
+    }
+};
+
 /**
  * Processes configuration and returns config options.
  *
@@ -392,6 +416,8 @@ Configuration.prototype._processConfig = function(config) {
 
     // Override the properties
     copyConfiguration(overrides, currentConfig);
+
+    this._errorOnRemovedOptions(currentConfig);
 
     // NOTE: options is a separate object to ensure that future options must be added
     // to BUILTIN_OPTIONS to work, which also assures they aren't mistaken for a rule

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -782,5 +782,24 @@ describe('config/configuration', function() {
             expect(configuration.getFileExtensions().length).to.equal(1);
             expect(configuration.getFileExtensions()[0]).to.equal('.js');
         });
+
+        it('should error on removed options in 3.0', function() {
+            try {
+                configuration.load({
+                    esprima: true,
+                    esprimaOptions: true,
+                    verbose: true,
+                    esnext: true
+                });
+            } catch (e) {
+                expect(e.message).to.equal([
+                    'Config values to remove in 3.0:',
+                    'The `esprima` option since CST uses babylon (the babel parser) under the hood',
+                    'The `esprimaOptions` option.',
+                    'The `esnext` option is enabled by default.',
+                    'The `verbose` option is enabled by default.'
+                ].join('\n'));
+            }
+        });
     });
 });


### PR DESCRIPTION
```js
{
"esprima": true,
    "esprimaOptions": true,
    "verbose": true,
    "esnext": true,
}
```

<img width="829" alt="screen shot 2016-04-16 at 12 05 40 pm" src="https://cloud.githubusercontent.com/assets/588473/14582166/b171135e-03cb-11e6-93e6-f8edac0ece5a.png">
