### PR TITLE
Revert "Configuration: exclude nested node_modules by default"

### DIFF
--- a/lib/config/configuration.js
+++ b/lib/config/configuration.js
@@ -117,7 +117,7 @@ function Configuration() {
      * @protected
      * @type {Array}
      */
-    this._defaultExcludedFileMasks = ['.git/**', '*/node_modules/**'];
+    this._defaultExcludedFileMasks = ['.git/**', 'node_modules/**'];
 
     /**
      * List of existing files that falls under exclusion masks.

--- a/test/specs/config/configuration.js
+++ b/test/specs/config/configuration.js
@@ -580,7 +580,7 @@ describe('config/configuration', function() {
                 preset: 'test2'
             });
 
-            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', '*/node_modules/**']);
+            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', 'node_modules/**']);
         });
 
         it('should set `fileExtensions` setting from presets', function() {
@@ -774,7 +774,7 @@ describe('config/configuration', function() {
 
         it('should set default excludeFiles option', function() {
             configuration.load({});
-            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', '*/node_modules/**']);
+            expect(configuration.getExcludedFileMasks()).to.deep.equal(['.git/**', 'node_modules/**']);
         });
 
         it('should set default file extensions', function() {


### PR DESCRIPTION
This reverts commit 908bd20654723eac98949f994710c9ea902fe671.

Ref https://github.com/jscs-dev/node-jscs/issues/2221

Either we revert back to the old behavior and only exclude the top node_modules by default (which is what eslint is doing) or we also exclude nested ones by default.