### PR TITLE
validateIndentation: Add 'consistent' mode.

### DIFF
--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -195,21 +195,30 @@ function isFunctionExpression(node) {
 /**
  * Returns the first non-comment indentation in the first block or undefined.
  *
- * @param {Node} node
- * @param {String} parentType
+ * @param {String[]} programLines - The js file's lines
+ * @param {Node} node - esprima node
+ * @param {String} parentType - esprima parent node type
  * @param {Boolean} findAnywhere - Allow sampling whitespace outside of block nodes.
  * @returns {String|undefined}
  */
-function guessIntendedIndentation(node, parentType, findAnywhere) {
+function guessIntendedIndentation(programLines, node, parentType, findAnywhere) {
     if (node.type === 'Whitespace' && (findAnywhere || parentType === 'BlockStatement')) {
         var whitespaceChars = (node.value.match(/\n( +|\t+)/) || [])[1];
         if (whitespaceChars) {
+            // try to check the indentation on the previous line so we can only return
+            // the change in indentation.
+            var lineBeforeEndline = programLines[node.getLoc().start.line - 1] || '';
+            var prevWhitespaceChars = (lineBeforeEndline.match(/^( +|\t+)/) || [])[1];
+            if (prevWhitespaceChars) {
+                // find the delta indentation.
+                whitespaceChars = whitespaceChars.substring(prevWhitespaceChars.length);
+            }
             return whitespaceChars;
         }
     }
     for (var t = 0, len = node.childElements.length; t < len; t++) {
         var child = node.childElements[t];
-        var ans = guessIntendedIndentation(child, node.type, findAnywhere);
+        var ans = guessIntendedIndentation(programLines, child, node.type, findAnywhere);
         if (ans) {
             return ans;
         }
@@ -658,7 +667,7 @@ module.exports.prototype = {
         }
 
         if (this._consistentMode) {
-            var indent = guessIntendedIndentation(program);
+            var indent = guessIntendedIndentation(file.getLines(), program);
             if (indent) {
                 if (indent.charAt(0) === ' ') {
                     this._indentChar = ' ';
@@ -671,7 +680,7 @@ module.exports.prototype = {
                 }
             } else {
                 // Couldn't find a place to sample indentation, so do a wider search.
-                indent = guessIntendedIndentation(program, undefined, true);
+                indent = guessIntendedIndentation(file.getLines(), program, undefined, true);
                 // Only set the nonIndentChar because this whitespace sample is unreliable.
                 if (indent && indent.charAt(0) === ' ') {
                     this._nonIndentChar = '\t';

--- a/lib/rules/validate-indentation.js
+++ b/lib/rules/validate-indentation.js
@@ -193,6 +193,30 @@ function isFunctionExpression(node) {
 }
 
 /**
+ * Returns the first non-comment indentation in the first block or undefined.
+ *
+ * @param {Node} node
+ * @param {String} parentType
+ * @param {Boolean} findAnywhere - Allow sampling whitespace outside of block nodes.
+ * @returns {String|undefined}
+ */
+function guessIntendedIndentation(node, parentType, findAnywhere) {
+    if (node.type === 'Whitespace' && (findAnywhere || parentType === 'BlockStatement')) {
+        var whitespaceChars = (node.value.match(/\n( +|\t+)/) || [])[1];
+        if (whitespaceChars) {
+            return whitespaceChars;
+        }
+    }
+    for (var t = 0, len = node.childElements.length; t < len; t++) {
+        var child = node.childElements[t];
+        var ans = guessIntendedIndentation(child, node.type, findAnywhere);
+        if (ans) {
+            return ans;
+        }
+    }
+}
+
+/**
  * Returns module block statement. Works with IIFE, require, define.
  *
  * @param {Program} program
@@ -311,7 +335,12 @@ module.exports.prototype = {
             options = options.value;
         }
 
+        if (options.toLowerCase && options.toLowerCase() === 'consistent') {
+            this._consistentMode = true;
+        }
+
         assert(
+            this._consistentMode ||
             options === '\t' ||
                 (typeof options === 'number' && options > 0),
             this.getOptionName() + ' option requires a positive number of spaces or "\\t"' +
@@ -627,6 +656,31 @@ module.exports.prototype = {
         if (program.getFirstToken().isWhitespace) {
             firstWhitespace = program.getFirstToken();
         }
+
+        if (this._consistentMode) {
+            var indent = guessIntendedIndentation(program);
+            if (indent) {
+                if (indent.charAt(0) === ' ') {
+                    this._indentChar = ' ';
+                    this._nonIndentChar = '\t';
+                    this._indentSize = indent.length;
+                } else {
+                    this._nonIndentChar = ' ';
+                    this._indentChar = '\t';
+                    this._indentSize = 1;
+                }
+            } else {
+                // Couldn't find a place to sample indentation, so do a wider search.
+                indent = guessIntendedIndentation(program, undefined, true);
+                // Only set the nonIndentChar because this whitespace sample is unreliable.
+                if (indent && indent.charAt(0) === ' ') {
+                    this._nonIndentChar = '\t';
+                } else {
+                    this._nonIndentChar = ' ';
+                }
+            }
+        }
+
         this._checkNode(program, errors, 0, {
             moduleBody: getModuleBody(program),
             firstWhitespace: firstWhitespace

--- a/test/specs/rules/validate-indentation.js
+++ b/test/specs/rules/validate-indentation.js
@@ -153,6 +153,67 @@ describe('rules/validate-indentation', function() {
         ]);
     });
 
+    it('should guess the intended indentation when using consistent mode.', function() {
+        checker.configure({ validateIndentation: 'consistent' });
+        expect(checker.checkString('' +
+            'function a (x) {\n' +
+            '\tif (true) {\n' +
+            '\t\tconsole.log("something");\n' +
+            '\t}\n' +
+            '\tswitch (x) {\n' +
+            '\t\tcase 1:\n' +
+            '\t\t\treturn 1\n' +
+            '\t\tdefault:\n' +
+            '\t\t\treturn 2\n' +
+            '\t}\n' +
+            '}'
+        )).to.have.no.errors();
+
+        expect(checker.checkString('' +
+            'function a (x) {\n' +
+            '   if (true) {\n' +
+            '      console.log("something");\n' +
+            '   }\n' +
+            '   switch (x) {\n' +
+            '      case 1:\n' +
+            '         return 1\n' +
+            '      default:\n' +
+            '         return 2\n' +
+            '   }\n' +
+            '}'
+        )).to.have.no.errors();
+
+        expect(checker.checkString('' +
+            'function a (x) {\n' +
+            '  if (true) {\n' +
+            '    console.log("something");\n' +
+            '  }\n' +
+            '  switch (x) {\n' +
+            '    case 1:\n' +
+            '       return 1\n' +
+            '    default:\n' +
+            '      return 2\n' +
+            '  }\n' +
+            '}'
+        )).to.have.one.validation.error.from('validateIndentation');
+
+        expect(checker.checkString('' +
+            'var a = "123" +\n' +
+            '  "abc";\n' +
+            'var b = "123" +\n' +
+            '   "abc";\n' +
+            'var c = "abc" +\n' +
+            '\t"123";\n'
+        )).to.have.one.validation.error.from('validateIndentation');
+
+        expect(checker.checkString('' +
+            'var a = "123" +\n' +
+            '\t"abc";\n' +
+            'var b = "abc" +\n' +
+            '  "123";\n'
+        )).to.have.one.validation.error.from('validateIndentation');
+    });
+
     describe('includeEmptyLines', function() {
         it('should validate indentation on an empty line when includeEmptyLines is true', function() {
             checker.configure({

--- a/test/specs/rules/validate-indentation.js
+++ b/test/specs/rules/validate-indentation.js
@@ -162,9 +162,9 @@ describe('rules/validate-indentation', function() {
             '\t}\n' +
             '\tswitch (x) {\n' +
             '\t\tcase 1:\n' +
-            '\t\t\treturn 1\n' +
+            '\t\t\treturn 1;\n' +
             '\t\tdefault:\n' +
-            '\t\t\treturn 2\n' +
+            '\t\t\treturn 2;\n' +
             '\t}\n' +
             '}'
         )).to.have.no.errors();
@@ -176,11 +176,24 @@ describe('rules/validate-indentation', function() {
             '   }\n' +
             '   switch (x) {\n' +
             '      case 1:\n' +
-            '         return 1\n' +
+            '         return 1;\n' +
             '      default:\n' +
-            '         return 2\n' +
+            '         return 2;\n' +
             '   }\n' +
             '}'
+        )).to.have.no.errors();
+
+        expect(checker.checkString('' +
+            'var a = {\n' +
+            '    prop1: "asd",\n' +
+            '    prop2: function() {\n' +
+            '        console.log("qwe");\n' +
+            '    },\n' +
+            '    prop3: "zxc"\n' +
+            '};\n' +
+            'function foo() {\n' +
+            '    return 2;\n' +
+            '}\n'
         )).to.have.no.errors();
 
         expect(checker.checkString('' +
@@ -190,9 +203,9 @@ describe('rules/validate-indentation', function() {
             '  }\n' +
             '  switch (x) {\n' +
             '    case 1:\n' +
-            '       return 1\n' +
+            '       return 1;\n' +
             '    default:\n' +
-            '      return 2\n' +
+            '      return 2;\n' +
             '  }\n' +
             '}'
         )).to.have.one.validation.error.from('validateIndentation');


### PR DESCRIPTION
Consistent mode tries to guess the intended indentation in the file and
sets the indentation settings accordingly.

Hello, I finally decided to take the time to do this. This just adds a 'consistent' option to validateIndentation. So now validateIndentation can be a number, "\t" or "consistent". This is helpful for people who work on a wide variety of projects with their own indentation rules where the projects don't necessarily have a jscs file. It is also helpful for people who have a global jscsrc file so they can enjoy consistent indentation along with all of their other favorite style rules. This is especially helpful for editors that use that global jscsrc file on any source file (a new unsaved file or otherwise).

It's important to note that when using consistent mode, jscs has to make a guess at what the intended indentation should be. So there might be cases where it will guess wrong. So the trade off is more flexibility when switching between projects with different indentation rules and incorrect indentation warnings (probably a rare occurrence).

Here's how it works:
After a lot of thought, I decided that the most reliable place to sample indentation is the first Whitespace node directly inside a BlockStatement node from the AST. Additionally, the Whitespace node must start with a newline character (\n or \r\n). If it can't find a place to sample the indentation, it will try once more, but this time the Whitespace node doesn't have to be in a BlockStatement. However, if it has to search a second time, it will only take note of the type of indentation being used (so it will only warn if the code mixes spaces and tabs).

I think this would be a good option for jscs to have. It would certainly save me a lot of frustration. Let me know if I need to change anything about the PR. Thanks!