### PR TITLE
Misc: do not modify CST in check mode

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -87,7 +87,8 @@ Errors.prototype = {
             element: errorInfo.element,
             offset: errorInfo.offset,
             additional: errorInfo.additional,
-            fixed: errorInfo.fixed
+            fixed: false,
+            fix: errorInfo.fix
         });
     },
 

--- a/lib/rules/disallow-spaces-inside-parentheses.js
+++ b/lib/rules/disallow-spaces-inside-parentheses.js
@@ -89,6 +89,7 @@ module.exports.prototype = {
         var only = this._only;
         var singleQuote = this._onlySingleQuote;
         var doubleQuote = this._onlyDoubleQuote;
+        var alreadyAdded = [];
 
         file.iterateTokensByTypeAndValue('Punctuator', '(', function(token) {
             var nextToken = file.getNextToken(token, {includeComments: true});
@@ -115,17 +116,26 @@ module.exports.prototype = {
                 return;
             }
 
-            errors.assert.noWhitespaceBetween({
+            var isAdded = errors.assert.noWhitespaceBetween({
                 token: token,
                 nextToken: nextToken,
                 message: 'Illegal space after opening round bracket'
             });
+
+            if (isAdded) {
+                alreadyAdded.push(token);
+            }
         });
 
         file.iterateTokensByTypeAndValue('Punctuator', ')', function(token) {
             var prevToken = file.getPrevToken(token, {includeComments: true});
             var value = prevToken.getSourceCode();
             var shouldReturn = true;
+
+            // Do not check already found errors, like "function ( ) { ..."
+            if (alreadyAdded.indexOf(prevToken) > -1) {
+                return;
+            }
 
             if (doubleQuote && prevToken.type === 'String' && value[value.length - 1] === '"') {
                 shouldReturn = false;

--- a/lib/rules/require-aligned-multiline-params.js
+++ b/lib/rules/require-aligned-multiline-params.js
@@ -141,8 +141,7 @@ module.exports.prototype = {
                             token: param.getFirstToken(),
                             actual: paramColumn,
                             expected: referenceColumn,
-                            indentChar: ' ',
-                            silent: false
+                            indentChar: ' '
                         });
                     }
 

--- a/lib/string-checker.js
+++ b/lib/string-checker.js
@@ -95,41 +95,75 @@ StringChecker.prototype = {
     },
 
     /**
-     * Fix provided error.
+     * Apply fix for common errors.
+     *
+     * @param {Error} error
+     * @return {Boolean} whether the correction was carried out
+     * @private
+     */
+    _fixCommonError: function(error) {
+        if (error.fix) {
+            // "error.fixed = true" should go first, so rule can
+            // decide for itself (with "error.fixed = false")
+            // if it can fix this particular error
+            error.fixed = true;
+            error.fix();
+        }
+
+        return !!error.fixed;
+    },
+
+    /**
+     * Apply fix for specific error.
+     *
+     * @param {Error} error
+     * @return {Boolean} whether the correction was carried out
+     * @private
+     */
+    _fixSpecificError: function(file, error) {
+        var configuration = this.getConfiguration();
+        var instance = configuration.getConfiguredRule(error.rule);
+
+        if (instance && instance._fix) {
+            // "error.fixed = true" should go first, so rule can
+            // decide for itself (with "error.fixed = false")
+            // if it can fix this particular error
+            error.fixed = true;
+            instance._fix(file, error);
+        }
+
+        return !!error.fixed;
+    },
+
+    /**
+     * Apply specific and common fixes.
      *
      * @param {JsFile} file
      * @param {Errors} errors
      * @protected
      */
     _fixJsFile: function(file, errors) {
-        var list = errors.getErrorList();
-        var configuration = this.getConfiguration();
-
-        list.forEach(function(error) {
+        errors.getErrorList().forEach(function(error) {
             if (error.fixed) {
                 return;
             }
 
-            var instance = configuration.getConfiguredRule(error.rule);
+            try {
+                // Try to apply fixes for common errors
+                var isFixed = this._fixCommonError(error);
 
-            if (instance && instance._fix) {
-                try {
-
-                    // "error.fixed = true" should go first, so rule can
-                    // decide for itself (with "error.fixed = false")
-                    // if it can fix this particular error
-                    error.fixed = true;
-                    instance._fix(file, error);
-
-                } catch (e) {
-                    error.fixed = undefined;
-                    errors.add(
-                        getInternalErrorMessage(error.rule, e),
-                        file.getProgram()
-                    );
+                // Apply specific fix
+                if (!isFixed) {
+                    this._fixSpecificError(file, error);
                 }
+            } catch (e) {
+                error.fixed = false;
+                errors.add(
+                    getInternalErrorMessage(error.rule, e),
+                    file.getProgram()
+                );
             }
-        });
+        }, this);
     },
 
     /**
@@ -232,7 +266,7 @@ StringChecker.prototype = {
     },
 
     /**
-     * Checks file provided with a string.
+     * Checks and fix file provided with a string.
      *
      * @param {String} source
      * @param {String} [filename='input']
@@ -254,11 +288,11 @@ StringChecker.prototype = {
         } else {
             var attempt = 0;
             do {
-                // Changes to current sources are made in rules through assertions.
+
+                // Fill in errors list
                 this._checkJsFile(file, errors);
 
-                // If assertions weren't used but rule has "fix" method,
-                // which we could use.
+                // Apply fixes
                 this._fixJsFile(file, errors);
 
                 var hasFixes = errors.getErrorList().some(function(err) {

--- a/lib/token-assert.js
+++ b/lib/token-assert.js
@@ -24,10 +24,11 @@ utils.inherits(TokenAssert, EventEmitter);
  * @param {Object} options.nextToken
  * @param {String} [options.message]
  * @param {Number} [options.spaces] Amount of spaces between tokens.
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.whitespaceBetween = function(options) {
     options.atLeast = 1;
-    this.spacesBetween(options);
+    return this.spacesBetween(options);
 };
 
 /**
@@ -38,10 +39,11 @@ TokenAssert.prototype.whitespaceBetween = function(options) {
  * @param {Object} options.nextToken
  * @param {String} [options.message]
  * @param {Boolean} [options.disallowNewLine=false]
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.noWhitespaceBetween = function(options) {
     options.exactly = 0;
-    this.spacesBetween(options);
+    return this.spacesBetween(options);
 };
 
 /**
@@ -55,6 +57,7 @@ TokenAssert.prototype.noWhitespaceBetween = function(options) {
  * @param {Object} [options.atMost] At most how many spaces the tokens are apart
  * @param {Object} [options.exactly] Exactly how many spaces the tokens are apart
  * @param {Boolean} [options.disallowNewLine=false]
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.spacesBetween = function(options) {
     var token = options.token;
@@ -64,13 +67,13 @@ TokenAssert.prototype.spacesBetween = function(options) {
     var exactly = options.exactly;
 
     if (!token || !nextToken) {
-        return;
+        return false;
     }
 
     this._validateOptions(options);
 
     if (!options.disallowNewLine && !this._file.isOnTheSameLine(token, nextToken)) {
-        return;
+        return false;
     }
 
     // Only attempt to remove or add lines if there are no comments between the two nodes
@@ -78,9 +81,9 @@ TokenAssert.prototype.spacesBetween = function(options) {
     var fixed = !options.token.getNextNonWhitespaceToken().isComment;
 
     var emitError = function(countPrefix, spaceCount) {
-        if (fixed) {
+        var fix = function() {
             this._file.setWhitespaceBefore(nextToken, new Array(spaceCount + 1).join(' '));
-        }
+        }.bind(this);
 
         var msgPostfix = token.value + ' and ' + nextToken.value;
 
@@ -103,18 +106,28 @@ TokenAssert.prototype.spacesBetween = function(options) {
             message: options.message,
             element: token,
             offset: token.getSourceCodeLength(),
-            fixed: fixed
+            fix: fixed ? fix : undefined
         });
     }.bind(this);
 
     var spacesBetween = this._file.getDistanceBetween(token, nextToken);
+
     if (atLeast !== undefined && spacesBetween < atLeast) {
         emitError('at least', atLeast);
-    } else if (atMost !== undefined && spacesBetween > atMost) {
-        emitError('at most', atMost);
-    } else if (exactly !== undefined && spacesBetween !== exactly) {
-        emitError('exactly', exactly);
+        return true;
     }
+
+    if (atMost !== undefined && spacesBetween > atMost) {
+        emitError('at most', atMost);
+        return true;
+    }
+
+    if (exactly !== undefined && spacesBetween !== exactly) {
+        emitError('exactly', exactly);
+        return true;
+    }
+
+    return false;
 };
 
 /**
@@ -125,7 +138,7 @@ TokenAssert.prototype.spacesBetween = function(options) {
  * @param {Number} options.expected
  * @param {String} options.indentChar
  * @param {String} options.token
- * @param {Boolean} [options.silent] if true, will suppress error emission but still fix whitespace
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.indentation = function(options) {
     var token = options.token;
@@ -135,36 +148,36 @@ TokenAssert.prototype.indentation = function(options) {
     var indentChar = options.indentChar;
 
     if (actual === expected) {
-        return;
+        return false;
     }
 
-    if (!options.silent) {
-        this.emit('error', {
-            message: 'Expected indentation of ' + expected + ' characters',
-            line: lineNumber,
-            column: expected,
-            fixed: true
-        });
-    }
+    this.emit('error', {
+        message: 'Expected indentation of ' + expected + ' characters',
+        line: lineNumber,
+        column: expected,
+        fix: function() {
+            var newWhitespace = (new Array(expected + 1)).join(indentChar);
 
-    var newWhitespace = (new Array(expected + 1)).join(indentChar);
+            this._updateWhitespaceByLine(token, function(lines) {
+                lines[lines.length - 1] = newWhitespace;
+                return lines;
+            });
 
-    this._updateWhitespaceByLine(token, function(lines) {
-        lines[lines.length - 1] = newWhitespace;
-        return lines;
+            if (token.isComment) {
+                this._updateCommentWhitespace(token, indentChar, actual, expected);
+            }
+        }.bind(this)
     });
 
-    if (token.isComment) {
-        this._updateCommentWhitespace(token, indentChar, actual, expected);
-    }
+    return true;
 };
 
 /**
  * Updates the whitespace of a line by passing split lines to a callback function
  * for editing.
  *
- * @param  {Object} token
- * @param  {Function} callback
+ * @param {Object} token
+ * @param {Function} callback
  */
 TokenAssert.prototype._updateWhitespaceByLine = function(token, callback) {
     var lineBreak = this._file.getLineBreakStyle();
@@ -178,10 +191,10 @@ TokenAssert.prototype._updateWhitespaceByLine = function(token, callback) {
  * Updates the whitespace of a line by passing split lines to a callback function
  * for editing.
  *
- * @param  {Object} token
- * @param  {Function} indentChar
- * @param  {Number} actual
- * @param  {Number} expected
+ * @param {Object} token
+ * @param {Function} indentChar
+ * @param {Number} actual
+ * @param {Number} expected
  */
 TokenAssert.prototype._updateCommentWhitespace = function(token, indentChar, actual, expected) {
     var difference = expected - actual;
@@ -210,11 +223,12 @@ TokenAssert.prototype._updateCommentWhitespace = function(token, indentChar, act
  * @param {Object} options.nextToken
  * @param {Boolean} [options.stickToPreviousToken]
  * @param {String} [options.message]
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.sameLine = function(options) {
     options.exactly = 0;
 
-    this.linesBetween(options);
+    return this.linesBetween(options);
 };
 
 /**
@@ -224,11 +238,12 @@ TokenAssert.prototype.sameLine = function(options) {
  * @param {Object} options.token
  * @param {Object} options.nextToken
  * @param {Object} [options.message]
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.differentLine = function(options) {
     options.atLeast = 1;
 
-    this.linesBetween(options);
+    return this.linesBetween(options);
 };
 
 /**
@@ -244,6 +259,7 @@ TokenAssert.prototype.differentLine = function(options) {
  * @param {Object} [options.exactly] Exactly how many lines the tokens are apart
  * @param {Boolean} [options.stickToPreviousToken] When auto-fixing stick the
  *     nextToken onto the previous token.
+ * @return {Boolean} whether an error was found
  */
 TokenAssert.prototype.linesBetween = function(options) {
     var token = options.token;
@@ -253,7 +269,7 @@ TokenAssert.prototype.linesBetween = function(options) {
     var exactly = options.exactly;
 
     if (!token || !nextToken) {
-        return;
+        return false;
     }
 
     this._validateOptions(options);
@@ -266,6 +282,10 @@ TokenAssert.prototype.linesBetween = function(options) {
 
     var emitError = function(countPrefix, lineCount) {
         var msgPrefix = token.value + ' and ' + nextToken.value;
+
+        var fix = function() {
+            this._augmentLineCount(options, lineCount);
+        }.bind(this);
 
         if (!options.message) {
             if (exactly === 0) {
@@ -280,25 +300,30 @@ TokenAssert.prototype.linesBetween = function(options) {
             }
         }
 
-        if (fixed) {
-            this._augmentLineCount(options, lineCount);
-        }
-
         this.emit('error', {
             message: options.message,
             element: token,
             offset: token.getSourceCodeLength(),
-            fixed: fixed
+            fix: fixed ? fix : undefined
         });
     }.bind(this);
 
     if (atLeast !== undefined && linesBetween < atLeast) {
         emitError('at least', atLeast);
-    } else if (atMost !== undefined && linesBetween > atMost) {
-        emitError('at most', atMost);
-    } else if (exactly !== undefined && linesBetween !== exactly) {
-        emitError('exactly', exactly);
+        return true;
     }
+
+    if (atMost !== undefined && linesBetween > atMost) {
+        emitError('at most', atMost);
+        return true;
+    }
+
+    if (exactly !== undefined && linesBetween !== exactly) {
+        emitError('exactly', exactly);
+        return true;
+    }
+
+    return false;
 };
 
 /**
@@ -312,6 +337,7 @@ TokenAssert.prototype.linesBetween = function(options) {
  * @param {Object} [options.atMost] At most how many spaces the tokens are apart
  * @param {Object} [options.exactly] Exactly how many spaces the tokens are apart
  * @throws {Error} If the options are non-sensical
+ * @private
  */
 TokenAssert.prototype._validateOptions = function(options) {
     var token = options.token;
@@ -346,6 +372,7 @@ TokenAssert.prototype._validateOptions = function(options) {
  * @param {Object} options.nextToken
  * @param {Boolean} [options.stickToPreviousToken]
  * @param {Number} lineCount
+ * @private
  */
 TokenAssert.prototype._augmentLineCount = function(options, lineCount) {
     var token = options.nextToken;

--- a/test/specs/token-assert.js
+++ b/test/specs/token-assert.js
@@ -194,7 +194,7 @@ describe('token-assert', function() {
                 expect(onError).to.have.callCount(1);
 
                 var error = onError.getCall(0).args[0];
-                expect(error.fixed).to.equal(false);
+                expect(error.fix).to.equal(undefined);
                 expect(file.getWhitespaceBefore(yToken)).to.equal('');
             });
         });
@@ -536,7 +536,9 @@ describe('token-assert', function() {
             var file = createJsFile('x\n  + y;');
 
             var tokenAssert = new TokenAssert(file);
-            tokenAssert.on('error', function() {});
+            tokenAssert.on('error', function(errorInfo) {
+                errorInfo.fix();
+            });
             var token = file.getTree().getFirstToken();
             var nextToken = file.findNextToken(token, 'Punctuator', '+');
             tokenAssert.sameLine({
@@ -831,7 +833,9 @@ describe('token-assert', function() {
                 var file = createJsFile('  x\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.findNextToken(
                     file.getTree().getFirstToken(),
@@ -851,7 +855,9 @@ describe('token-assert', function() {
                 var file = createJsFile('  x\n\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -868,7 +874,9 @@ describe('token-assert', function() {
                 var file = createJsFile('  x\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -899,7 +907,6 @@ describe('token-assert', function() {
                 expect(onError).to.have.callCount(1);
 
                 var error = onError.getCall(0).args[0];
-                expect(error.fixed).to.equal(false);
                 expect(file.getWhitespaceBefore(nextToken)).to.equal('\n');
             });
         });
@@ -965,7 +972,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -982,7 +991,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x  \n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -999,7 +1010,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n  \n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1016,7 +1029,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1033,7 +1048,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1108,7 +1125,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1125,7 +1144,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1142,7 +1163,9 @@ describe('token-assert', function() {
                 var file = createJsFile('x\n\n  =y;');
 
                 var tokenAssert = new TokenAssert(file);
-                tokenAssert.on('error', function() {});
+                tokenAssert.on('error', function(errorInfo) {
+                    errorInfo.fix();
+                });
 
                 var token = file.getTree().getFirstToken();
                 var nextToken = file.findNextToken(token, 'Punctuator', '=');
@@ -1251,24 +1274,6 @@ describe('token-assert', function() {
             expect(onError).to.have.not.callCount(0);
         });
 
-        it('with silent option, should not trigger on incorrect indentation', function() {
-            var file = createJsFile('  x=y;');
-
-            var tokenAssert = new TokenAssert(file);
-            var onError = sinon.spy();
-            tokenAssert.on('error', onError);
-
-            tokenAssert.indentation({
-                token: file.getProgram().getFirstToken().getNextCodeToken(),
-                actual: 2,
-                expected: 0,
-                indentChar: ' ',
-                silent: true
-            });
-
-            expect(onError).to.have.callCount(0);
-        });
-
         it('should fix whitespace on incorrect indentation for the first token', function() {
             var file = createJsFile('  x=y;');
 
@@ -1290,8 +1295,9 @@ describe('token-assert', function() {
             var file = createJsFile('  /*\n   *\n   */\nx=y;');
 
             var tokenAssert = new TokenAssert(file);
-            var onError = sinon.spy();
-            tokenAssert.on('error', onError);
+            tokenAssert.on('error', function(errorInfo) {
+                errorInfo.fix();
+            });
 
             var comment = file.getProgram().getFirstToken().getNextNonWhitespaceToken();
             tokenAssert.indentation({
@@ -1310,8 +1316,9 @@ describe('token-assert', function() {
             var file = createJsFile('  /*\n   *\n   */\nx=y;');
 
             var tokenAssert = new TokenAssert(file);
-            var onError = sinon.spy();
-            tokenAssert.on('error', onError);
+            tokenAssert.on('error', function(errorInfo) {
+                errorInfo.fix();
+            });
 
             var comment = file.getProgram().getFirstToken().getNextNonWhitespaceToken();
             tokenAssert.indentation({


### PR DESCRIPTION
* Slightly changes token-assert API by providing result of the check
with return values

* Apply fixes only in fix mode

* Modify couple rules to adjust to new strategy

* Make "fixed" property of the Error instance consistent

* Introduce "fix" property of the Error class

* Divide fix behaviour on "common" and "specific" actions

Consequently should speed up linting

Fixes #2250

/cc @mdevils 