### PR TITLE
Disallowing multiple spaces.

### DIFF
--- a/presets/google.json
+++ b/presets/google.json
@@ -21,6 +21,7 @@
     "validateQuoteMarks": "'",
 
     "disallowMultipleLineStrings": true,
+    "disallowMultipleSpaces": true,
     "disallowMixedSpacesAndTabs": true,
     "disallowTrailingWhitespace": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,


### PR DESCRIPTION
Disallow multiple indentation characters (tabs or spaces) between identifiers, keywords, and any other token.

Would be great if you could still merge this trivial PR, my team are using ```jscs``` for certain projects.